### PR TITLE
Expose batching argument and fix output readout

### DIFF
--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -10,6 +10,7 @@ register_tt_models()  # Import and register models from tt-metal
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, default="meta-llama/Llama-3.1-70B-Instruct", help="Model name")
+    parser.add_argument("--max_num_seqs", type=int, default=32, help="Maximum number of sequences to be processed in a single iteration")
     args, unknown_args = parser.parse_known_args()
     
     check_tt_model_supported(args.model)
@@ -17,7 +18,7 @@ def main():
     sys.argv.extend([
         "--model", args.model,
         "--block_size", "64",
-        "--max_num_seqs", "32",
+        "--max_num_seqs", str(args.max_num_seqs),
         "--num_scheduler_steps", "10",
     ])
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -506,7 +506,7 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             if async_out_proc_per_trace:
                 # trigger output processor on host while device is executing next step
                 self._send_prev_step_async_out(model_input, step_idx)
-            tt_out = self.model.read_decode_output(tt_out, model_input.unpadded_batch_size, is_tokens=(self.sample_on_device_mode is not None))
+            tt_out = self.model.read_decode_output(tt_out, model_input.unpadded_batch_size, padded_batch=len(model_input.input_tokens), is_tokens=(self.sample_on_device_mode is not None))
 
         # Note: for other devices, vLLM applies vllm.model_executor.layers.logits_processor::LogitsProcessor::_apply_logits_processors on logits, we don't use this
         # Note: for other devices, vLLM applies vllm.model_executor.layers.sampler::Sampler for sampling tokens, we don't use this


### PR DESCRIPTION
- Adding support to pass batching argument to enable benchmarks for different data-parallel configurations.
- Fix for initial batch=1 run.
- Requires [this tt-metal PR](https://github.com/tenstorrent/tt-metal/pull/22789) to be merged