### PR TITLE
Fix num kv heads per device calculation for num devices > num kv heads

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -63,7 +63,11 @@ To measure performance (Llama70B) for a single batch of 32 prompts (with the def
 MESH_DEVICE=T3K_LINE WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf
 ```
 
-**Note**: By default, the inference example will run with Llama-3.1-70B. To run with Llama-3.1-8B, Llama-3.2-1B, or Llama-3.2-3B, ensure that the apprioriate environment variables are set as per the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3), then set `MESH_DEVICE=<device>` (valid options for `<device>` are `N150`, `N300`, or `T3K_LINE`) and one of the following:
+**Note 1 (Llama70B)**: To run Llama70B on Galaxy, set `MESH_DEVICE=TG` and do not set `WH_ARCH_YAML=...`.
+
+**Note 2 (Llama70B)**: By default, this will run the newer tt-metal implementation of Llama70B from the [Llama3 demo](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3) which is currently ~10% slower than the [old Llama70b implemenentation](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/t3000/llama3_70b). To run with the old implementation, set `MESH_DEVICE=T3K_RING` and modify the `TtLlamaForCausalLM` model import in [offline_inference_tt.py](https://github.com/tenstorrent/vllm/blob/dev/examples/offline_inference_tt.py) to `from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM`.
+
+**Note 3 (Other Llama Versions)**: By default, the inference example will run with Llama-3.1-70B. To run with Llama-3.1-8B, Llama-3.2-1B, or Llama-3.2-3B, ensure that the apprioriate environment variables are set as per the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3), then set `MESH_DEVICE=<device>` (valid options for `<device>` are `N150`, `N300`, `T3K_LINE`, or `TG`) and one of the following:
 - Llama-3.1-8B: `--model "meta-llama/Meta-Llama-3.1-8B"`
 - Llama-3.2-1B: `--model "meta-llama/Llama-3.2-1B"`
 - Llama-3.2-3B: `--model "meta-llama/Llama-3.2-3B"`

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -127,12 +127,12 @@ class TTCacheEngine:
         device_config: DeviceConfig,
     ) -> int:
         '''
-        Returns the number of KV heads per attention layer. Makes the assumption
-        that we are tensor parallel by the number of devices.
+        Returns the number of KV heads per attention layer (per device). Makes the assumption
+        that we are tensor parallel by min(number of devices, number of KV heads).
         '''
         num_devices = len(device_config.device.get_devices())
         num_kv_heads = model_config.get_num_kv_heads(parallel_config)
-        num_kv_heads //= num_devices # TP = num_devices
+        num_kv_heads //= min(num_devices, num_kv_heads)  # TP = num_devices if num_devices < num_kv_heads
         return num_kv_heads
 
     @staticmethod


### PR DESCRIPTION
- Previously for kv cache creation, the number of kv heads per device was determined as (num kv heads) / (num devices) which is incorrect for (num devices) > (num kv heads) (should instead divide by the minimum of the two numbers). E.g. when running on TT galaxy, the number of devices (32) exceeds the total number of kv heads for llama3 (8) and the tensor parallel factor should be 8. 
- Updated tt-metal readme to include TG and old llama70b instructions