### PR TITLE
Update metal README with branch instructions, update inference example with different prompts (same seq len)

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -5,39 +5,56 @@ from tt_metal.models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaMo
 
 from vllm import LLM, SamplingParams
 from vllm import ModelRegistry
-ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
 
-# Sample prompts.
-prompts = [
-    "List the first 5 prime numbers",
-    "Give a brief history of the internet",
-    "Describe to me some good coding practices",
-    "How many countries are in Africa?",
-    "what is the capital of USA?",
-    "what is the capital of Canada?",
-    "what is the capital of UK?",
-    "what is the capital of Germany?",
-    "what is the capital of France?",
-    "what is the capital of Japan?",
-    "what is the capital of India?",
-    "what is the capital of China?",
-    "what is the currency of Cuba?",
-    "what is the currency of Lebanon?",
-    "what is the currency of Brazil?",
-    "what is the currency of Australia?",
-] * 2  # [32, 8] tokens
 
-# Create a sampling params object.
-sampling_params = SamplingParams(max_tokens=32)
+def main():
+    # Sample prompts.
+    prompts = [
+        "List the first 5 prime numbers",
+        "Give a brief history of the internet",
+        "Describe to me some good coding practices",
+        "How many countries are in Africa?",
+        "what is the capital of USA?",
+        "what is the capital of Canada?",
+        "what is the capital of UK?",
+        "what is the capital of Germany?",
+        "what is the capital of France?",
+        "what is the capital of Japan?",
+        "what is the capital of India?",
+        "what is the capital of China?",
+        "what is the currency of Cuba?",
+        "what is the currency of Lebanon?",
+        "what is the currency of Brazil?",
+        "what is the currency of Australia?",
+    ] * 2  # [32, 8] tokens
 
-# Create an LLM.
-llm = LLM(model="meta-llama/Meta-Llama-3.1-70B")
+    # Create an LLM.
+    ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
+    llm = LLM(model="meta-llama/Meta-Llama-3.1-70B")
 
-# Generate texts from the prompts. The output is a list of RequestOutput objects
-# that contain the prompt, generated text, and other information.
-outputs = llm.generate(prompts, sampling_params)
-# Print the outputs.
-for output in outputs:
-    prompt = output.prompt
-    generated_text = output.outputs[0].text
-    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+    # TODO: Double check how many different seq lengths need to be compiled for decode
+    print("Starting compile run")
+    generate_tokens(llm, prompts, print_output=False)
+    print("Finished compile run")
+
+    print("Starting inference run")
+    generate_tokens(llm, prompts)
+    print("Finished inference run")
+    
+
+def generate_tokens(llm : LLM, prompts, max_tokens=32, print_output=True):
+    sampling_params = SamplingParams(max_tokens=max_tokens)
+    
+    # Generate texts from the prompts. The output is a list of RequestOutput objects
+    # that contain the prompt, generated text, and other information.
+    outputs = llm.generate(prompts, sampling_params)
+    # Print the outputs.
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        if print_output:
+            print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+            
+
+if __name__ == "__main__":
+    main()

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -8,15 +8,27 @@ from vllm import ModelRegistry
 ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
 
 # Sample prompts.
-# prompts = [
-#     "Hello, my name is",
-#     "The president of the United States is",
-#     "The capital of France is",
-#     "The future of AI is",
-# ]
-prompts = [ "Hello, my name is" ] * 32
+prompts = [
+    "List the first 5 prime numbers",
+    "Give a brief history of the internet",
+    "Describe to me some good coding practices",
+    "How many countries are in Africa?",
+    "what is the capital of USA?",
+    "what is the capital of Canada?",
+    "what is the capital of UK?",
+    "what is the capital of Germany?",
+    "what is the capital of France?",
+    "what is the capital of Japan?",
+    "what is the capital of India?",
+    "what is the capital of China?",
+    "what is the currency of Cuba?",
+    "what is the currency of Lebanon?",
+    "what is the currency of Brazil?",
+    "what is the currency of Australia?",
+] * 2  # [32, 8] tokens
+
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=0.8, top_p=0.95)
+sampling_params = SamplingParams(max_tokens=32)
 
 # Create an LLM.
 llm = LLM(model="meta-llama/Meta-Llama-3.1-70B")

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -1,5 +1,10 @@
 
-## Environment Creation 
+## vLLM and tt-metal Branches
+Git-checkout the following branches in each repo separately:
+- vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev)
+- tt-metal branch: [vllm_dev](https://github.com/tenstorrent/tt-metal/tree/vllm_dev)
+
+## Environment Creation
 
 To setup the tt-metal environment with vLLM, follow the instructions in `setup-metal.sh`
 


### PR DESCRIPTION
- Add tt-metal and vLLM branches to tt-metal README
- Add different input prompts (same prompt length) to inference example (32 x 8 tokens) and set num output tokens to 32
- Add compile and inference runs to inference example