### PR TITLE
Specify mesh_type when opening t3k device, enable async call in TTExecutorAsync, update tt-metal commit

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -2,7 +2,7 @@
 ## vLLM and tt-metal Branches
 Git-checkout the following branches in each repo separately:
 - vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev) (last verified commit: [3f7beb2](https://github.com/tenstorrent/vllm/tree/3f7beb23cbaf3be2e104061905da5f91644e5a68))
-- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [0107040](https://github.com/tenstorrent/tt-metal/tree/01070409e582616d8962f371e8497abbf252bb81))
+- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [f521af0](https://github.com/tenstorrent/tt-metal/tree/f521af0061bf53567942b7a27fd89aa300ec16ce))
 
 ## Environment Creation
 

--- a/vllm/executor/tt_executor.py
+++ b/vllm/executor/tt_executor.py
@@ -110,8 +110,6 @@ class TTExecutorAsync(TTExecutor, ExecutorAsyncBase):
         self,
         execute_model_req: ExecuteModelRequest,
     ) -> SamplerOutput:
-        # TODO: async execution of the TT model is currently not supported, make call async when supported
-        # output = await make_async(self.driver_worker.execute_model
-        #                           )(execute_model_req)
-        output = self.driver_worker.execute_model(execute_model_req)
+        output = await make_async(self.driver_worker.execute_model
+                                  )(execute_model_req)
         return output

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -376,6 +376,7 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             ttnn.MeshShape(2, 4),
             dispatch_core_type=self._get_dispatch_core_type(),
             **device_params,
+            mesh_type=ttnn.MeshType.Ring,
         )
         logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
         return mesh_device


### PR DESCRIPTION
- Specify mesh_type when opening t3k device since it is now required to avoid device order issues with latest tt-metal
- Enable async model execution in TTExecutorAsync since the following issues are now resolved: 
  - #15, 
  - https://github.com/tenstorrent/tt-metal/issues/13447
- Update tt-metal commit in README

fyi @cglagovichTT 