### PR TITLE
Add `max_seq_len` as parameter

### DIFF
--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -206,7 +206,7 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             max_tokens_all_users = 65536  # [INFO] avoid OOM for Llama-3.2-90B
         else:
             # Note: includes num vision tokens for multi-modal
-            max_tokens_all_users = self.model_config.max_model_len
+            max_tokens_all_users = 131072
 
         # To fit a max batch with (max_tokens_all_users / max batch) per user,
         # allocate an extra block_size per user since vLLM uses a worst-case


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/24282

We want to run different data-parallel configurations which in turn create different tensor-parallel instances that can have different `max_seq_len`.

- [x] [vllm nightly](https://github.com/tenstorrent/tt-metal/actions/runs/16813102183)
- [ ] [shield llama8b dp=4](https://github.com/tenstorrent/tt-shield/actions/runs/16813121134)