### PR TITLE
Update tt-metal+vLLM instructions to clarify tt-metal installation and where to find commits

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -1,23 +1,22 @@
 
 ## vLLM and tt-metal Branches
-Git-checkout the following branches in each repo separately:
-- vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev) (last verified commit: [f1cb301](https://github.com/tenstorrent/vllm/tree/f1cb30141b662650353d40a330366c50b83b5a98))
-- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal) (last verified commit: [v0.57.0-rc44](https://github.com/tenstorrent/tt-metal/tree/v0.57.0-rc44))
+For the latest versions of vLLM and tt-metal, git-checkout the following branches in each repo separately:
+- vLLM branch: [dev](https://github.com/tenstorrent/vllm/tree/dev) (do not commit to this branch)
+- tt-metal branch: [main](https://github.com/tenstorrent/tt-metal)
+
+>[!NOTE]
+> If testing a specific model, please refer to the [TT-Metal LLMs table](https://github.com/tenstorrent/tt-metal?tab=readme-ov-file#llms) for the appropriate commits to use for tt-metal and vLLM.
 
 ## Environment Creation
 
 **To create the vLLM+tt-metal environment (first time):**
-1. Set tt-metal environment variables (see INSTALLING.md in tt-metal repo)
+1. Install and build tt-metal following the instructions in [INSTALLING.md](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md). Ensure that the necessary environment variables for running tt-metal tests were set.
 2. From the main vLLM directory, run:
     ```sh
     export vllm_dir=$(pwd)
     source $vllm_dir/tt_metal/setup-metal.sh
     ```
-3. From the main tt-metal directory, build and create the environment as usual:
-    ```sh
-    ./build_metal.sh && ./create_venv.sh
-    source $PYTHON_ENV_DIR/bin/activate
-    ```
+3. (Optional step when installing tt-metal from source) In step 2, `PYTHON_ENV_DIR` is set to `${TT_METAL_HOME}/build/python_env_vllm`. Create the tt-metal virtual environment following the instructions in [INSTALLING.md#option-1-from-source](https://github.com/tenstorrent/tt-metal/blob/main/INSTALLING.md#option-1-from-source). Then, enter that virtual environment with `source $PYTHON_ENV_DIR/bin/activate`.
 4. Install vLLM:
     ```sh
     pip3 install --upgrade pip
@@ -53,12 +52,12 @@ To run Meta-Llama-3.1/3.2, it is required to have access to the model on Hugging
 
 ### Llama-3.1/3.2 (1B, 3B, 8B, 70B) and Qwen-2.5 (7B, 72B) Text Models
 
-To generate tokens (Llama70B) for sample prompts (with batch size 32):
+To generate tokens (Llama70B on QuietBox) for sample prompts (with batch size 32):
 ```sh
 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py
 ```
 
-To measure performance (Llama70B) for a single batch of 32 prompts (with the default prompt length of 128 tokens):
+To measure performance (Llama70B on QuietBox) for a single batch of 32 prompts (with the default prompt length of 128 tokens):
 ```sh
 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf
 ```
@@ -85,30 +84,26 @@ MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python exampl
 - Qwen-2.5-72B: `--model "Qwen/Qwen2.5-72B"` (currently only supported on T3K)
 - DeepSeek-R1-Distill-Llama-70B: `--model "deepseek-ai/DeepSeek-R1-Distill-Llama-70B"`
 
-Command line to run Llama70B on TG is:
+The command to run Llama70B on Galaxy is:
 ```sh
 MESH_DEVICE=TG LLAMA_DIR=<path to weights> TT_LLAMA_TEXT_VER="llama3_subdevices" python examples/offline_inference_tt.py --model "meta-llama/Llama-3.1-70B-Instruct" --override_tt_config '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D", "worker_l1_size": 1344544, "trace_region_size": 62000000}'
 ```
 
 ### Llama-3.2 (11B and 90B) Vision models
 
-To generate tokens for sample prompts:
+To generate tokens (Llama-3.2-11B on N300) for sample prompts:
 ```sh
 MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
 ```
 
-To measure performance for a single batch (with the default prompt length of 128 tokens):
+To measure performance (Llama-3.2-11B on N300) for a single batch (with the default prompt length of 128 tokens):
 ```sh
 MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --measure_perf --multi_modal --max_seqs_in_batch 16
 ```
 
-**Note**: To run on T3000, set `MESH_DEVICE=T3K` and `--max_seqs_in_batch 32`.
-
-**Note**: Running `90B` model, set `MESH_DEVICE=T3K` and `--max_seqs_in_batch 4`:
-
-```sh
-MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-90B-Vision-Instruct" --multi_modal --max_seqs_in_batch 4
-```
+> **Notes:**
+> - To run the 11B model on QuietBox, set `MESH_DEVICE=T3K` and `--max_seqs_in_batch 32`.
+> - To run the 90B model, set `MESH_DEVICE=T3K`, `--model "meta-llama/Llama-3.2-90B-Vision-Instruct"` and `--max_seqs_in_batch 4`.
 
 ## Running the server example
 
@@ -117,9 +112,9 @@ To start up the server:
 VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
 ```
 
-**Note**: By default, the server will run with Llama-3.1-70B-Instruct. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
-
-**Note**: Custom TT options can be set using `--override_tt_config` as described in [Running the offline inference example](#running-the-offline-inference-example).
+> **Notes:**
+> - By default, the server will run with Llama-3.1-70B-Instruct. To run with other models, set `MESH_DEVICE` and `--model` as described in [Running the offline inference example](#running-the-offline-inference-example).
+> - Custom TT options can be set using `--override_tt_config` as described in [Running the offline inference example](#running-the-offline-inference-example).
 
 To send a request to the server:
 ```sh


### PR DESCRIPTION
- Remove dev and tt-metal commits from readme and instead point to the LLM table for the commits for each model
- Update the environment creation steps to remove commands for building / creating tt-metal env and instead refer to tt-metal installing doc
- Organize detailed notes in other sections of the readme
