### PR TITLE
Add Llama-3.2-11B-Vision to the list of supported models.

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -99,6 +99,7 @@ def check_tt_model_supported(model):
         "meta-llama/Llama-3.2-1B-Instruct",
         "meta-llama/Llama-3.2-3B",
         "meta-llama/Llama-3.2-3B-Instruct",
+        "meta-llama/Llama-3.2-11B-Vision",
         "meta-llama/Llama-3.2-11B-Vision-Instruct",
         "meta-llama/Llama-3.2-90B-Vision-Instruct",
         "meta-llama/Llama-3.3-70B",


### PR DESCRIPTION
@skhorasganiTT Please take a look.

`tt-metal` already lists `meta-llama/Llama-3.2-11B-Vision` in the list of supported models.
https://github.com/tenstorrent/tt-metal/blob/249582925cbe8a97f766bbfbcda42bf0ecf126f4/models/tt_transformers/README.md?plain=1#L13C1-L14C1