### PR TITLE
Ignore best-of request parameter

### DIFF
--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -239,6 +239,8 @@ async def async_request_openai_completions(
             "logprobs": request_func_input.logprobs,
             "stream": True,
         }
+        # Temporary workaround! This is already fixed on latest vLLM/main.
+        # Just run it over when rebasing.
         if request_func_input.best_of is not None and request_func_input.best_of > 1:
             payload["best_of"] = request_func_input.best_of
         if request_func_input.ignore_eos:

--- a/benchmarks/backend_request_func.py
+++ b/benchmarks/backend_request_func.py
@@ -235,12 +235,15 @@ async def async_request_openai_completions(
             "model": request_func_input.model,
             "prompt": request_func_input.prompt,
             "temperature": 0.0,
-            "best_of": request_func_input.best_of,
             "max_tokens": request_func_input.output_len,
             "logprobs": request_func_input.logprobs,
             "stream": True,
-            "ignore_eos": request_func_input.ignore_eos,
         }
+        if request_func_input.best_of is not None and request_func_input.best_of > 1:
+            payload["best_of"] = request_func_input.best_of
+        if request_func_input.ignore_eos:
+            payload["ignore_eos"] = request_func_input.ignore_eos
+
         headers = {
             "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}"
         }


### PR DESCRIPTION
tt_worker throws an error if best_of parameter is set
The default value is 1, so ignore it in backend request
This will enable benchmark_serving script to be used with tt

the approach is aligned with the changes on the main branch (for ignore-eos).