### PR TITLE
Add device-specific request validation in LLMEngine and modify request-specific asserts in TTModelRunner to not crash server instances

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -16,8 +16,8 @@ from vllm.inputs.data import TokensPrompt
 from vllm.engine.multiprocessing.client import MQLLMEngineClient
 
 # Import and register model from tt-metal
-from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
-ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
+from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM
+ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
 
 
 def run_inference(

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -5,8 +5,8 @@ import runpy
 from vllm import ModelRegistry
 
 # Import and register model from tt-metal
-from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
-ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaModelForGeneration)
+from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM
+ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
 
 
 def main():

--- a/vllm/executor/tt_executor.py
+++ b/vllm/executor/tt_executor.py
@@ -4,7 +4,7 @@ from vllm.executor.executor_base import ExecutorBase, ExecutorAsyncBase
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
 from vllm.model_executor.layers.sampler import SamplerOutput
-from vllm.sequence import ExecuteModelRequest
+from vllm.sequence import ExecuteModelRequest, SequenceGroup
 from vllm.utils import make_async
 
 logger = init_logger(__name__)
@@ -99,6 +99,12 @@ class TTExecutor(ExecutorBase):
     def list_prompt_adapters(self) -> Set[int]:
         raise NotImplementedError(
             "Soft prompt is currently not supported by the TT backend.")
+        
+    def validate_seq_group(self, seq_group: SequenceGroup) -> None:
+        '''
+        Validate the sequence group before it is scheduled for execution in LLMEngine::_add_processed_request.
+        '''
+        self.driver_worker.model_runner.validate_seq_group(seq_group)
    
 class TTExecutorAsync(TTExecutor, ExecutorAsyncBase):
 


### PR DESCRIPTION
Issue: https://github.com/tenstorrent/vllm/issues/29

- Added `_validate_device_inputs` to `LLMEngine` for performing device-specific request validation (whereas the existing `_validate_model_inputs` and custom input processors can be used for device agnostic or model-specific request validation). Currently only supported for TT models through TTExecutor::validate_seq_group
- Changed sampling param assertions in `TTModelRunner` to ValueErrors which are triggered through the invocation of `_validate_device_inputs` mentioned above, so that bad requests return 400 errors instead of crashing the server
- Changed batch level assertions (during step execution) for same temp/top-p/top-k params to warnings to avoid server crashes (this cannot be handled through _validate_device_inputs since it has already reached step execution at which point any assertion or error will crash the server)
- Note: This PR also relies on https://github.com/tenstorrent/tt-metal/pull/15880