### PR TITLE
Use TT_LLAMA_TEXT_VER to switch between TT Llama implementations

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -2,6 +2,7 @@ import json
 import argparse
 from tqdm import tqdm
 import uvloop
+import os
 import time
 from pathlib import Path
 from pkg_resources import resource_filename
@@ -19,14 +20,21 @@ from vllm.engine.multiprocessing.client import MQLLMEngineClient
 from vllm.model_executor.models.mllama import MLLAMA_IMAGE_TOKEN, MLLAMA_IMAGE_TOKEN_ID
 
 def register_tt_models():
-    from models.tt_transformers.tt.generator_vllm import LlamaForCausalLM
-    # To use old version of llama70b tt-metal model, use the import below
-    # from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM as LlamaForCausalLM
+    llama_text_version = os.getenv("TT_LLAMA_TEXT_VER", "tt_transformers")
+    if llama_text_version == "tt_transformers":
+        from models.tt_transformers.tt.generator_vllm import LlamaForCausalLM
+    elif llama_text_version == "llama3_subdevices":
+        from models.demos.llama3_subdevices.tt.generator_vllm import LlamaForCausalLM
+    elif llama_text_version == "llama2_70b":
+        from models.demos.t3000.llama2_70b.tt.generator_vllm import TtLlamaForCausalLM as LlamaForCausalLM
+    else:
+        raise ValueError(f"Unsupported TT Llama version: {llama_text_version}, pick one of [tt_transformers, llama3_subdevices, llama2_70b]")
+
     ModelRegistry.register_model("TTLlamaForCausalLM", LlamaForCausalLM)
-    
+
     from models.tt_transformers.tt.generator_vllm import MllamaForConditionalGeneration
     ModelRegistry.register_model("TTMllamaForConditionalGeneration", MllamaForConditionalGeneration)
-    
+
     from models.tt_transformers.tt.generator_vllm import Qwen2ForCausalLM
     ModelRegistry.register_model("TTQwen2ForCausalLM", Qwen2ForCausalLM)
 
@@ -69,6 +77,8 @@ def check_tt_model_supported(model):
         "meta-llama/Llama-3.2-3B-Instruct",
         "meta-llama/Llama-3.2-11B-Vision-Instruct",
         "meta-llama/Llama-3.2-90B-Vision-Instruct",
+        "meta-llama/Llama-3.3-70B",
+        "meta-llama/Llama-3.3-70B-Instruct",
         "Qwen/Qwen2.5-7B",
         "Qwen/Qwen2.5-7B-Instruct",
         "Qwen/Qwen2.5-72B",


### PR DESCRIPTION
* Use TT_LLAMA_TEXT_VER to switch between TT Llama implementations
* Add Llama-3.3 to the list of supported models

I messed up the branch during rebase that I used in https://github.com/tenstorrent/vllm/pull/78.
Let's continue here, please? Thanks!