### PR TITLE
Keep transformers below 4.52

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -4,7 +4,7 @@ numpy < 2.0.0
 requests >= 2.26.0
 tqdm
 py-cpuinfo
-transformers >= 4.45.2  # Required for Llama 3.2 and Qwen2-VL.
+transformers >= 4.45.2, < 4.52  # Required for Llama 3.2 and Qwen2-VL, yet keep CLIPSdpaAttention
 tokenizers >= 0.19.1  # Required for Llama 3.
 protobuf # Required by LlamaTokenizer.
 fastapi >= 0.107.0, < 0.113.0; python_version < '3.9'


### PR DESCRIPTION
In the latest transformers (4.52 from ~2h ago) CLIPSdpaAttention is removed from `modeling_clip.py`. This has been resolved on vLLM `main`, but for our branch we need to keep the transformers at this version.
