### PR TITLE
Update default device trace region size to match TT-Transformers and support BH-QB-Llama70B

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -74,7 +74,7 @@ MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python exampl
 
 **Note 1**: Custom TT options can be set using `--override_tt_config` with a json string, e.g. `--override_tt_config '{"sample_on_device_mode": "all"}'`, however these shouldn't be used unless the model supports them (most currently do not). Supported parameters are:
 - `sample_on_device_mode`: ["all", "decode_only"]
-- `trace_region_size`: [default: 23887872]
+- `trace_region_size`: [default: 25000000]
 - `worker_l1_size`
 - `fabric_config`: ["DISABLED", "FABRIC_1D", "FABRIC_2D", "CUSTOM"]
 - `dispatch_core_axis`: ["row", "col"]

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -418,7 +418,7 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
         if self.trace_mode:
             # Set the most common value as default, override later
-            device_params["trace_region_size"] = 23887872
+            device_params["trace_region_size"] = 25000000
             if override_tt_config and "trace_region_size" in override_tt_config:
                 device_params["trace_region_size"] = override_tt_config[
                     "trace_region_size"]


### PR DESCRIPTION
- Update default device trace region size (increase by ~1MB) to match new default for TT-Transformers from https://github.com/tenstorrent/tt-metal/pull/23153.