### PR TITLE
Fix default mesh device selection after recent commit modified it

### DIFF
--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -465,11 +465,13 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             "T3K": (1, 8),
             "TG": (8, 4)
         }
-        mesh_device_env = os.environ.get("MESH_DEVICE", "")
-        assert mesh_device_env in mesh_grid_dict, (
-            f"Invalid MESH_DEVICE: {mesh_device_env}")
-        mesh_grid = mesh_grid_dict.get(mesh_device_env,
-                                       (1, num_devices_available))
+        mesh_device_env = os.environ.get("MESH_DEVICE")
+        if mesh_device_env is not None:
+            assert mesh_device_env in mesh_grid_dict, (
+                f"Invalid MESH_DEVICE: {mesh_device_env}")
+            mesh_grid = mesh_grid_dict[mesh_device_env]
+        else:
+            mesh_grid = (1, num_devices_available)
 
         if mesh_grid[0] * mesh_grid[1] > num_devices_available:
             assert (f"Requested mesh grid shape {mesh_grid} is larger than "


### PR DESCRIPTION
- Fixed default mesh device selection after it broke in 11f4a99 (was asserting that "" is not a valid key for `mesh_grid_dict`).