### PR TITLE
Fixed Mistral7B config.head_dim == None

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -965,7 +965,8 @@ class ModelConfig:
         if self.is_attention_free:
             return 0
 
-        if hasattr(self.hf_text_config, "head_dim") and (self.hf_text_config.head_dim is not None):
+        # NOTE: Some configs may set head_dim=None in the config
+        if getattr(self.hf_text_config, "head_dim", None) is not None:
             return self.hf_text_config.head_dim
         # FIXME(woosuk): This may not be true for all models.
         return (self.hf_text_config.hidden_size //

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -965,7 +965,7 @@ class ModelConfig:
         if self.is_attention_free:
             return 0
 
-        if hasattr(self.hf_text_config, "head_dim"):
+        if hasattr(self.hf_text_config, "head_dim") and (self.hf_text_config.head_dim is not None):
             return self.hf_text_config.head_dim
         # FIXME(woosuk): This may not be true for all models.
         return (self.hf_text_config.hidden_size //


### PR DESCRIPTION
[25437](https://github.com/tenstorrent/tt-metal/issues/25437)
After updating transformers to 4.53.0, mistral config sets some of the variables to None and this causes issue while running.