### PR TITLE
Add option to sample on device for decode and add override_tt_config vLLM option for custom TT args

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -121,8 +121,13 @@ def run_inference(
     disable_async_output_proc=False,
     multi_modal=False,
     test_increasing_seq_lens=False,
+    sample_on_device_decode=False,
 ):
     check_tt_model_supported(model)
+    
+    override_tt_config = {}
+    if sample_on_device_decode:
+        override_tt_config["sample_on_device_decode"] = True
     
     # LLM args
     engine_kw_args = {
@@ -135,6 +140,7 @@ def run_inference(
         "log_global_stats": True if measure_perf else False,
         "num_scheduler_steps": num_scheduler_steps,
         "disable_async_output_proc": disable_async_output_proc,
+        "override_tt_config": override_tt_config,
     }
     
     # Generation args
@@ -291,6 +297,7 @@ if __name__ == "__main__":
     parser.add_argument("--num_scheduler_steps", type=int, default=10, help="Number of scheduler steps")
     parser.add_argument("--multi_modal", action="store_true", help="Run multi-modal inference with Llama3.2-11b")
     parser.add_argument("--test_increasing_seq_lens", action="store_true", help="Test generations of small to large sequences")
+    parser.add_argument("--sample_on_device_decode", action="store_true", help="Enable sampling on device during decode")
     args = parser.parse_args()
 
     run_inference(
@@ -307,4 +314,5 @@ if __name__ == "__main__":
         disable_async_output_proc=args.disable_async_output_proc,
         multi_modal=args.multi_modal,
         test_increasing_seq_lens=args.test_increasing_seq_lens,
+        sample_on_device_decode=args.sample_on_device_decode,
     )

--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -10,7 +10,7 @@ register_tt_models()  # Import and register models from tt-metal
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, default="meta-llama/Llama-3.1-70B-Instruct", help="Model name")
-    args = parser.parse_args()
+    args, unknown_args = parser.parse_known_args()
     
     check_tt_model_supported(args.model)
     

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -102,12 +102,14 @@ To start up the server:
 VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
 ```
 
+**Note**: By default, the server will run with Llama-3.1-70B-Instruct. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
+
+**Note**: Custom TT options can be set using `--override_tt_config`, e.g. `--override_tt_config '{"sample_on_device_decode": true}'`, however these shouldn't be used unless the model supports them (most currently do not).
+
 To send a request to the server:
 ```sh
 curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{ "model": "meta-llama/Llama-3.1-70B-Instruct", "prompt": "San Francisco is a", "max_tokens": 32, "temperature": 1, "top_p": 0.9, "top_k": 10 }'
 ```
-
-**Note**: By default, the server will run with Llama-3.1-70B-Instruct. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
 
 ### Llama-3.2 (11B and 90B) Vision models
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -99,7 +99,8 @@ class ModelConfig:
         override_neuron_config: Initialize non default neuron config or 
             override default neuron config that are specific to Neuron devices, 
             this argument will be used to configure the neuron config that 
-            can not be gathered from the vllm arguments. 
+            can not be gathered from the vllm arguments.
+        override_tt_config: Override default TT config, specific to TT devices.
         config_format: The config format which shall be loaded.
             Defaults to 'auto' which defaults to 'hf'.
         mm_processor_kwargs: Arguments to be forwarded to the model's processor
@@ -132,6 +133,7 @@ class ModelConfig:
                  limit_mm_per_prompt: Optional[Mapping[str, int]] = None,
                  use_async_output_proc: bool = True,
                  override_neuron_config: Optional[Dict[str, Any]] = None,
+                 override_tt_config: Optional[Dict[str, Any]] = None,
                  config_format: ConfigFormat = ConfigFormat.AUTO,
                  mm_processor_kwargs: Optional[Dict[str, Any]] = None) -> None:
         self.model = model
@@ -207,6 +209,7 @@ class ModelConfig:
 
         self.override_neuron_config = override_neuron_config if is_neuron(
         ) else None
+        self.override_tt_config = override_tt_config if is_tt() else None
         self._verify_embedding_mode()
         self._verify_quantization()
         self._verify_cuda_graph()

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -178,6 +178,7 @@ class EngineArgs:
     collect_detailed_traces: Optional[str] = None
     disable_async_output_proc: bool = False
     override_neuron_config: Optional[Dict[str, Any]] = None
+    override_tt_config: Optional[Dict[str, Any]] = None
     mm_processor_kwargs: Optional[Dict[str, Any]] = None
     scheduling_policy: Literal["fcfs", "priority"] = "fcfs"
 
@@ -818,6 +819,12 @@ class EngineArgs:
             default=None,
             help="Override or set neuron device configuration. "
             "e.g. {\"cast_logits_dtype\": \"bloat16\"}.'")
+        parser.add_argument(
+            '--override-tt-config',
+            type=json.loads,
+            default=None,
+            help="Override or set TT device configuration. "
+            "e.g. '{\"sample_on_device_decode\": true}'")
 
         parser.add_argument(
             '--scheduling-policy',
@@ -866,6 +873,7 @@ class EngineArgs:
             limit_mm_per_prompt=self.limit_mm_per_prompt,
             use_async_output_proc=not self.disable_async_output_proc,
             override_neuron_config=self.override_neuron_config,
+            override_tt_config=self.override_tt_config,
             config_format=self.config_format,
             mm_processor_kwargs=self.mm_processor_kwargs,
         )

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -117,7 +117,11 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         self.block_size = cache_config.block_size
 
         self.trace_mode = trace_mode  # whether to use ttnn tracing for model execution
-        self.sample_on_device_decode = False  # whether to sample on device for decode, TODO: make this configurable
+        override_tt_config = model_config.override_tt_config
+        if override_tt_config is not None and "sample_on_device_decode" in override_tt_config:
+            self.sample_on_device_decode = override_tt_config["sample_on_device_decode"]
+        else:
+            self.sample_on_device_decode = False  # whether to sample on device for decode
         logger.info(f"TTModelRunner: trace_mode={self.trace_mode}, sample_on_device_decode={self.sample_on_device_decode}")
 
         self.cached_step_outputs: List[torch.Tensor] = []  # Only used for multi-step execution

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -117,6 +117,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         self.block_size = cache_config.block_size
 
         self.trace_mode = trace_mode  # whether to use ttnn tracing for model execution
+        self.sample_on_device_decode = False  # whether to sample on device for decode, TODO: make this configurable
+        logger.info(f"TTModelRunner: trace_mode={self.trace_mode}, sample_on_device_decode={self.sample_on_device_decode}")
 
         self.cached_step_outputs: List[torch.Tensor] = []  # Only used for multi-step execution
         
@@ -464,6 +466,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             execute_model_kwargs["prompt_lens"] = model_input.prompt_lens
         else:
             execute_model_kwargs["start_pos"] = model_input.input_positions
+            if self.sample_on_device_decode:
+                execute_model_kwargs["sampling_params"] = model_input.tt_sampling_params
         if model_input.cross_block_tables is not None:
             execute_model_kwargs["cross_page_table"] = model_input.cross_block_tables
         
@@ -491,18 +495,23 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             else:
                 enc_dec_kwargs = {}
             
-            tt_logits = self.model.decode_forward(
+            tt_out = self.model.decode_forward(
                 **execute_model_kwargs, **enc_dec_kwargs, enable_trace=self.trace_mode, read_from_device=False
             )
             if async_out_proc_per_trace:
                 # trigger output processor on host while device is executing next step
                 self._send_prev_step_async_out(model_input, step_idx)
-            logits = self.model.read_decode_output(tt_logits, model_input.unpadded_batch_size)
+            tt_out = self.model.read_decode_output(tt_out, model_input.unpadded_batch_size, is_tokens=self.sample_on_device_decode)
+            if not self.sample_on_device_decode:
+                logits = tt_out
+            else:
+                next_token_ids = tt_out
 
         # Note: for other devices, vLLM applies vllm.model_executor.layers.logits_processor::LogitsProcessor::_apply_logits_processors on logits, we don't use this
         # Note: for other devices, vLLM applies vllm.model_executor.layers.sampler::Sampler for sampling tokens, we don't use this
-        next_logits = logits[:model_input.unpadded_batch_size, -1, :]  # unpadded batch, vocab of last token
-        next_token_ids = self._sample_tokens(next_logits, model_input.tt_sampling_params)
+        if not is_decode or not self.sample_on_device_decode:
+            next_logits = logits[:model_input.unpadded_batch_size, -1, :]  # unpadded batch, vocab of last token
+            next_token_ids = self._sample_tokens(next_logits, model_input.tt_sampling_params)
         
         return next_token_ids
 


### PR DESCRIPTION
Corresponding issue: [#20181](https://github.com/tenstorrent/tt-metal/issues/20181)

- Added `sample_on_device_decode` attribute to TTModelRunner for enabling sampling on device for decode (disabled by default). If true, a `TTSamplingParams` dataclass will be passed into the TT models `decode_forward` function. This should only be set to true if the TT model is able to support top-p/k sampling and greedy decoding.
- Added `override_tt_config` option to vLLM for passing in TT-specific args like `sample_on_device_decode`
- Added `sample_on_device_decode` option to `offline_inference_tt.py`
- Updated `server_example_tt.py` to accept unknown args (i.e. those that can be passed into vLLM's EngineArgs like `override_tt_config`)

Note: this PR requires https://github.com/tenstorrent/tt-metal/pull/20458