### PR TITLE
Fix pre-commit errors

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -171,7 +171,7 @@ def run_inference(
     check_tt_model_supported(model)
 
     if multi_modal:
-        assert "Llama-3.2" in model, "The multi-modal inference test" + \
+        assert "Llama-3.2" in model, "The multi-modal inference test " + \
             "currently only supports Llama-3.2 models"
 
     # LLM args

--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -24,15 +24,18 @@ from vllm.utils import merge_async_iterators
 def register_tt_models():
     llama_text_version = os.getenv("TT_LLAMA_TEXT_VER", "tt_transformers")
     if llama_text_version == "tt_transformers":
-        path_llama_text = "models.tt_transformers.tt.generator_vllm:LlamaForCausalLM"
+        path_llama_text = \
+            "models.tt_transformers.tt.generator_vllm:LlamaForCausalLM"
     elif llama_text_version == "llama3_subdevices":
-        path_llama_text = "models.demos.llama3_subdevices.tt.generator_vllm:LlamaForCausalLM"
+        path_llama_text = \
+            "models.demos.llama3_subdevices.tt.generator_vllm:LlamaForCausalLM"
     elif llama_text_version == "llama2_70b":
-        path_llama_text = "models.demos.t3000.llama2_70b.tt.generator_vllm:TtLlamaForCausalLM"
+        path_llama_text = \
+            "models.demos.t3000.llama2_70b.tt.generator_vllm:TtLlamaForCausalLM"
     else:
         raise ValueError(
-            f"Unsupported TT Llama version: {llama_text_version}, pick one of [tt_transformers, llama3_subdevices, llama2_70b]"
-        )
+            f"Unsupported TT Llama version: {llama_text_version}, "
+            "pick one of [tt_transformers, llama3_subdevices, llama2_70b]")
 
     # Llama3.1/3.2 - Text
     ModelRegistry.register_model("TTLlamaForCausalLM", path_llama_text)
@@ -118,7 +121,8 @@ def check_tt_model_supported(model):
 
 def run_seq_len_tests(engine_kw_args, sampling_params):
     '''
-    Test generation of a few simple counting prompts with arbitrary increasing sequence lengths
+    Test generation of a few simple counting prompts 
+    with arbitrary increasing sequence lengths
     '''
 
     model = engine_kw_args["model"]
@@ -131,8 +135,8 @@ def run_seq_len_tests(engine_kw_args, sampling_params):
 
     prompts = []
     for size in count_sizes:
