### PR TITLE
Readme update: Use PyTorch's cpu wheel

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -23,7 +23,7 @@ vLLM requires Python 3.9+ (Python 3.10.12 is the default `python3` on Ubuntu 22.
 4. Install vLLM:
     ```sh
     pip3 install --upgrade pip
-    cd $vllm_dir && pip install -e .
+    cd $vllm_dir && pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu
     ```
 
 **To activate the vLLM+tt-metal environment (after the first time):**


### PR DESCRIPTION
After PyTorch 2.2 they are not publishing cpu version to PyPI anymore.
We need to target the cpu wheel directly.