### PR TITLE
Slightly modify TTModelRunner to handle text-only prompts with multimodal llama

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -35,19 +35,22 @@ def get_sample_multi_modal_llama_inputs():
     Prepare 4 sample multi-modal prompts for Llama3.2-11B
     '''
     IMG_PATH = Path(resource_filename("llama_models", "scripts/resources/"))
-    relative_img_paths = ["dog.jpg", "pasta.jpeg", "ocr_image.jpeg", "clutter.jpeg"]
+    relative_img_paths = [None, "pasta.jpeg", "ocr_image.jpeg", "clutter.jpeg"]
     questions = [
-        "Write a haiku for this image.",
+        "Write a haiku.",
         "What is for dinner?",
         "What is the full text of this image? Do OCR",
         "What objects are in this image?"
     ]
     inputs = []
     for relative_img_path, question in zip(relative_img_paths, questions):
-        with open(IMG_PATH / relative_img_path, "rb") as f:
-            img = PIL_Image.open(f).convert("RGB")
-        prompt = f"{MLLAMA_IMAGE_TOKEN}{question}"
-        inputs.append({"prompt": prompt, "multi_modal_data": {"image": img}})
+        if relative_img_path is not None:
+            with open(IMG_PATH / relative_img_path, "rb") as f:
+                img = PIL_Image.open(f).convert("RGB")
+            prompt = f"{MLLAMA_IMAGE_TOKEN}{question}"
+            inputs.append({"prompt": prompt, "multi_modal_data": {"image": img}})
+        else:
+            inputs.append({"prompt": question})
     return inputs
 
 


### PR DESCRIPTION
- Issue: https://github.com/tenstorrent/vllm/issues/53
- Add proper handling of text-only prompts during execution of multi-modal models to TTModelRunner
- Modify offline inference example for llama3.2-11b-vision to include a text-only prompt
- Note: this PR relies on https://github.com/tenstorrent/tt-metal/pull/17105
