### PR TITLE
Add Qwen2.5 TT model option and generation test for arbitrary increasing seq lens

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -26,6 +26,9 @@ def register_tt_models():
     
     from models.demos.llama3.tt.generator_vllm import TtMllamaForConditionalGeneration
     ModelRegistry.register_model("TTMllamaForConditionalGeneration", TtMllamaForConditionalGeneration)
+    
+    from models.demos.llama3.tt.generator_vllm import TtQwen2ForCausalLM
+    ModelRegistry.register_model("TTQwen2ForCausalLM", TtQwen2ForCausalLM)
 
 register_tt_models()  # Import and register models from tt-metal
 
@@ -65,6 +68,10 @@ def check_tt_model_supported(model):
         "meta-llama/Llama-3.2-3B",
         "meta-llama/Llama-3.2-3B-Instruct",
         "meta-llama/Llama-3.2-11B-Vision-Instruct",
+        "Qwen/Qwen2.5-7B",
+        "Qwen/Qwen2.5-7B-Instruct",
+        "Qwen/Qwen2.5-72B",
+        "Qwen/Qwen2.5-72B-Instruct",
     ]
     assert model in supported_models, f"Invalid model: {model}"
 

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -1,4 +1,3 @@
-import os
 import json
 import argparse
 from tqdm import tqdm
@@ -8,6 +7,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 from PIL import Image as PIL_Image
 import numpy as np
+from transformers import AutoTokenizer
 
 from vllm import LLM, SamplingParams
 from vllm import ModelRegistry
@@ -75,6 +75,36 @@ def check_tt_model_supported(model):
     ]
     assert model in supported_models, f"Invalid model: {model}"
 
+
+def run_seq_len_tests(engine_kw_args, sampling_params):
+    '''
+    Test generation of a few simple counting prompts with arbitrary increasing sequence lengths
+    '''
+
+    model = engine_kw_args["model"]
+    is_instruct = "Instruct" in model
+    count_sizes = [10, 100, 2000, 16000, 40000]
+    
+    if is_instruct:
+        tokenizer = AutoTokenizer.from_pretrained(model, trust_remote_code=True)
+    
+    prompts = []
+    for size in count_sizes:
+        prompt = "Continue this counting sequence (with no explanation): " + " ".join(str(i) for i in range(1, size+1))
+        if is_instruct:
+            prompt = {"role": "user", "content": prompt}
+            prompt = tokenizer.apply_chat_template([prompt],
+                                                    tokenize=False,
+                                                    add_generation_prompt=True)
+        prompts.append(prompt)    
+    
+    llm = LLM(**engine_kw_args)
+    
+    # Run generation one prompt at a time
+    for i in range(len(count_sizes)):
+        generate_tokens(llm, [prompts[i]], sampling_params, print_output=True)
+    
+
 def run_inference(
     model,
     prompts_json,
@@ -88,6 +118,7 @@ def run_inference(
     num_scheduler_steps=10,
     disable_async_output_proc=False,
     multi_modal=False,
+    test_increasing_seq_lens=False,
 ):
     check_tt_model_supported(model)
     
@@ -111,6 +142,13 @@ def run_inference(
         sampling_params = SamplingParams(max_tokens=max_tokens, ignore_eos=ignore_eos, temperature=0.0)
     else:
         sampling_params = SamplingParams(max_tokens=max_tokens, ignore_eos=ignore_eos, top_k=10, top_p=0.9, temperature=1.0)
+
+    if test_increasing_seq_lens:
+        assert not measure_perf, "measure_perf option not supported with test_increasing_seq_lens"
+        assert not async_engine, "async_engine option not supported with test_increasing_seq_lens"
+        print("Ignoring prompts json for sequence length testing")
+        run_seq_len_tests(engine_kw_args, sampling_params)
+        return
 
     # Prepare inputs
     if not measure_perf:
@@ -250,6 +288,7 @@ if __name__ == "__main__":
     parser.add_argument("--disable_async_output_proc", action="store_true", help="Disable async output processing")
     parser.add_argument("--num_scheduler_steps", type=int, default=10, help="Number of scheduler steps")
     parser.add_argument("--multi_modal", action="store_true", help="Run multi-modal inference with Llama3.2-11b")
+    parser.add_argument("--test_increasing_seq_lens", action="store_true", help="Test generations of small to large sequences")
     args = parser.parse_args()
 
     run_inference(
@@ -265,4 +304,5 @@ if __name__ == "__main__":
         num_scheduler_steps=args.num_scheduler_steps,
         disable_async_output_proc=args.disable_async_output_proc,
         multi_modal=args.multi_modal,
+        test_increasing_seq_lens=args.test_increasing_seq_lens,
     )

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -47,11 +47,11 @@ To run Meta-Llama-3.1/3.2, it is required to have access to the model on Hugging
 ## Preparing the tt-metal models
 
 1. Ensure that `$PYTHONPATH` contains the path to tt-metal (should already have been done when installing tt-metal)
-2. For the desired model, follow the setup instructions (if any) for the corresponding tt-metal demo. E.g. For Llama-3.1/3.2, follow the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3) for preparing the weights and environment variables, and install any extra requirements (e.g. `pip install -r models/demos/llama3/requirements.txt`).
+2. For the desired model, follow the setup instructions (if any) for the corresponding tt-metal demo. E.g. For Llama-3.1/3.2 and Qwen-2.5, follow the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3) for preparing the weights and environment variables, and install any extra requirements (e.g. `pip install -r models/demos/llama3/requirements.txt`).
 
 ## Running the offline inference example
 