-        prompt = "Continue this counting sequence (with no explanation): " + " ".join(
-            str(i) for i in range(1, size + 1))
+        prompt = "Continue this counting sequence (with no explanation): " + \
+            " ".join(str(i) for i in range(1, size + 1))
         if is_instruct:
             prompt = {"role": "user", "content": prompt}
             prompt = tokenizer.apply_chat_template([prompt],
@@ -155,7 +159,7 @@ def run_inference(
         num_repeat_prompts=2,
         measure_perf=False,
         perf_prompt_len=None,
-        greedy_sampling=False,  # Option to use greedy decoding instead of top-k/p
+        greedy_sampling=False,  # Use greedy decoding instead of top-k/p
         async_engine=False,
         num_scheduler_steps=10,
         disable_async_output_proc=False,
@@ -167,7 +171,8 @@ def run_inference(
     check_tt_model_supported(model)
 
     if multi_modal:
-        assert "Llama-3.2" in model, "The multi-modal inference test currently only supports Llama-3.2 models"
+        assert "Llama-3.2" in model, "The multi-modal inference test" + \
+            "currently only supports Llama-3.2 models"
 
     # LLM args
     engine_kw_args = {
@@ -186,8 +191,9 @@ def run_inference(
         if override_tt_config:
             engine_kw_args["override_tt_config"] = json.loads(
                 override_tt_config)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON string for override_tt_config: {e}")
+    except json.JSONDecodeError as err:
+        raise ValueError(
+            f"Invalid JSON string for override_tt_config: {err}") from err
 
     # Generation args
     ignore_eos = measure_perf
@@ -204,8 +210,10 @@ def run_inference(
                                          temperature=1.0)
 
     if test_increasing_seq_lens:
-        assert not measure_perf, "measure_perf option not supported with test_increasing_seq_lens"
-        assert not async_engine, "async_engine option not supported with test_increasing_seq_lens"
+        assert not measure_perf, (
+            "measure_perf option not supported with test_increasing_seq_lens")
+        assert not async_engine, (
+            "async_engine option not supported with test_increasing_seq_lens")
         print("Ignoring prompts json for sequence length testing")
         run_seq_len_tests(engine_kw_args, sampling_params)
         return
@@ -225,7 +233,8 @@ def run_inference(
             prompts = prompts * num_repeat_prompts
         print("Number of prompts:", len(prompts))
     else:
-        assert perf_prompt_len is not None, "perf_prompt_len is required to generate dummy prompts"
+        assert perf_prompt_len is not None, \
+            "perf_prompt_len is required to generate dummy prompts"
         print("Measuring performance with dummy prompts of length",
               perf_prompt_len)
         print("Generating prompts with output length", max_tokens)
@@ -291,8 +300,11 @@ def run_inference(
 
 def check_valid_perf_prompt_len(max_model_len, perf_prompt_len,
                                 sampling_params):
-    assert_str = f"prompt length ({perf_prompt_len}) + num generated tokens ({sampling_params.max_tokens}) will exceed max_model_len ({max_model_len})"
-    assert perf_prompt_len + sampling_params.max_tokens <= max_model_len, assert_str
+    assert_str = (f"prompt length ({perf_prompt_len}) + num generated tokens "
+                  f"({sampling_params.max_tokens}) will exceed max_model_len "
+                  f"({max_model_len})")
+    assert perf_prompt_len + sampling_params.max_tokens <= max_model_len, (
+        assert_str)
 
 
 def run_inference_perf(
@@ -333,7 +345,8 @@ def generate_tokens(llm: LLM,
                     sampling_params,
                     prompt_token_ids=None,
                     print_output=True):
-    # Generate texts from the prompts. The output is a list of RequestOutput objects
+    # Generate texts from the prompts.
+    # The output is a list of RequestOutput objects
     # that contain the prompt, generated text, and other information.
     outputs = llm.generate(prompts, sampling_params, prompt_token_ids)
     # Print the outputs.
@@ -344,9 +357,10 @@ def generate_tokens(llm: LLM,
         num_tokens_prompt = len(output.prompt_token_ids)
         num_tokens_output = len(output.outputs[0].token_ids)
         if print_output:
-            print(
-                f"Prompt #{request_id} ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n"
-            )
+            print(f"Prompt #{request_id} "
+                  f"({num_tokens_prompt} tokens): {prompt!r}, "
+                  "Generated text "
+                  f"({num_tokens_output} tokens): {generated_text!r}\n")
 
 
 async def generate_tokens_async(llm: MQLLMEngineClient,
@@ -375,9 +389,10 @@ async def generate_tokens_async(llm: MQLLMEngineClient,
         num_tokens_prompt = len(res.prompt_token_ids)
         num_tokens_output = len(res.outputs[0].token_ids)
         if print_output and res.finished:
-            print(
-                f"Prompt ({num_tokens_prompt} tokens): {prompt!r}, Generated text ({num_tokens_output} tokens): {generated_text!r}\n"
-            )
+            print(f"Prompt "
+                  f"({num_tokens_prompt} tokens): {prompt!r}, "
+                  "Generated text "
+                  f"({num_tokens_output} tokens): {generated_text!r}\n")
 
 
 if __name__ == "__main__":

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -213,8 +213,7 @@ class LLMEngine:
         vllm_config: VllmConfig,
         executor_class: Type[ExecutorBase],
         log_stats: bool,
-        log_global_stats:
-        bool = False,  # if True and log_stats is True, log with GlobalStatLogger as well
+        log_global_stats: bool = False,
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: Optional[Dict[str, StatLoggerBase]] = None,
         input_registry: InputRegistry = INPUT_REGISTRY,
@@ -1171,7 +1170,8 @@ class LLMEngine:
             seq_group = scheduled_seq_group.seq_group
             seq_group.maybe_set_first_token_time(now)
             if not seq_group.is_prefill() and is_last_step:
-                # set time after all steps since _get_stats sets actual_num_batched_tokens based on num steps
+                # set time after all steps since _get_stats sets
+                # actual_num_batched_tokens based on num steps
                 seq_group.set_last_token_time(now)
             request_output = RequestOutputFactory.create(
                 seq_group,
@@ -1198,12 +1198,12 @@ class LLMEngine:
                 scheduler.free_finished_seq_groups()
 
         # Log and reset global stats if there are no unfinished requests left
-        if not self.has_unfinished_requests():
-            if self.log_stats and 'global' in self.stat_loggers:
-                global_stat_logger = cast(GlobalStatLogger,
-                                          self.stat_loggers['global'])
-                global_stat_logger.log_out()
-                global_stat_logger.reset()
+        if (not self.has_unfinished_requests() and self.log_stats
+                and 'global' in self.stat_loggers):
+            global_stat_logger = cast(GlobalStatLogger,
+                                      self.stat_loggers['global'])
+            global_stat_logger.log_out()
+            global_stat_logger.reset()
 
         # For multi-step without streaming, don't create outputs each iteration
         if not is_last_step and not ctx.multi_step_stream_outputs:
@@ -1224,7 +1224,8 @@ class LLMEngine:
             seq_group = scheduled_seq_group.seq_group
             seq_group.maybe_set_first_token_time(now)
             if not seq_group.is_prefill() and is_last_step:
-                # set time after all steps since _get_stats sets actual_num_batched_tokens based on num steps
+                # set time after all steps since _get_stats sets
+                # actual_num_batched_tokens based on num steps
                 seq_group.set_last_token_time(now)
             request_output = RequestOutputFactory.create(
                 seq_group,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -213,7 +213,8 @@ class LLMEngine:
         vllm_config: VllmConfig,
         executor_class: Type[ExecutorBase],
         log_stats: bool,
-        log_global_stats: bool = False,
+        log_global_stats: bool = False,  # if True and log_stats is True, 
+        # log with GlobalStatLogger as well
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: Optional[Dict[str, StatLoggerBase]] = None,
         input_registry: InputRegistry = INPUT_REGISTRY,

--- a/vllm/engine/metrics.py
+++ b/vllm/engine/metrics.py
@@ -460,7 +460,8 @@ class AvgTracker:
 
 
 class GlobalStatLogger(StatLoggerBase):
-    """GlobalStatLogger is used in LLMEngine to track stats across the entire generation (until manually reset)"""
+    """GlobalStatLogger is used in LLMEngine to track stats across the entire 
+    generation (until manually reset)"""
 
     def __init__(self) -> None:
         self.time_to_first_token = AvgTracker()
@@ -483,11 +484,11 @@ class GlobalStatLogger(StatLoggerBase):
         ttft = self.time_to_first_token
         tpot = self.time_per_output_token
         if ttft.count != 0:
-            logger.info(f"Average time to first token (batch): {ttft.avg} s")
+            logger.info("Average time to first token (batch): %f s", ttft.avg)
         if tpot.count != 0:
             decode_throughput = 1 / tpot.avg if tpot.avg != 0 else 0
-            logger.info(
-                f"Average decode throughput: {decode_throughput} t/s/u")
+            logger.info("Average decode throughput: %f t/s/u",
+                        decode_throughput)
 
     def reset(self) -> None:
         self.time_to_first_token = AvgTracker()

--- a/vllm/executor/ray_distributed_executor.py
+++ b/vllm/executor/ray_distributed_executor.py
@@ -528,7 +528,7 @@ class RayDistributedExecutor(DistributedExecutorBase):
         ray.get(parallel_worker_tasks)
 
     def _check_ray_cgraph_installation(self):
-        import pkg_resources
+        import pkg_resources  # type: ignore
         from packaging import version
 
         required_version = version.parse("2.43.0")

--- a/vllm/model_executor/model_loader/tt_loader.py
+++ b/vllm/model_executor/model_loader/tt_loader.py
@@ -19,7 +19,8 @@ class TTModelLoader(BaseModelLoader):
                    cache_config: CacheConfig) -> nn.Module:
         """Load a model with the given configurations."""
 
-        # For TT models, prepend "TT" to the architecture name, e.g. "TTLlamaForCausalLM"
+        # For TT models, prepend "TT" to the architecture name,
+        # e.g. "TTLlamaForCausalLM"
         arch_names = model_config.hf_config.architectures
         assert len(model_config.hf_config.architectures) == 1
         arch_names[0] = "TT" + arch_names[0]
@@ -27,9 +28,10 @@ class TTModelLoader(BaseModelLoader):
         model_class, _ = get_model_architecture(model_config)
 
         data_parallel = 1
-        if model_config.override_tt_config and 'data_parallel' in model_config.override_tt_config:
+        if (model_config.override_tt_config
+                and 'data_parallel' in model_config.override_tt_config):
             data_parallel = model_config.override_tt_config['data_parallel']
-            logger.info(f"Overriding data_parallel to {data_parallel}")
+            logger.info("Overriding data_parallel to %d", data_parallel)
 
         model = model_class.initialize_vllm_model(
             model_config.hf_config,

--- a/vllm/model_executor/model_loader/tt_loader.py
+++ b/vllm/model_executor/model_loader/tt_loader.py
@@ -1,8 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from torch import nn
 
-from vllm.config import (CacheConfig, DeviceConfig, ModelConfig,
-                         ParallelConfig, SchedulerConfig)
+from vllm.config import ModelConfig, VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.loader import BaseModelLoader
 from vllm.model_executor.model_loader.utils import get_model_architecture
@@ -12,15 +11,15 @@ logger = init_logger(__name__)
 
 class TTModelLoader(BaseModelLoader):
 
-    def load_model(self, *, model_config: ModelConfig,
-                   device_config: DeviceConfig,
-                   parallel_config: ParallelConfig,
-                   scheduler_config: SchedulerConfig,
-                   cache_config: CacheConfig) -> nn.Module:
+    def load_model(self, *, vllm_config: VllmConfig) -> nn.Module:
         """Load a model with the given configurations."""
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
+        model_config = vllm_config.model_config
+        device_config = vllm_config.device_config
+        scheduler_config = vllm_config.scheduler_config
+
         arch_names = model_config.hf_config.architectures
         assert len(model_config.hf_config.architectures) == 1
         arch_names[0] = "TT" + arch_names[0]

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -193,7 +193,8 @@ def neuron_platform_plugin() -> Optional[str]:
 def tt_platform_plugin() -> Optional[str]:
     is_tt = False
     try:
-        import ttnn  # assume ttnn is installed if and only if machine has TT devices
+        # assume ttnn is installed if and only if machine has TT devices
+        import ttnn  # noqa: F401
         is_tt = True
     except Exception:
         pass

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -35,9 +35,11 @@ class TTPlatform(Platform):
             "Chunked prefill is not yet supported for TT backend")
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend")
-        assert vllm_config.parallel_config.tensor_parallel_size == vllm_config.parallel_config.pipeline_parallel_size == 1, (
-            "TT backend does not support distributed execution")
-        assert not vllm_config.lora_config, "LoRA is not supported for TT backend"
+        assert (vllm_config.parallel_config.tensor_parallel_size == 1
+                and vllm_config.parallel_config.pipeline_parallel_size
+                == 1), "TT backend does not support distributed execution"
+        assert not vllm_config.lora_config, (
+            "LoRA is not supported for TT backend")
 
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
@@ -64,9 +66,9 @@ class TTPlatform(Platform):
                     f"Currently not supporting logprobs on {cls.device_name}")
             if params.prompt_logprobs is not None:
                 raise ValueError(
-                    f"Currently not supporting prompt_logprobs on {cls.device_name}"
-                )
+                    f"Currently not supporting prompt_logprobs on "
+                    f"{cls.device_name}")
             if params.guided_decoding is not None:
                 raise ValueError(
-                    f"Currently not supporting guided decoding on {cls.device_name}"
-                )
+                    f"Currently not supporting guided decoding on "
+                    f"{cls.device_name}")

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -81,7 +81,8 @@ def top_pk_logits_efficient(logits,
                             k=10,
                             temperature=1.0,
                             return_probs=False):
-    # do not keep the entire vocab size after top k. Instead, keep the k size tensor and record the associated indices
+    # Do not keep the entire vocab size after top k.
+    # Instead, keep the k size tensor and record the associated indices.
     if k == -1:  # no top-k sampling
         top_k_values, top_k_indices = logits, torch.arange(
             logits.shape[-1]).unsqueeze(0).repeat(logits.shape[0], 1)
@@ -113,9 +114,11 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
 
         self.block_size = self.cache_config.block_size
 
-        self.trace_mode = trace_mode  # whether to use ttnn tracing for model execution
+        # whether to use ttnn tracing for model execution
+        self.trace_mode = trace_mode
         override_tt_config = self.model_config.override_tt_config
-        if override_tt_config is not None and "sample_on_device_mode" in override_tt_config:
+        if (override_tt_config is not None
+                and "sample_on_device_mode" in override_tt_config):
             self.sample_on_device_mode = override_tt_config[
                 "sample_on_device_mode"]
             assert self.sample_on_device_mode in [
@@ -124,7 +127,9 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         else:
             self.sample_on_device_mode = None  # whether to sample on device
         logger.info(
-            f"TTModelRunner: trace_mode={self.trace_mode}, sample_on_device_mode={self.sample_on_device_mode}"
+            "TTModelRunner: trace_mode=%s, sample_on_device_mode=%s",
+            self.trace_mode,
+            self.sample_on_device_mode,
         )
 
         self.cached_step_outputs: List[torch.Tensor] = [
@@ -137,27 +142,36 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         # Detect if the model has "mrope" rope_scaling type.
         # mrope requires keep "rope_deltas" between prompt and decoding phases.
         if self.model_config.uses_mrope:
-            assert "TTModelRunner does not currently support models with mrope rope_scaling"
+            assert ("TTModelRunner does not currently support models with "
+                    "mrope rope_scaling")
 
     def load_model(self) -> None:
-        # Note: using custom TT loader instead of selecting from default vllm loaders
+        # Note: using custom TT loader
+        # instead of selecting from default vllm loaders
         loader = TTModelLoader(self.load_config)
-        self.model = loader.load_model(model_config=self.model_config,
-                                       device_config=self.device_config,
-                                       parallel_config=self.parallel_config,
-                                       scheduler_config=self.scheduler_config,
-                                       cache_config=self.cache_config)
+        self.model = loader.load_model(
+            model_config=self.model_config,
+            device_config=self.device_config,
+            parallel_config=self.parallel_config,
+            scheduler_config=self.scheduler_config,
+            cache_config=self.cache_config,
+        )
         if self.model_config.is_encoder_decoder:
-            self.max_cross_blocks = self.model.max_cross_attn_tokens // self.cache_config.block_size
+            self.max_cross_blocks = (self.model.max_cross_attn_tokens //
+                                     self.cache_config.block_size)
 
         # Detect if the model is a TG Llama to use DP KV cache
-        # vLLM doesn't know which blocks correspond to which DP device pool so may allocate non-local blocks to a user
-        # To avoid bad output because of this, we maintain a seq_id_to_batch_slot mapping so that we can place the users on the correct devices
-        # This requires passing seq_id and finished requests to the generator
+        # vLLM doesn't know which blocks correspond to which DP device pool so
+        # may allocate non-local blocks to a user. To avoid bad output because
+        # of this, we maintain a seq_id_to_batch_slot mapping so that we can
+        # place the users on the correct devices. This requires passing seq_id
+        # and finished requests to the generator.
         # TODO: Extend this to support other DP models
-        if "Llama" in self.model_config.model and "70B" in self.model_config.model and self.device_config.device.get_num_devices(
-        ) == 32 and (self.model_config.override_tt_config.get(
-                "data_parallel", 1) == 1):
+        if ("Llama" in self.model_config.model
+                and "70B" in self.model_config.model
+                and self.device_config.device.get_num_devices() == 32
+                and (self.model_config.override_tt_config.get(
+                    "data_parallel", 1) == 1)):
             self.dp_kv_cache = True
         else:
             self.dp_kv_cache = False
@@ -236,17 +250,22 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             block_tables.append(block_table)
 
             # Multi-modal data
-            # TODO: Replace with multi_modal_input_mapper (used by CPU/GPU model runners) once TT models no longer require raw PIL images
+            # TODO: Replace with multi_modal_input_mapper
+            # (used by CPU/GPU model runners) once TT models
+            # no longer require raw PIL images
             if supports_multimodal(self.model) and is_prompt:
                 if (multi_modal_data := seq_group_metadata.multi_modal_data):
-                    assert "image" in multi_modal_data, "Currently only supporting image multi-modal inputs"
+                    assert "image" in multi_modal_data, (
+                        "Currently only supporting image multi-modal inputs")
                     image = multi_modal_data[
                         "image"]  # this is of type PIL.Image.Image
                     multi_modal_kwargs["images"].append(image)
                 else:
                     multi_modal_kwargs["images"].append(None)
 
-            # Encoder-decoder data (currently only supporting cross attention metadata and not additional encoder data)
+            # Encoder-decoder data
+            # (currently only supporting cross attention metadata
+            # and not additional encoder data)
             if self.model_config.is_encoder_decoder:
                 cross_block_table = seq_group_metadata.cross_block_table
                 cross_block_tables.append(cross_block_table)
@@ -260,27 +279,36 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                 top_pk_sampling_params["top_k"] = sampling_params.top_k
                 top_pk_sampling_params["top_p"] = sampling_params.top_p
             else:
-                if top_pk_sampling_params[
-                        "temperature"] != sampling_params.temperature:
+                if (top_pk_sampling_params["temperature"]
+                        != sampling_params.temperature):
                     logger.warning(
-                        f"Currently only supporting same temperature for all sequences in batch, falling back to first sequence's temperature ({top_pk_sampling_params['temperature']})"
-                    )
+                        "Currently only supporting same temperature for all "
+                        "sequences in batch, falling back to first sequence's "
+                        "temperature (%s)",
+                        top_pk_sampling_params['temperature'])
                 if top_pk_sampling_params["top_k"] != sampling_params.top_k:
                     logger.warning(
-                        f"Currently only supporting same top_k for all sequences in batch, falling back to first sequence's top_k ({top_pk_sampling_params['top_k']})"
-                    )
+                        "Currently only supporting same top_k"
+                        "for all sequences in batch, "
+                        "falling back to first sequence's top_k (%s)",
+                        top_pk_sampling_params['top_k'])
                 if top_pk_sampling_params["top_p"] != sampling_params.top_p:
                     logger.warning(
-                        f"Currently only supporting same top_p for all sequences in batch, falling back to first sequence's top_p ({top_pk_sampling_params['top_p']})"
-                    )
+                        "Currently only supporting same top_p"
+                        "for all sequences in batch, "
+                        "falling back to first sequence's top_p (%s)",
+                        top_pk_sampling_params['top_p'])
 
         tt_sampling_params = TTSamplingParams(
             temperature=top_pk_sampling_params["temperature"],
             top_k=top_pk_sampling_params["top_k"],
             top_p=top_pk_sampling_params["top_p"])
 
-        # Remove cached encoder-decoder data for any seq ids that are not in the current batch (assume they were either finished or preempted)
-        if self.model_config.is_encoder_decoder and not is_prompt and self.cached_enc_dec_data:
+        # Remove cached encoder-decoder data
+        # for any seq ids that are not in the current batch
+        # (assume they were either finished or preempted)
+        if (self.model_config.is_encoder_decoder and not is_prompt
+                and self.cached_enc_dec_data):
             seq_ids_to_del = []
             for seq_id in self.cached_enc_dec_data:
                 if seq_id not in seq_groups:
@@ -322,8 +350,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             # TODO: Remove once TT models can support arbitrary batch sizes
             # Pad batch to max_num_seqs
             if input_tokens.shape[0] < self.scheduler_config.max_num_seqs:
-                batch_pad_len = self.scheduler_config.max_num_seqs - input_tokens.shape[
-                    0]
+                batch_pad_len = self.scheduler_config.max_num_seqs - \
+                    input_tokens.shape[0]
                 input_tokens = torch.cat([
                     input_tokens,
                     torch.zeros(batch_pad_len,
@@ -352,7 +380,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                                     device="cpu")
                     ])
 
-            # Pad block_tables to max num blocks so ttnn tracing can work (requires constant shape)
+            # Pad block_tables to max num blocks
+            # so ttnn tracing can work (requires constant shape)
             if self.trace_mode:
                 block_tables = torch.cat([
                     block_tables,
@@ -364,7 +393,9 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                 ],
                                          dim=1)
                 if self.model_config.is_encoder_decoder:
-                    # Note for vision models: the number of cross blocks may change if the number of image tiles changes or if prompts are text-only
+                    # Note for vision models: the number of cross blocks
+                    # may change if the number of image tiles changes
+                    # or if prompts are text-only
                     cross_block_tables = torch.cat([
                         cross_block_tables,
                         torch.zeros(cross_block_tables.shape[0],
@@ -403,17 +434,23 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
     ) -> Optional[List[SamplerOutput]]:
         is_decode = model_input.prompt_lens is None
 
-        # Note on async_out_proc + multi-step: for gpu/tpu, the N steps are enqueued on device and the last step
-        # will trigger the output processor for all outputs but the last. Currently for TT, the inputs/outputs of each step
-        # are transferred between host/device, so async_out_proc does not help unless using async_out_proc_per_trace
-        # which triggers the output processor for step (i) on host while device is executing step (i+1).
+        # Note on async_out_proc + multi-step: for gpu/tpu, the N steps are
+        # enqueued on device and the last step will trigger the output
+        # processor for all outputs but the last. Currently for TT,
+        # the inputs/outputs of each step are transferred between host/device,
+        # so async_out_proc does not help unless using async_out_proc_per_trace
+        # which triggers the output processor for step (i) on host while device
+        # is executing step (i+1).
         use_async_out_proc = model_input.async_callback is not None
-        async_out_proc_per_trace = self.trace_mode and self.scheduler_config.is_multi_step and use_async_out_proc
+        async_out_proc_per_trace = (self.trace_mode
+                                    and self.scheduler_config.is_multi_step
+                                    and use_async_out_proc)
 
         if not is_decode:
             assert num_steps == 1, "Num steps must be 1 for prefill"
 
-        if model_input.is_first_multi_step:  # always true if not using multi-step
+        # always true if not using multi-step
+        if model_input.is_first_multi_step:
             self.cached_step_outputs = []
             for i in range(num_steps):
                 next_token_ids = self._execute_model_single_step(
@@ -440,7 +477,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                                         device="cpu")
                         ])
 
-                    # Update input positions for all except those that are -1 (padding)
+                    # Update input positions for all
+                    # except those that are -1 (padding)
                     new_input_positions = torch.where(
                         model_input.input_positions == -1,
                         model_input.input_positions,
@@ -461,7 +499,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                 assert num_outputs == 1, "Last step should only have one output"
             for i in range(num_outputs):
                 next_token_ids = self.cached_step_outputs.pop(0)
-                # TODO: add read back from device once model can keep executing steps on device
+                # TODO: add read back from device
+                # once model can keep executing steps on device
                 sampler_output = self._make_sampler_output(
                     next_token_ids, model_input.seq_groups)
                 sampler_outputs.append(sampler_output)
@@ -492,8 +531,10 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         next_token_ids: List[int],
         seq_groups: List[int],
     ) -> SamplerOutput:
-        # Minimal code to construct the sampler outputs, based on tpu_model_runner.py
-        # TT backend does not support the advanced sampling parameters such as logprobs.
+        # Minimal code to construct the sampler outputs,
+        # based on tpu_model_runner.py
+        # TT backend does not support the advanced sampling parameters
+        # such as logprobs.
         zero_logprob = Logprob(0.0)
         sampler_outputs = []
         for batch_idx, seq_id in enumerate(seq_groups):
@@ -541,16 +582,18 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
 
         if self.dp_kv_cache:
             # Send finished request ids and seq groups to generator
-            execute_model_kwargs[
-                "finished_requests_ids"] = model_input.finished_requests_seq_ids
+            execute_model_kwargs["finished_requests_ids"] = (
+                model_input.finished_requests_seq_ids)
             execute_model_kwargs["seq_groups"] = model_input.seq_groups
 
         if not is_decode:
             outputs = self.model.prefill_forward(**execute_model_kwargs)
 
             if self.model_config.is_encoder_decoder:
-                # Save encoder-decoder data for use in subsequent decode steps (may need to be updated for future models)
-                tt_out, cross_attention_masks, full_text_row_masked_out_mask = outputs
+                # Save encoder-decoder data for use in subsequent decode steps
+                # (may need to be updated for future models)
+                tt_out, cross_attention_masks, \
+                full_text_row_masked_out_mask = outputs
                 if self.cached_enc_dec_data is None:
                     self.cached_enc_dec_data = {}
                 for i, seq_id in enumerate(model_input.seq_groups):
@@ -588,15 +631,21 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                                                enable_trace=self.trace_mode,
                                                read_from_device=False)
             if async_out_proc_per_trace:
-                # trigger output processor on host while device is executing next step
+                # trigger output processor on host while device is executing
+                # next step
                 self._send_prev_step_async_out(model_input, step_idx)
             tt_out = self.model.read_decode_output(
                 tt_out,
                 model_input.unpadded_batch_size,
                 is_tokens=(self.sample_on_device_mode is not None))
 
-        # Note: for other devices, vLLM applies vllm.model_executor.layers.logits_processor::LogitsProcessor::_apply_logits_processors on logits, we don't use this
-        # Note: for other devices, vLLM applies vllm.model_executor.layers.sampler::Sampler for sampling tokens, we don't use this
+        # Note: for other devices, vLLM applies
+        # vllm.model_executor.layers.logits_processor::LogitsProcessor::
+        # _apply_logits_processors
+        # on logits, we don't use this
+        # Note: for other devices, vLLM applies
+        # vllm.model_executor.layers.sampler::Sampler for sampling tokens,
+        # we don't use this
         if not self.sample_on_device_mode or (
                 self.sample_on_device_mode == "decode_only" and not is_decode):
             next_logits = tt_out[:model_input.unpadded_batch_size,

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -149,13 +149,16 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         # Note: using custom TT loader
         # instead of selecting from default vllm loaders
         loader = TTModelLoader(self.load_config)
-        self.model = loader.load_model(
+
+        vllm_config = VllmConfig(
             model_config=self.model_config,
             device_config=self.device_config,
             parallel_config=self.parallel_config,
             scheduler_config=self.scheduler_config,
             cache_config=self.cache_config,
         )
+
+        self.model = loader.load_model(vllm_config=vllm_config)
         if self.model_config.is_encoder_decoder:
             self.max_cross_blocks = (self.model.max_cross_attn_tokens //
                                      self.cache_config.block_size)

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -460,9 +460,11 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             "T3K": (1, 8),
             "TG": (8, 4)
         }
-        env = os.environ.get("MESH_DEVICE", "")
-        assert env in mesh_grid_dict, f"Invalid MESH_DEVICE: {env}"
-        mesh_grid = mesh_grid_dict.get(env, (1, num_devices_available))
+        mesh_device_env = os.environ.get("MESH_DEVICE", "")
+        assert mesh_device_env in mesh_grid_dict, (
+            f"Invalid MESH_DEVICE: {mesh_device_env}")
+        mesh_grid = mesh_grid_dict.get(mesh_device_env,
+                                       (1, num_devices_available))
 
         if mesh_grid[0] * mesh_grid[1] > num_devices_available:
             assert (f"Requested mesh grid shape {mesh_grid} is larger than "

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -420,16 +420,18 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
     # Must be called before creating the mesh device
     def _set_fabric(self):
         fabric_config = self._get_fabric_config()
-        if fabric_config:        
+        if fabric_config:
             ttnn.set_fabric_config(fabric_config)
 
     # From tt-metal/conftest.py:
     # Reset fabric config to DISABLED if not None, and do nothing otherwise
-    # Temporarily require previous state to be passed in as even setting it to DISABLED might be unstable
-    # This is to ensure that we don't propagate the instability to the rest of CI
+    # Temporarily require previous state to be passed
+    # in as even setting it to DISABLED might be unstable
+    # This is to ensure that we don't propagate
+    # the instability to the rest of CI
     def _reset_fabric(self):
         fabric_config = self._get_fabric_config()
-        if fabric_config:        
+        if fabric_config:
             ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
     def _device_params_from_override_tt_config(self):


### PR DESCRIPTION
Continue fixing pre-commit. Some of the errors were
- Long lines
- Using f-strings with logger
- mypy error for pkg_resources, ignored since it's no longer in vllm/main
- incorrect signatures for abstract method in subclasses
- dead code with missing arguments
- incorrect types

I aimed to do the simplest thing to solve the errors to enable pre-commit, I would leave further refactoring for another time.
To test the changes I ran locally `server_example_tt.py` with `benchmark_serving.py` for llama8b data-parallel configurations.

- [x] [vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/15675766030)