### PR TITLE
Modify async_out_proc + multi-step for trace mode to trigger output processor for step (i) when running step (i+1)

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -40,7 +40,7 @@ def run_inference(
         "max_num_batched_tokens": 131072,
         "log_global_stats": True if measure_perf else False,
         "num_scheduler_steps": 10,
-        "disable_async_output_proc": True,
+        "disable_async_output_proc": False,
     }
     
     # Generation args

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -17,7 +17,6 @@ def main():
         "--max_model_len", "131072",
         "--max_num_batched_tokens", "131072",
         "--num_scheduler_steps", "10",
-        "--disable_async_output_proc",
     ])
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -2,7 +2,7 @@
 ## vLLM and tt-metal Branches
 Git-checkout the following branches in each repo separately:
 - vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev) (last verified commit: [409dbd7](https://github.com/tenstorrent/vllm/tree/409dbd77b1af5c26cbd5b047448cb6a8e9767a35))
-- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [2c84ace](https://github.com/tenstorrent/tt-metal/tree/2c84ace80a82302607e809ebce5c9514d5edc22a))
+- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [685ef13](https://github.com/tenstorrent/tt-metal/tree/685ef1303b5abdfda63183fdd4fd6ed51b496833))
 
 ## Environment Creation
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1680,7 +1680,7 @@ class LLMEngine:
                     latency = seq_group.get_last_latency(now)
                     
                     # Divide by the number of outputs for the multi-step case
-                    num_outputs = len(model_output)
+                    num_outputs = scheduler_outputs.num_lookahead_slots + 1
                     latency /= num_outputs
                     
                     time_per_output_tokens_iter.append(latency)


### PR DESCRIPTION
- Add `async_out_proc_per_trace` to `TTModelRunner::execute_model` (currently always enabled when async_output_proc, multi-step, and trace-mode are on) to trigger vllm output processor for step (i) when running step (i+1) such that output processor overhead is amortized over num_scheduler_steps (set to 10 in inference example). 
- Enable async_output_proc in `offline_inference_tt.py` and `server_example_tt.py`
- Improves e2e perf measurement from `offline_inference_tt.py` from ~12.4 t/s/u to ~13.3 t/s/u.