### PR TITLE
Modify pre-commit to enforce line length for only yapf and not ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,6 @@ ignore_patterns = [
 ]
 
 [tool.ruff]
-# Allow lines to be as long as 80.
-line-length = 80
 exclude = [
     # External file, leaving license intact
     "examples/other/fp8/quantizer/quantize.py"
@@ -115,6 +113,8 @@ ignore = [
     "UP032",
     # Can remove once 3.10+ is the minimum Python version
     "UP007",
+    # Avoid double-enforcing line length, let yapf handle it
+    "E501",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
- Currently both yapf and ruff are enforcing line length during pre-commit, resulting in double enforcing / conflicts for line length checks and manual work for devs when ruff doesn't automatically fix issues.
- Modifying pre-commit to ignore the line length check for ruff and let yapf handle it, so that manual work for devs is reduced. 
- Note: the default line length for yapf is 79, and previously ruff was using 80, so there should be minimal or no changes needed for the existing vLLM code.