### PR TITLE
Add support for different prompt lengths

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -1,3 +1,4 @@
+from typing import List
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -8,43 +9,39 @@ from vllm import ModelRegistry
 
 
 def main():
+    # Generation args
+    ignore_eos = True
+    max_num_seqs = 32  # max sequences in a single batch
+    
     # Sample prompts.
     prompts = [
-        "List the first 5 prime numbers",
-        "Give a brief history of the internet",
-        "Describe to me some good coding practices",
-        "How many countries are in Africa?",
-        "what is the capital of USA?",
-        "what is the capital of Canada?",
-        "what is the capital of UK?",
-        "what is the capital of Germany?",
-        "what is the capital of France?",
-        "what is the capital of Japan?",
-        "what is the capital of India?",
-        "what is the capital of China?",
-        "what is the currency of Cuba?",
-        "what is the currency of Lebanon?",
-        "what is the currency of Brazil?",
-        "what is the currency of Australia?",
-    ] * 2  # [32, 8] tokens
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ] * 16  # 64 prompts
+    sampling_params = [
+        SamplingParams(max_tokens=32, ignore_eos=ignore_eos),
+        SamplingParams(max_tokens=32, ignore_eos=ignore_eos),
+        SamplingParams(max_tokens=32, ignore_eos=ignore_eos),
+        SamplingParams(max_tokens=32, ignore_eos=ignore_eos),
+    ] * 16
 
     # Create an LLM.
     ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
-    llm = LLM(model="meta-llama/Meta-Llama-3.1-70B", block_size=64)
+    llm = LLM(model="meta-llama/Meta-Llama-3.1-70B", block_size=64, max_num_seqs=max_num_seqs)
 
     # TODO: Double check how many different seq lengths need to be compiled for decode
     print("Starting compile run")
-    generate_tokens(llm, prompts, print_output=False)
+    generate_tokens(llm, prompts[:max_num_seqs], sampling_params[:max_num_seqs], print_output=False)
     print("Finished compile run")
 
     print("Starting inference run")
-    generate_tokens(llm, prompts)
+    generate_tokens(llm, prompts, sampling_params)
     print("Finished inference run")
     
 
-def generate_tokens(llm : LLM, prompts, max_tokens=32, print_output=True):
-    sampling_params = SamplingParams(max_tokens=max_tokens)
-    
+def generate_tokens(llm : LLM, prompts, sampling_params : List[SamplingParams], print_output=True):
     # Generate texts from the prompts. The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
     outputs = llm.generate(prompts, sampling_params)


### PR DESCRIPTION
- Add support for different prompt lengths to TTModelRunner
- Update inference example to have 64 prompts with separate sampling params, and to ignore eos