### PR TITLE
[TT] Add support for multi-modal llama, different TT devices, paged cross attention

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -91,11 +91,11 @@ def run_inference(
             with open(prompts_json, 'r') as file:
                 prompts = json.load(file)
             assert isinstance(prompts, list), "Prompts must be a list of strings"
-            if num_repeat_prompts is not None:
-                prompts = prompts * num_repeat_prompts
         else:
             print("Ignoring prompts json for multi-modal inference")
             prompts = get_sample_multi_modal_llama_inputs() 
+        if num_repeat_prompts is not None:
+            prompts = prompts * num_repeat_prompts
         print("Number of prompts:", len(prompts))
     else:
         assert perf_prompt_len is not None, "perf_prompt_len is required to generate dummy prompts"
@@ -180,7 +180,7 @@ def generate_tokens(llm : LLM, prompts, sampling_params, prompt_token_ids=None, 
         num_tokens_prompt = len(output.prompt_token_ids)
         num_tokens_output = len(output.outputs[0].token_ids)
         if print_output:
-            print(f"Prompt ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
+            print(f"Prompt #{output.request_id + 1} ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
 
 
 async def generate_tokens_async(llm : MQLLMEngineClient, prompts, sampling_params, prompt_token_ids=None, print_output=True):
@@ -204,7 +204,7 @@ async def generate_tokens_async(llm : MQLLMEngineClient, prompts, sampling_param
         num_tokens_prompt = len(res.prompt_token_ids)
         num_tokens_output = len(res.outputs[0].token_ids)
         if print_output and res.finished:
-            print(f"Prompt ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
+            print(f"Prompt #{res.request_id + 1} ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
 
 
 if __name__ == "__main__":
@@ -215,6 +215,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_tokens", type=int, default=128, help="Length of outputs")
     parser.add_argument("--greedy_sampling", action="store_true", help="Use greedy decoding instead of top-k/p")
     parser.add_argument("--max_seqs_in_batch", type=int, default=32, help="Maximum batch size for inference")
+    parser.add_argument("--num_repeat_prompts", type=int, default=2, help="Number of times to repeat prompts")
     parser.add_argument("--async_engine", action="store_true", help="Use async engine")
     parser.add_argument("--disable_async_output_proc", action="store_true", help="Disable async output processing")
     parser.add_argument("--num_scheduler_steps", type=int, default=10, help="Number of scheduler steps")
@@ -228,6 +229,7 @@ if __name__ == "__main__":
         max_tokens=args.max_tokens,
         greedy_sampling=args.greedy_sampling,
         max_seqs_in_batch=args.max_seqs_in_batch,
+        num_repeat_prompts=args.num_repeat_prompts,
         async_engine=args.async_engine,
         num_scheduler_steps=args.num_scheduler_steps,
         disable_async_output_proc=args.disable_async_output_proc,

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -206,13 +206,12 @@ async def generate_tokens_async(llm : MQLLMEngineClient, prompts, sampling_param
         generators.append(generator)
     all_gens = merge_async_iterators(*generators)
     async for i, res in all_gens:
-        request_id = int(res.request_id) + 1
         prompt = res.prompt
         generated_text = res.outputs[0].text
         num_tokens_prompt = len(res.prompt_token_ids)
         num_tokens_output = len(res.outputs[0].token_ids)
         if print_output and res.finished:
-            print(f"Prompt #{request_id} ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
+            print(f"Prompt ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n")
 
 
 if __name__ == "__main__":

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -18,9 +18,9 @@ from vllm.engine.multiprocessing.client import MQLLMEngineClient
 
 # Import and register models from tt-metal
 from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM
-from models.demos.llama3.tt.generator import LlamaGenerator
+from models.demos.llama3.tt.generator_vllm import TtMllamaForConditionalGeneration
 ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
-ModelRegistry.register_model("TTMllamaForConditionalGeneration", LlamaGenerator)
+ModelRegistry.register_model("TTMllamaForConditionalGeneration", TtMllamaForConditionalGeneration)
 
 
 def get_sample_multi_modal_llama_inputs():

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -59,8 +59,6 @@ def run_inference(
         os.environ["MESH_DEVICE"] = "N300"
         assert not measure_perf, "measure_perf is not yet supported for multi-modal inference"
         assert not async_engine, "async_engine is not yet supported for multi-modal inference"
-        assert disable_async_output_proc, "async output processing is not yet supported for multi-modal inference"
-        assert num_scheduler_steps == 1, "multi-step scheduling is not yet supported for multi-modal inference"
     else:
         model = "meta-llama/Meta-Llama-3.1-70B"
         os.environ["MESH_DEVICE"] = "T3K_RING"

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -38,7 +38,6 @@ def get_sample_multi_modal_llama_inputs():
             img = PIL_Image.open(f).convert("RGB")
         prompt = f"<|image|>{question}"
         inputs.append({"prompt": prompt, "multi_modal_data": {"image": img}})
-    inputs = inputs[0:1]  # TODO: Remove once model supports batch > 1
     return inputs
 
 

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -23,6 +23,7 @@ def main():
             os.environ["MESH_DEVICE"] = "N300"
         else:
             assert os.environ["MESH_DEVICE"] in ["N300", "T3K_LINE"], "Invalid MESH_DEVICE for multi-modal inference"
+        sys.argv.remove("--multi_modal")  # remove the flag for the API server
     else:
         model = "meta-llama/Meta-Llama-3.1-70B"
         os.environ["MESH_DEVICE"] = "T3K_RING"

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -1,18 +1,31 @@
+import argparse
 import os
 import sys
 import runpy
 
 from vllm import ModelRegistry
 
-# Import and register model from tt-metal
+# Import and register models from tt-metal
 from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM
+from models.demos.llama3.tt.generator_vllm import TtMllamaForConditionalGeneration
 ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
+ModelRegistry.register_model("TTMllamaForConditionalGeneration", TtMllamaForConditionalGeneration)
 
 
 def main():
-    os.environ["MESH_DEVICE"] = "T3K_RING"
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--multi_modal", action="store_true", help="Run multi-modal inference with Llama3.2-11b")
+    args = parser.parse_args()
+    
+    if args.multi_modal:
+        model = "meta-llama/Llama-3.2-11B-Vision-Instruct"
+        os.environ["MESH_DEVICE"] = "N300"
+    else:
+        model = "meta-llama/Meta-Llama-3.1-70B"
+        os.environ["MESH_DEVICE"] = "T3K_RING"
+    
     sys.argv.extend([
-        "--model", "meta-llama/Meta-Llama-3.1-70B",
+        "--model", model,
         "--block_size", "64",
         "--max_num_seqs", "32",
         "--max_model_len", "131072",

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -10,6 +10,7 @@ ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
 
 
 def main():
+    os.environ["MESH_DEVICE"] = "T3K_RING"
     sys.argv.extend([
         "--model", "meta-llama/Meta-Llama-3.1-70B",
         "--block_size", "64",

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -19,7 +19,10 @@ def main():
     
     if args.multi_modal:
         model = "meta-llama/Llama-3.2-11B-Vision-Instruct"
-        os.environ["MESH_DEVICE"] = "N300"
+        if os.environ.get("MESH_DEVICE") is None:
+            os.environ["MESH_DEVICE"] = "N300"
+        else:
+            assert os.environ["MESH_DEVICE"] in ["N300", "T3K_LINE"], "Invalid MESH_DEVICE for multi-modal inference"
     else:
         model = "meta-llama/Meta-Llama-3.1-70B"
         os.environ["MESH_DEVICE"] = "T3K_RING"

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -30,15 +30,17 @@ Git-checkout the following branches in each repo separately:
     source $vllm_dir/tt_metal/setup-metal.sh && source $PYTHON_ENV_DIR/bin/activate
     ```
 
-## Accessing the Meta-Llama-3.1 Hugging Face Model
+## Accessing the Meta-Llama Hugging Face Models
 
-To run Meta-Llama-3.1, it is required to have access to the model on Hugging Face. To gain access:
-1. Request access on [https://huggingface.co/meta-llama/Meta-Llama-3.1-70B](https://huggingface.co/meta-llama/Meta-Llama-3.1-70B).
+To run Meta-Llama-3.1/3.2, it is required to have access to the model on Hugging Face. To gain access:
+1. Request access on Hugging Face:
+    - Llama-3.1: [https://huggingface.co/meta-llama/Meta-Llama-3.1-70B](https://huggingface.co/meta-llama/Meta-Llama-3.1-70B)
+    - Llama-3.2: [https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)
 2. Once you have received access, create and copy your access token from the settings tab on Hugging Face.
 3. Run this code in python and paste your access token:
     ```python
-    from huggingface_hub import notebook_login
-    notebook_login()
+    from huggingface_hub import login
+    login()
     ```
 
 ## Preparing the tt-metal models

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -71,12 +71,15 @@ WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_infer
 
 To measure performance for a single batch (with the default prompt length of 128 tokens):
 ```python
-WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 4
 ```
 
-**Note**: By default the multi-modal inference example will run with `MESH_DEVICE=N300`. To run on T3000, set `MESH_DEVICE=T3K_LINE` and `--max_seqs_in_batch 32 --num_repeat_prompts 16`
+**Note**: By default, the multi-modal inference example will run with `MESH_DEVICE=N300`. To run on T3000, set `MESH_DEVICE=T3K_LINE` and `--max_seqs_in_batch 32 --num_repeat_prompts 16`.
 
-## Running the server example (experimental)
+## Running the server example
+
 ```python
 VLLM_RPC_TIMEOUT=100000 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
 ```
+
+**Note**: By default, the server will run with Llama-3.1-70B. To run with Llama-3.2-11B-Vision-Instruct instead, add `--multi_modal`.

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -49,6 +49,9 @@ To run Meta-Llama-3.1/3.2, it is required to have access to the model on Hugging
 2. For the desired model, follow the setup instructions (if any) for the corresponding tt-metal demo. E.g. For Llama-3.1-70B, follow the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/t3000/llama3_70b) for preparing the weights and environment variables.
 
 ## Running the offline inference example
+
+### Llama-3.1-70B
+
 To generate tokens for sample prompts:
 ```python
 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py
@@ -58,6 +61,20 @@ To measure performance for a single batch (with the default prompt length of 128
 ```python
 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf
 ```
+
+### Llama-3.2-11B-Vision-Instruct
+
+To generate tokens for sample prompts:
+```python
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
+```
+
+To measure performance for a single batch (with the default prompt length of 128 tokens):
+```python
+WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
+```
+
+**Note**: By default the multi-modal inference example will run with `MESH_DEVICE=N300`. To run on T3000, set `MESH_DEVICE=T3K_LINE` and `--max_seqs_in_batch 32 --num_repeat_prompts 16`
 
 ## Running the server example (experimental)
 ```python

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -326,6 +326,11 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                     block_tables,
                     torch.zeros(batch_pad_len, block_tables.shape[1], dtype=torch.int32, device="cpu")
                 ])
+                if self.model_config.is_encoder_decoder_model:
+                    cross_block_tables = torch.cat([
+                        cross_block_tables,
+                        torch.zeros(batch_pad_len, cross_block_tables.shape[1], dtype=torch.int32, device="cpu")
+                    ])
             
             # Pad block_tables to max num blocks so ttnn tracing can work (requires constant shape)
             if self.trace_mode:

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -125,12 +125,6 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         
         self.cached_enc_dec_data: Optional[Dict[int, Dict[str, Any]]] = None  # seq_id -> enc_dec_data
 
-        # Multi-modal data support - add once TT models no longer require raw PIL images
-        # self.mm_registry = MULTIMODAL_REGISTRY
-        # self.multi_modal_input_mapper = self.mm_registry \
-        #     .create_input_mapper(self.model_config)
-        # self.mm_registry.init_mm_limits_per_prompt(self.model_config)
-
         if self.model_is_mrope:
             assert "TTModelRunner does not currently support models with mrope rope_scaling"
         

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -268,9 +268,12 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         
         # Remove cached encoder-decoder data for any seq ids that are not in the current batch (assume they were either finished or preempted)
         if not is_prompt and self.cached_enc_dec_data:
+            seq_ids_to_del = []
             for seq_id in self.cached_enc_dec_data:
                 if seq_id not in seq_groups:
-                    del self.cached_enc_dec_data[seq_id]
+                    seq_ids_to_del.append(seq_id)
+            for seq_id in seq_ids_to_del:
+                del self.cached_enc_dec_data[seq_id]
         
         # Convert lists to tensors and add padding
         

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -183,11 +183,7 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             self.cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[
                 self.cache_config.cache_dtype]
 
-        if self.model_config.model == 'meta-llama/Llama-3.2-11B-Vision-Instruct':
-            self.trace_mode = False
-            logger.warning("trace_mode is not yet supported for Llama-3.2-11B-Vision-Instruct")
-        else:
-            self.trace_mode = True  # whether to use ttnn tracing for model execution, TODO: make this configurable
+        self.trace_mode = True  # whether to use ttnn tracing for model execution, TODO: make this configurable
 
         self.model_runner: TTModelRunner = TTModelRunner(
             model_config,

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -184,7 +184,11 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             self.cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[
                 self.cache_config.cache_dtype]
 
-        self.trace_mode = True  # whether to use ttnn tracing for model execution, TODO: make this configurable
+        if self.model_config.model == 'meta-llama/Llama-3.2-11B-Vision-Instruct':
+            self.trace_mode = False
+            logger.warning("trace_mode is not yet supported for Llama-3.2-11B-Vision-Instruct")
+        else:
+            self.trace_mode = True  # whether to use ttnn tracing for model execution, TODO: make this configurable
 
         self.model_runner: TTModelRunner = TTModelRunner(
             model_config,

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -237,10 +237,7 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         appended to.
         """
         # TODO: Add proper implementation which runs profiling on TT devices
-        if self.model_config.model == 'meta-llama/Llama-3.2-11B-Vision-Instruct':
-            max_tokens_all_users = 65536
-        else:
-            max_tokens_all_users = 131072
+        max_tokens_all_users = 131072  # Note: includes num vision tokens for multi-modal
         num_tt_blocks = math.ceil(max_tokens_all_users / self.cache_config.block_size)
         num_tt_blocks = int(num_tt_blocks * 1.01)  # Add 1% to account for vLLM's watermark_blocks
         num_cpu_blocks = 0

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -48,7 +48,6 @@ class TTCacheEngine:
         # Models like Jamba, have mixed typed layers, E.g Mamba
         self.num_attention_layers = model_config.get_num_attention_layers(
             parallel_config)
-        # TODO: exclude cross attention layers from num_attention_layers if not using paged attention
 
         self.num_kv_heads = TTCacheEngine.get_num_kv_heads(
             model_config, parallel_config, device_config

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -3,6 +3,7 @@ import os
 from typing import List, Optional, Tuple
 import time
 import math
+from tqdm import tqdm
 
 import torch
 
@@ -11,7 +12,7 @@ from vllm.config import (CacheConfig, DeviceConfig, LoadConfig, ModelConfig,
 from vllm.logger import init_logger
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import ExecuteModelRequest
-from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size, is_pin_memory_available
+from vllm.utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
 from vllm.worker.worker import raise_if_cache_size_invalid
 from vllm.worker.tt_model_runner import TTModelRunner, TTModelInput
 from vllm.worker.worker_base import (LocalOrDistributedWorkerBase,
@@ -47,9 +48,10 @@ class TTCacheEngine:
         # Models like Jamba, have mixed typed layers, E.g Mamba
         self.num_attention_layers = model_config.get_num_attention_layers(
             parallel_config)
+        # TODO: exclude cross attention layers from num_attention_layers if not using paged attention
 
         self.num_kv_heads = TTCacheEngine.get_num_kv_heads(
-            model_config, parallel_config
+            model_config, parallel_config, device_config
         )
 
         self.block_size = cache_config.block_size
@@ -95,7 +97,7 @@ class TTCacheEngine:
                 kv_cache.append([cache_k, cache_v])
         else:
             cache_kv = torch.zeros(kv_cache_shape, dtype=self.dtype)
-            for _ in range(num_layers):
+            for _ in tqdm(range(num_layers), desc="Allocating TT kv caches for each layer"):
                 kv_tt = [ttnn.as_tensor(
                     lp,
                     device=self.device_config.device,
@@ -123,15 +125,15 @@ class TTCacheEngine:
     def get_num_kv_heads(
         model_config: ModelConfig,
         parallel_config: ParallelConfig,
+        device_config: DeviceConfig,
     ) -> int:
         '''
         Returns the number of KV heads per attention layer. Makes the assumption
-        that we are tensor parallel by a factor of 8.
+        that we are tensor parallel by the number of devices.
         '''
+        num_devices = len(device_config.device.get_devices())
         num_kv_heads = model_config.get_num_kv_heads(parallel_config)
-        # TODO: get num devices from device_config.device (device_mesh)
-        # TODO: add get_num_devices to worker
-        num_kv_heads //= 8 # TP=8, tries to use distributed worker if you give LLM 8 TP
+        num_kv_heads //= num_devices # TP = num_devices
         return num_kv_heads
 
     @staticmethod
@@ -211,8 +213,7 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         return self.tt_cache
 
     def init_device(self) -> None:
-        # TODO: Add support for devices other than T3K
-        self.mesh_device = self._open_t3k_mesh_device()
+        self.mesh_device = self._open_mesh_device()
         self.device_config.device = self.mesh_device
         
         # TODO: Add flag for enabling program cache
@@ -237,7 +238,10 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         appended to.
         """
         # TODO: Add proper implementation which runs profiling on TT devices
-        max_tokens_all_users = 131072
+        if self.model_config.model == 'meta-llama/Llama-3.2-11B-Vision-Instruct':
+            max_tokens_all_users = 65536
+        else:
+            max_tokens_all_users = 131072
         num_tt_blocks = math.ceil(max_tokens_all_users / self.cache_config.block_size)
         num_tt_blocks = int(num_tt_blocks * 1.01)  # Add 1% to account for vLLM's watermark_blocks
         num_cpu_blocks = 0
@@ -408,18 +412,33 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type, dispatch_core_axis)
         return dispatch_core_config
 
-    def _open_t3k_mesh_device(self):
+    def _open_mesh_device(self):
+        num_devices_available = len(ttnn.get_device_ids())
+        
+        mesh_grid_dict = {"N150": (1, 1), "N300": (1, 2), "T3K_LINE": (1, 8), "T3K_RING": (2, 4)}
+        mesh_device = os.environ.get("MESH_DEVICE")
+        if mesh_device is not None:
+            assert mesh_device in mesh_grid_dict, f"Invalid MESH_DEVICE: {mesh_device}"
+        mesh_grid = mesh_grid_dict.get(mesh_device, (1, num_devices_available))
+        if mesh_device == "T3K_RING":
+            mesh_type=ttnn.MeshType.Ring
+        else:
+            mesh_type=ttnn.MeshType.RowMajor
+        
+        if mesh_grid[0] * mesh_grid[1] > num_devices_available:
+            assert f"Requested mesh grid shape {mesh_grid} is larger than number of available devices {num_devices_available}"
+        
         if self.trace_mode:
             device_params = {"trace_region_size": 14227456}  # TODO: make this configurable
         else:
             device_params = {}
         mesh_device = ttnn.open_mesh_device(
-            ttnn.MeshShape(2, 4),
+            ttnn.MeshShape(*mesh_grid),
             dispatch_core_config=self._get_dispatch_core_config(device_params),
             **device_params,
-            mesh_type=ttnn.MeshType.Ring,
+            mesh_type=mesh_type,
         )
-        logger.debug(f"multidevice with {mesh_device.get_num_devices()} devices is created")
+        logger.info(f"multidevice with {mesh_device.get_num_devices()} devices and grid {mesh_grid} is created")
         return mesh_device
     
     def _enable_program_cache(self):


### PR DESCRIPTION
- Add support for different TT devices (specified through the `MESH_DEVICE` environment variable)
- Added support for multi-modal and encoder-decoder model execution (currently only tested for llama3.2-11b) using cross block tables in `TTModelRunner`
- Added support for multi-modal llama (llama3.2-11b) with ttnn-tracing, multi-step execution, async output processing
- Added `--multi_modal` option to `offline_inference_tt.py` for running the inference example with llama3.2-11b (supports token generation and perf measurement using `--measure_perf`)
- Added `--multi_modal` option to `server_example_tt.py` for running the server example with llama3.2-11b
- Updated tt_metal README with instructions for multi-modal llama
- Note: this PR relies on https://github.com/tenstorrent/tt-metal/pull/16076
