### PR TITLE
Update TT vLLM readme with example server request, change default server model to 70B-Instruct

### DIFF
--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -9,7 +9,7 @@ register_tt_models()  # Import and register models from tt-metal
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", type=str, default="meta-llama/Meta-Llama-3.1-70B", help="Model name")
+    parser.add_argument("--model", type=str, default="meta-llama/Llama-3.1-70B-Instruct", help="Model name")
     args = parser.parse_args()
     
     check_tt_model_supported(args.model)

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -91,9 +91,15 @@ MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examp
 
 ## Running the server example
 
+To start up the server:
 ```python
 VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
 ```
 
-**Note**: By default, the server will run with Llama-3.1-70B. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
+To send a request to the server:
+```sh
+curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{ "model": "meta-llama/Llama-3.1-70B-Instruct", "prompt": "San Francisco is a", "max_tokens": 32, "temperature": 1, "top_p": 0.9, "top_k": 10 }'
+```
+
+**Note**: By default, the server will run with Llama-3.1-70B-Instruct. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
 


### PR DESCRIPTION
- Update TT vLLM readme with example server request
- Change default model in `server_example_tt.py` to Llama3.1-70B-Instruct