### PR TITLE
Change TT Llama/Qwen imports to use new tt_transformers path

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -19,16 +19,16 @@ from vllm.engine.multiprocessing.client import MQLLMEngineClient
 from vllm.model_executor.models.mllama import MLLAMA_IMAGE_TOKEN, MLLAMA_IMAGE_TOKEN_ID
 
 def register_tt_models():
-    from models.demos.llama3.tt.generator_vllm import TtLlamaForCausalLM
+    from models.tt_transformers.tt.generator_vllm import LlamaForCausalLM
     # To use old version of llama70b tt-metal model, use the import below
-    # from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM
-    ModelRegistry.register_model("TTLlamaForCausalLM", TtLlamaForCausalLM)
+    # from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM as LlamaForCausalLM
+    ModelRegistry.register_model("TTLlamaForCausalLM", LlamaForCausalLM)
     
-    from models.demos.llama3.tt.generator_vllm import TtMllamaForConditionalGeneration
-    ModelRegistry.register_model("TTMllamaForConditionalGeneration", TtMllamaForConditionalGeneration)
+    from models.tt_transformers.tt.generator_vllm import MllamaForConditionalGeneration
+    ModelRegistry.register_model("TTMllamaForConditionalGeneration", MllamaForConditionalGeneration)
     
-    from models.demos.llama3.tt.generator_vllm import TtQwen2ForCausalLM
-    ModelRegistry.register_model("TTQwen2ForCausalLM", TtQwen2ForCausalLM)
+    from models.tt_transformers.tt.generator_vllm import Qwen2ForCausalLM
+    ModelRegistry.register_model("TTQwen2ForCausalLM", Qwen2ForCausalLM)
 
 register_tt_models()  # Import and register models from tt-metal
 


### PR DESCRIPTION
- Modifed the imports of the TT transformers models to use the new directory introduced in https://github.com/tenstorrent/tt-metal/pull/18478