### PR TITLE
handle new llama 3.1 8B HF repo name and old in parameter setting max seq len to avoid OOM on n150 in #65

### DIFF
--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -237,7 +237,7 @@ class TTWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         appended to.
         """
         # TODO: Add proper implementation which runs profiling on TT devices
-        if ("meta-llama/Meta-Llama-3.1-8B" in self.model_config.model and 
+        if ("Llama-3.1-8B" in self.model_config.model and 
             len(self.device_config.device.get_devices()) == 1):  # Llama8B on N150
             max_tokens_all_users = 65536
         else:


### PR DESCRIPTION
fixes #65 

Tested on LoudBox (T3K) with MESH_DEVICE=N150.