### PR TITLE
[Bugfix] #31 _make_sampler_output return expected SequenceOutput output_token: int

### DIFF
--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -351,7 +351,7 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         zero_logprob = Logprob(0.0)
         sampler_outputs = []
         for batch_idx, seq_id in enumerate(seq_groups):
-            next_token_id = next_token_ids[batch_idx]
+            next_token_id = int(next_token_ids[batch_idx])
             seq_outputs = [SequenceOutput(seq_id, next_token_id,
                                 {next_token_id: zero_logprob})]
             sampler_outputs.append(


### PR DESCRIPTION
# change log
- Fixes #31 
- _make_sampler_output return expected SequenceOutput output_token: int

## summary

_make_sampler_output makes sense to do the conversion because input (cached_step_outputs) is expected to be List[torch.Tensor] so further upstream would require other changes.

vllm/vllm/worker/tt_model_runner.py::TTModelRunner::_make_sampler_output -> SamplerOutput

vllm/vllm/model_executor/layers/sampler.py::SamplerOutput

    outputs: List[CompletionSequenceGroupOutput]

vllm/vllm/sequence.py::CompletionSequenceGroupOutput

    samples: List[SequenceOutput]

vllm/vllm/sequence.py::SequenceOutput

    output_token: int

