### PR TITLE
Hotfix: README.md

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -137,7 +137,7 @@ payload = {
             "content": [
                 {
                     "type": "text",
-                    "text": "<image>\nWhat is for dinner?"
+                    "text": "What is for dinner?"
                 },
                 {
                     "type": "image_url",


### PR DESCRIPTION
The vLLM instructions found [here](https://docs.vllm.ai/en/v0.5.3/models/vlm.html) gave two example of constructing prompt for vision models. The first example used <image>\n in the text prompt. The second example did not need that token in the text prompt.

The code snippet that shows how to generate prompt for the supported vision models in the README.md of this repo was following the second example mentioned above. However, <image>\n was incorrectly included in the text prompt.

This PR fixes the above mistake by removing <image>\n from the text prompt example in README.md