-### Llama-3.1/3.2 Text Models (1B, 3B, 8B, 70B)
+### Llama-3.1/3.2 (1B, 3B, 8B, 70B) and Qwen-2.5 (7B, 72B) Text Models
 
 To generate tokens (Llama70B) for sample prompts (with batch size 32):
 ```python
@@ -67,10 +67,12 @@ MESH_DEVICE=T3K_LINE WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python e
 
 **Note 2 (Llama70B)**: By default, this will run the newer tt-metal implementation of Llama70B from the [Llama3 demo](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3). To run with the [old Llama70B implemenentation](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/t3000/llama3_70b), set `MESH_DEVICE=T3K_RING` and modify the `TtLlamaForCausalLM` model import in [offline_inference_tt.py](https://github.com/tenstorrent/vllm/blob/dev/examples/offline_inference_tt.py) to `from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM`.
 
-**Note 3 (Other Llama Versions)**: By default, the inference example will run with Llama-3.1-70B. To run with Llama-3.1-8B, Llama-3.2-1B, or Llama-3.2-3B, ensure that the apprioriate environment variables are set as per the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3), then set `MESH_DEVICE=<device>` (valid options for `<device>` are `N150`, `N300`, `T3K_LINE`, or `TG`) and one of the following:
+**Note 3 (Other Models)**: By default, the inference example will run with Llama-3.1-70B. To run with Llama-3.1-8B, Llama-3.2-1B, Llama-3.2-3B, Qwen-2.5-7B, or Qwen-2.5-72B, ensure that the apprioriate environment variables are set as per the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/demos/llama3), then set `MESH_DEVICE=<device>` (valid options for `<device>` are `N150`, `N300`, `T3K_LINE`, or `TG`) and one of the following:
 - Llama-3.1-8B: `--model "meta-llama/Meta-Llama-3.1-8B"`
 - Llama-3.2-1B: `--model "meta-llama/Llama-3.2-1B"`
 - Llama-3.2-3B: `--model "meta-llama/Llama-3.2-3B"`
+- Qwen-2.5-7B: `--model "Qwen/Qwen2.5-7B"` (currently only supported on N300)
+- Qwen-2.5-72B: `--model "Qwen/Qwen2.5-72B"` (currently only supported on T3K)
 
 ### Llama-3.2-11B-Vision-Instruct
 
@@ -92,5 +94,5 @@ MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examp
 VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K_LINE WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
 ```
 
-**Note**: By default, the server will run with Llama-3.1-70B. To run with other Llama versions, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
+**Note**: By default, the server will run with Llama-3.1-70B. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
 


### PR DESCRIPTION
- Add Qwen2.5 to list of supported TT models and update README with instructions
- Add `test_increasing_seq_lens` option to `offline_inference_tt.py` for testing arbitrary increasing seq lens