### PR TITLE
Add Qwen2.5-14B to list of supported models, fix num available blocks for Qwen2.5-14B based models

### DIFF
--- a/examples/offline_inference_tt.py
+++ b/examples/offline_inference_tt.py
@@ -163,6 +163,8 @@ def check_tt_model_supported(model):
         "meta-llama/Llama-3.3-70B-Instruct",
         "Qwen/Qwen2.5-7B",
         "Qwen/Qwen2.5-7B-Instruct",
+        "Qwen/Qwen2.5-14B",
+        "Qwen/Qwen2.5-14B-Instruct",
         "Qwen/Qwen2.5-32B",
         "Qwen/Qwen2.5-32B-Instruct",
         "Qwen/Qwen2.5-Coder-32B",

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -208,13 +208,18 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
         if (("Llama-3.1-8B" in self.model_config.model
              or "Mistral-7B" in self.model_config.model)
-                and num_devices_per_model == 1
-                and is_wormhole):  # Llama8B on N150 and Mistral7B on N150
+                and num_devices_per_model == 1 and is_wormhole):
+            # Llama8B on N150 and Mistral7B on N150
+            max_tokens_all_users = 65536
+        elif (("DeepSeek-R1-Distill-Qwen-14B" in self.model_config.model
+               or "Qwen2.5-14B" in self.model_config.model)
+              and num_devices_per_model == 2 and is_wormhole):
+            # Qwen2.5-14B on N300
             max_tokens_all_users = 65536
         elif ("Llama-3.2-90B" in self.model_config.model
-              and num_devices_per_model == 8
-              and is_wormhole):  # Llama90B on WH T3K
-            max_tokens_all_users = 65536  # [INFO] avoid OOM for Llama-3.2-90B
+              and num_devices_per_model == 8 and is_wormhole):
+            # Llama90B on WH T3K
+            max_tokens_all_users = 65536
         else:
             # Note: includes num vision tokens for multi-modal
             max_tokens_all_users = 131072


### PR DESCRIPTION
- Issue https://github.com/tenstorrent/vllm/issues/163
- Reduce num kv blocks for Qwen2.5-14B based models on N300 to support 64k max tokens since 128k doesn't fit
- Add Qwen2.5-14B models to list of supported models in offline_inference_tt.py