### PR TITLE
Cache kv blocks for faster initialization, modify model and cache args to allow for higher seq lens

### DIFF
--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -14,7 +14,8 @@ def main():
         "--model", "meta-llama/Meta-Llama-3.1-70B",
         "--block_size", "64",
         "--max_num_seqs", "32",
-        "--max_model_len", "4096",
+        "--max_model_len", "131072",
+        "--max_num_batched_tokens", "131072",
     ])
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 

--- a/vllm/model_executor/model_loader/tt_loader.py
+++ b/vllm/model_executor/model_loader/tt_loader.py
@@ -22,5 +22,5 @@ class TTModelLoader(BaseModelLoader):
         arch_names[0] = "TT" + arch_names[0]
         
         model_class, _ = get_model_architecture(model_config)
-        model = model_class.initialize_vllm_model(model_config.hf_config, device_config.device)
+        model = model_class.initialize_vllm_model(model_config.hf_config, device_config.device, scheduler_config.max_num_seqs)
         return model


### PR DESCRIPTION
- Cache kv blocks for faster initialization
- Set `max_model_len` and `max_num_batched_tokens` to 128*1024 to allow running larger seq lens
- Set max batch size in TT llama directly from `scheduler_config.max_num_seqs`