### PR TITLE
Data-parallel support

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -65,10 +65,11 @@ MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python exampl
 
 **Note 1**: Custom TT options can be set using `--override_tt_config` with a json string, e.g. `--override_tt_config '{"sample_on_device_mode": "all"}'`, however these shouldn't be used unless the model supports them (most currently do not). Supported parameters are:
 - `sample_on_device_mode`: ["all", "decode_only"]
-- `trace_region_size`" [default: 23887872]
+- `trace_region_size`: [default: 23887872]
 - `worker_l1_size`
 - `fabric_config`: ["DISABLED", "FABRIC_1D", "FABRIC_2D", "CUSTOM"]
 - `dispatch_core_axis`: ["row", "col"]
+- `data_parallel`: [default: 1]
 
 **Note 2 (Llama70B)**: To run Llama70B on Galaxy, set `MESH_DEVICE=TG` and do not set `WH_ARCH_YAML=...`.
 


### PR DESCRIPTION
We need to pass `tt_data_parallel` parameter to benchmark DP configurations.
https://github.com/tenstorrent/vllm/issues/92