### PR TITLE
Fix llama-tg conditional behaviour

### DIFF
--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -690,7 +690,10 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                         )
                     }
             else:
-                tt_out = outputs  # [batch_size, seq_len, vocab_size]
+                # [ batch_size] if sampling on device
+                # [ batch_size, len, vocab_size] if not sampling on device
+                # the logits are not guaranteed to be for the whole sequence, usually only last token.
+                tt_out = outputs
         else:
             if self.model_config.is_encoder_decoder:
                 assert self.cached_req_data

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -178,12 +178,7 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         if ("Llama" in self.model_config.model
                 and "70B" in self.model_config.model
                 and self.device_config.device.get_num_devices() == 32
-                and not is_dp):
-            self.llama_tg = True
-        else:
-            self.llama_tg = False
-
-        if self.llama_tg or is_dp:
+                ) or is_dp:
             self.dp_kv_cache = True
         else:
             self.dp_kv_cache = False
@@ -496,8 +491,7 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                     next_token_ids, read_event = next_token_ids
                     self.cached_read_events.append(read_event)
                 self.cached_step_outputs.append(next_token_ids)
-                if (not self.llama_tg and i < num_steps - 1
-                        and not self.sample_on_device_mode):
+                if (i < num_steps - 1 and not self.sample_on_device_mode):
                     # Prepare the inputs for the next step
                     new_input_tokens = next_token_ids.unsqueeze(dim=1).int()
                     if new_input_tokens.shape[
@@ -806,14 +800,15 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                                  -1, :]  # unpadded batch, vocab of last token
             next_token_ids = self._sample_tokens(
                 next_logits, model_input.tt_sampling_params)
-        else:
-            if self.llama_tg:
+        else: # sample on device
+            if self.async_torch_proc:
+                # do not slice as this may be mid-transfer to host
                 next_token_ids = tt_out
             else:
                 next_token_ids = tt_out[:model_input.unpadded_batch_size]
         if not is_decode or not self.async_torch_proc:
             return next_token_ids
-        else:
+        else: # async torch proc only works in decode
             return tt_out, read_event
 
     def _sample_tokens(self, logits, tt_sampling_params: TTSamplingParams):

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -806,10 +806,11 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                 next_token_ids = tt_out
             else:
                 next_token_ids = tt_out[:model_input.unpadded_batch_size]
-        if not is_decode or not self.async_torch_proc:
-            return next_token_ids
-        else: # async torch proc only works in decode
+        if is_decode and self.async_torch_proc: # async torch proc only works in decode
             return tt_out, read_event
+        else:
+            return next_token_ids
+            
 
     def _sample_tokens(self, logits, tt_sampling_params: TTSamplingParams):
         if tt_sampling_params.temperature == 0:  # greedy decoding


### PR DESCRIPTION
Model runner had behaviour conditional on self.llama_tg where the behaviour should instead depend on specific features.
That has been removed.
This also fixes a potential race condition, where for async_torch_proc but not llama_tg in decode we could attempt to slice a tensor while it is being transferred to host. (stems from allowing non llama-tg async_torch_proc in #162 )

Also inverted an if for readability and fixed an inaccurate comment.

