### PR TITLE
Enable vllm support for Deepseek-R1-Distill-Qwen-14B

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -114,6 +114,7 @@ def check_tt_model_supported(model):
         "Qwen/Qwen3-14B",
         "Qwen/Qwen3-32B",
         "deepseek-ai/DeepSeek-R1-Distill-Llama-70B",
+        "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
         "mistralai/Mistral-7B-Instruct-v0.3",
     ]
     assert model in supported_models, f"Invalid model: {model}"


### PR DESCRIPTION
## Essential Elements of an Effective PR Description Checklist
- [ ] The purpose of the PR is to enable vllm support for Deepseek-R1-Distill-Qwen-14B

**Test ran:**
MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B"

Device used: Loudbox

