### PR TITLE
Add structured outputs / guided decoding / logprobs support with host-side sampling

### DIFF
--- a/examples/server_example_tt.py
+++ b/examples/server_example_tt.py
@@ -20,6 +20,12 @@ def main():
         default=32,
         help="Maximum number of sequences to be processed in a single iteration"
     )
+    parser.add_argument(
+        "--num_scheduler_steps",
+        type=int,
+        default=10,
+        help="Number of scheduler steps"
+    )
     args, _ = parser.parse_known_args()
 
     check_tt_model_supported(args.model)
@@ -32,7 +38,7 @@ def main():
         "--max_num_seqs",
         str(args.max_num_seqs),
         "--num_scheduler_steps",
-        "10",
+        str(args.num_scheduler_steps),
     ])
     runpy.run_module('vllm.entrypoints.openai.api_server', run_name='__main__')
 

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -46,6 +46,11 @@ class TTPlatform(Platform):
             parallel_config.worker_cls = "vllm.worker.tt_worker.TTWorker"
 
     @classmethod
+    def is_pin_memory_available(cls) -> bool:
+        # The sampling code tries to use pinned memory in case we're using GPUs.
+        return False
+
+    @classmethod
     def validate_request(
         cls,
         prompt: PromptType,
@@ -61,14 +66,7 @@ class TTPlatform(Platform):
             if params.best_of is not None:
                 raise ValueError(
                     f"Currently not supporting best_of on {cls.device_name}")
-            if params.logprobs is not None:
-                raise ValueError(
-                    f"Currently not supporting logprobs on {cls.device_name}")
             if params.prompt_logprobs is not None:
                 raise ValueError(
                     f"Currently not supporting prompt_logprobs on "
-                    f"{cls.device_name}")
-            if params.guided_decoding is not None:
-                raise ValueError(
-                    f"Currently not supporting guided decoding on "
                     f"{cls.device_name}")

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -411,7 +411,10 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
     def __del__(self):
         # Delete model runner first in case there are model arifacts
-        del self.model_runner
+        try:
+            del self.model_runner
+        except AttributeError:
+            pass #attributes may be already torn down when destructor is called
 
         if self.mesh_device:
             close_mesh_device(self.mesh_device,


### PR DESCRIPTION
This PR implements a compatibility-focused sampling mode in tt_model_runner. It hooks into vllm's full logit_processor and sampler stack and enables:
- structured outputs / guided decoding
- logprobs (not prompt_logprobs yet, but it's a necessary step for that one)
- multiple other sampling options

The limitation is that it only works with host-side sampling. LLama 70B on Galaxy always enables device sampling - TBC if we have a version that can use host sampling.

Unless force-enabled by an override-tt-config setting, the compat sampling is enabled per-batch when sampling arguments not supported by our host sampling implementation are detected.
Quick perf measurements shows comparable throughput - for LLama 3.1 8B on n150 regular host-side sampling gave 24.0 t/s/u, compat sampling had 22.8 t/s/u

Passing pipeline of current vllm-nightly: https://github.com/tenstorrent/tt-metal/actions/runs/17568161486

A pipeline testing structured outputs is WIP, fighting read-only weight cache due to different input lengths

