### PR TITLE
Add multi-step decoding, async output proc options to TTModelRunner, and inference examples with Async LLMEngine

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -31,7 +31,15 @@ def run_inference(
 
     # Create an LLM.
     ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
-    llm = LLM(model="meta-llama/Meta-Llama-3.1-70B", block_size=64, max_num_seqs=max_seqs_in_batch, max_model_len=131072, disable_log_stats=False, max_num_batched_tokens=131072)
+    llm = LLM(
+        model="meta-llama/Meta-Llama-3.1-70B", 
+        block_size=64, 
+        max_num_seqs=max_seqs_in_batch, 
+        max_model_len=131072, 
+        disable_log_stats=False, 
+        max_num_batched_tokens=131072,
+        num_scheduler_steps=10,
+    )
 
     if not measure_perf:
         # Load prompts from a JSON file

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -16,6 +16,8 @@ def main():
         "--max_num_seqs", "32",
         "--max_model_len", "131072",
         "--max_num_batched_tokens", "131072",
+        "--num_scheduler_steps", "10",
+        "--disable_async_output_proc",
     ])
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -2,7 +2,7 @@
 ## vLLM and tt-metal Branches
 Git-checkout the following branches in each repo separately:
 - vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev) (last verified commit: [409dbd7](https://github.com/tenstorrent/vllm/tree/409dbd77b1af5c26cbd5b047448cb6a8e9767a35))
-- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [ebdffa9](https://github.com/tenstorrent/tt-metal/tree/ebdffa93d911ebf18e1fd4058a6f65ed0dff09ef))
+- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [2c84ace](https://github.com/tenstorrent/tt-metal/tree/2c84ace80a82302607e809ebce5c9514d5edc22a))
 
 ## Environment Creation
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -376,9 +376,9 @@ class ModelConfig:
 
         # Reminder: Please update docs/source/serving/compatibility_matrix.rst
         # If the feature combo become valid
-        if device_config.device_type not in ("cuda", "tpu", "xpu"):
+        if device_config.device_type not in ("cuda", "tpu", "xpu", "tt"):
             logger.warning(
-                "Async output processing is only supported for CUDA, TPU, XPU. "
+                "Async output processing is only supported for CUDA, TPU, XPU, TT. "
                 "Disabling it for other platforms.")
             self.use_async_output_proc = False
             return

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -115,6 +115,7 @@ class EngineArgs:
     max_num_seqs: int = 256
     max_logprobs: int = 20  # Default value for OpenAI Chat Completions API
     disable_log_stats: bool = False
+    log_global_stats: bool = False
     revision: Optional[str] = None
     code_revision: Optional[str] = None
     rope_scaling: Optional[dict] = None
@@ -443,6 +444,9 @@ class EngineArgs:
         parser.add_argument('--disable-log-stats',
                             action='store_true',
                             help='Disable logging statistics.')
+        parser.add_argument('--log-global-stats',
+                            action='store_true',
+                            help='Use GlobalStatLogger when log stats is enabled.')
         # Quantization settings.
         parser.add_argument('--quantization',
                             '-q',

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1670,6 +1670,11 @@ class LLMEngine:
                 else:
                     # TPOTs.
                     latency = seq_group.get_last_latency(now)
+                    
+                    # Divide by the number of outputs for the multi-step case
+                    num_outputs = scheduler_outputs.num_lookahead_slots + 1
+                    latency /= num_outputs
+                    
                     time_per_output_tokens_iter.append(latency)
 
                 # Because of chunked prefill, we can have a single sequence

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -331,7 +331,7 @@ class AvgTracker:
 
 
 class GlobalStatLogger(StatLoggerBase):
-    """GlobalStatLogger is used in LLMEngine to track stats across the entire generation"""
+    """GlobalStatLogger is used in LLMEngine to track stats across the entire generation (until manually reset)"""
     
     def __init__(self) -> None:
         self.time_to_first_token = AvgTracker()
@@ -347,6 +347,15 @@ class GlobalStatLogger(StatLoggerBase):
             self.time_to_first_token.update(avg_list(stats.time_to_first_tokens_iter))
         if len(stats.time_per_output_tokens_iter) > 0:
             self.time_per_output_token.update(avg_list(stats.time_per_output_tokens_iter))
+    
+    def log_out(self):
+        ttft = self.time_to_first_token
+        tpot = self.time_per_output_token
+        if not ttft.count == 0:
+            logger.info(f"Average time to first token (batch): {ttft.avg} s")
+        if not tpot.count == 0:
+            decode_throughput = 1 / tpot.avg if tpot.avg != 0 else 0
+            logger.info(f"Average decode throughput: {decode_throughput} t/s/u")
             
     def reset(self) -> None:
         self.time_to_first_token = AvgTracker()

--- a/vllm/engine/multiprocessing/engine.py
+++ b/vllm/engine/multiprocessing/engine.py
@@ -143,6 +143,7 @@ class MQLLMEngine:
             executor_class=executor_class,
             log_requests=not engine_args.disable_log_requests,
             log_stats=not engine_args.disable_log_stats,
+            log_global_stats=engine_args.log_global_stats,
             usage_context=usage_context)
 
     def start(self):


### PR DESCRIPTION
- Added multi-step decoding to `TTWorker` and `TTModelRunner` (currently setting `num_scheduler_steps`=10 in inference example)
- Added async output processing option to `TTModelRunner` (currently does not yield benefit and disabled via `disable_async_output_proc` since decode steps bring outputs back to host)
- Added `async_engine` option to `offline_inference_tt.py` to generate/benchmark using Async LLMEngine
- Added `log_global_stats` option to `EngineArgs` for tracking prefill/decode perf across batches of requests (will log every time there are no unfinished requests left)