### PR TITLE
Add initial V1 support (disabled by default, opt-in for text-only non-DP models)

### DIFF
--- a/requirements/tt.txt
+++ b/requirements/tt.txt
@@ -2,8 +2,8 @@
 -r common.txt
 
 # TT-NN works with older torch versions, but vLLM requires torch >= 2.7.0
-torch==2.7.0+cpu
-torchvision==0.22.0
-torchaudio==2.7.0
+torch==2.7.1+cpu
+torchvision==0.22.1
+torchaudio==2.7.1
 # Pinned down in https://github.com/tenstorrent/vllm/pull/127 to match tt-metal's requirements
 numpy>=1.24.4,<2

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -74,6 +74,7 @@ MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python exampl
 
 **Note 1**: Custom TT options can be set using `--override_tt_config` with a json string, e.g. `--override_tt_config '{"sample_on_device_mode": "all"}'`, however these shouldn't be used unless the model supports them (most currently do not). Supported parameters are:
 - `sample_on_device_mode`: ["all", "decode_only"]
+- `trace_mode`: [true, false]
 - `trace_region_size`: [default: 25000000]
 - `worker_l1_size`
 - `fabric_config`: ["DISABLED", "FABRIC_1D", "FABRIC_2D", "CUSTOM"]

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -63,13 +63,13 @@ To run Meta-Llama-3.1/3.2, it is required to have access to the model on Hugging
 To generate tokens (Llama70B on QuietBox) for sample prompts (with batch size 32):
 
 ```sh
-MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py
+MESH_DEVICE=T3K python examples/offline_inference_tt.py
 ```
 
 To measure performance (Llama70B on QuietBox) for a single batch of 32 prompts (with the default prompt length of 128 tokens):
 
 ```sh
-MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --measure_perf
+MESH_DEVICE=T3K python examples/offline_inference_tt.py --measure_perf
 ```
 
 **Note 1**: Custom TT options can be set using `--override_tt_config` with a json string, e.g. `--override_tt_config '{"sample_on_device_mode": "all"}'`, however these shouldn't be used unless the model supports them (most currently do not). Supported parameters are:
@@ -81,7 +81,7 @@ MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python exampl
 - `dispatch_core_axis`: ["row", "col"]
 - `data_parallel`: [default: 1]
 
-**Note 2 (Llama70B)**: To run Llama70B on Galaxy, set `MESH_DEVICE=TG` and do not set `WH_ARCH_YAML=...`.
+**Note 2 (Llama70B)**: To run Llama70B on Galaxy, set `MESH_DEVICE=TG`.
 
 **Note 3 (Llama70B)**: By default, this will run the newer tt-metal implementation of Llama70B from the [tt_transformers demo](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers). To run other implementations use the `TT_LLAMA_TEXT_VER` environment variable:
 - `"llama3_70b_galaxy"` for the Llama TG implementation
@@ -106,13 +106,13 @@ MESH_DEVICE=TG LLAMA_DIR=<path to weights> TT_LLAMA_TEXT_VER="llama3_70b_galaxy"
 To generate tokens (Llama-3.2-11B on N300) for sample prompts:
 
 ```sh
-MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
+MESH_DEVICE=N300 python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --multi_modal --max_seqs_in_batch 16 --num_repeat_prompts 8
 ```
 
 To measure performance (Llama-3.2-11B on N300) for a single batch (with the default prompt length of 128 tokens):
 
 ```sh
-MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --measure_perf --multi_modal --max_seqs_in_batch 16
+MESH_DEVICE=N300 python examples/offline_inference_tt.py --model "meta-llama/Llama-3.2-11B-Vision-Instruct" --measure_perf --multi_modal --max_seqs_in_batch 16
 ```
 
 > **Notes:**
@@ -124,7 +124,7 @@ MESH_DEVICE=N300 WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examp
 To start up the server:
 
 ```sh
-VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K WH_ARCH_YAML=wormhole_b0_80_arch_eth_dispatch.yaml python examples/server_example_tt.py
+VLLM_RPC_TIMEOUT=100000 MESH_DEVICE=T3K python examples/server_example_tt.py
 ```
 
 > **Notes:**

--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -72,6 +72,8 @@ To measure performance (Llama70B on QuietBox) for a single batch of 32 prompts (
 MESH_DEVICE=T3K python examples/offline_inference_tt.py --measure_perf
 ```
 
+> **⚠️ Enabling V1 Backend**: Experimental V1 support has been added for text-only models. This can be enabled by setting `VLLM_USE_V1=1` and `--num_scheduler_steps 1`, though it may still have limitations compared to the default V0 backend. To disable multiprocessing in V1 (to step through code or make scheduling deterministic), set `VLLM_ENABLE_V1_MULTIPROCESSING=0`.
+
 **Note 1**: Custom TT options can be set using `--override_tt_config` with a json string, e.g. `--override_tt_config '{"sample_on_device_mode": "all"}'`, however these shouldn't be used unless the model supports them (most currently do not). Supported parameters are:
 - `sample_on_device_mode`: ["all", "decode_only"]
 - `trace_mode`: [true, false]

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1547,6 +1547,13 @@ class EngineArgs:
                 self.enable_prefix_caching = incremental_prefill_supported
                 logger.info("(%s) prefix caching by default", action)
 
+        # Disable chunked prefill for TT devices in V1
+        if current_platform.is_tt():
+            logger.info(
+                "Chunked prefill is not yet supported for TT devices; "
+                "disabling it for V1 backend.")
+            self.enable_chunked_prefill = False
+
         if not self.enable_chunked_prefill:
             self.max_num_batched_tokens = model_config.max_model_len
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1549,10 +1549,13 @@ class EngineArgs:
 
         # Disable chunked prefill for TT devices in V1
         if current_platform.is_tt():
-            logger.info(
-                "Chunked prefill is not yet supported for TT devices; "
-                "disabling it for V1 backend.")
+            logger.info("Chunked prefill is not yet supported for TT devices; "
+                        "disabling it for V1 backend.")
             self.enable_chunked_prefill = False
+
+            logger.info("Prefix caching is not yet supported for TT devices; "
+                        "disabling it for V1 backend.")
+            self.enable_prefix_caching = False
 
         if not self.enable_chunked_prefill:
             self.max_num_batched_tokens = model_config.max_model_len

--- a/vllm/model_executor/model_loader/tt_loader.py
+++ b/vllm/model_executor/model_loader/tt_loader.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from torch import nn
 
 from vllm.config import ModelConfig, VllmConfig
@@ -11,15 +13,14 @@ logger = init_logger(__name__)
 
 class TTModelLoader(BaseModelLoader):
 
-    def load_model(self, *, vllm_config: VllmConfig) -> nn.Module:
+    def load_model(self, vllm_config: VllmConfig, model_config: ModelConfig):
         """Load a model with the given configurations."""
 
-        # For TT models, prepend "TT" to the architecture name,
-        # e.g. "TTLlamaForCausalLM"
-        model_config = vllm_config.model_config
         device_config = vllm_config.device_config
         scheduler_config = vllm_config.scheduler_config
 
+        # For TT models, prepend "TT" to the architecture name,
+        # e.g. "TTLlamaForCausalLM"
         arch_names = model_config.hf_config.architectures
         for i in range(len(arch_names)):
             arch_names[i] = "TT" + arch_names[i]

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 from typing import TYPE_CHECKING, Optional, Union
 
 import torch
@@ -42,6 +44,8 @@ class TTPlatform(Platform):
                 == 1), "TT backend does not support distributed execution"
         assert not vllm_config.lora_config, (
             "LoRA is not supported for TT backend")
+        assert not vllm_config.cache_config.enable_prefix_caching, (
+            "Automatic prefix caching is not yet supported for TT backend")
 
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -86,7 +86,7 @@ class TTPlatform(Platform):
             cls.compat_sampling_possible = False
             logger.warning(
                 "Disabling compatibility sampling as it's not yet support for "
-                "V1 TT backend")
+                "V1 TT backend.")
 
         always_compat_sampling = False
         if override_tt_config is not None \
@@ -100,7 +100,7 @@ class TTPlatform(Platform):
                 if envs.VLLM_USE_V1:
                     raise ValueError(
                         "always_compat_sampling is not yet supported for "
-                        "V1 TT backend")
+                        "V1 TT backend.")
                 logger.info(
                     "Compatibility sampling mode enabled for all requests")
         cls.always_compat_sampling = always_compat_sampling  # type: ignore[attr-defined]

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -113,8 +113,22 @@ class TTPlatform(Platform):
 
     @classmethod
     def supports_v1(cls, model_config: ModelConfig) -> bool:
-        # V1 support on TT is experimental
-        return True
+        # V1 support on TT is experimental.
+        # Allow users to opt in, but give a warning.
+        if envs.is_set("VLLM_USE_V1") and envs.VLLM_USE_V1:
+            if model_config.is_encoder_decoder:
+                raise ValueError(
+                    "VLLM_USE_V1=1 was set but encoder-decoder models aren't "
+                    "yet supported in V1 for TT")
+            elif model_config.is_multimodal_model:
+                raise ValueError(
+                    "VLLM_USE_V1=1 was set but multimodal models aren't "
+                    "yet supported in V1 for TT")
+            logger.warning(
+                "Enabling V1 since VLLM_USE_V1=1, however V1 is still "
+                "experimental for TT backend.")
+            return envs.VLLM_USE_V1
+        return False
 
     @classmethod
     def is_pin_memory_available(cls) -> bool:

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -54,6 +54,8 @@ class TTPlatform(Platform):
         if parallel_config.worker_cls == "auto":
             if envs.VLLM_USE_V1:
                 parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
+                vllm_config.scheduler_config.scheduler_cls = (
+                    "vllm.v1.core.sched.ascend_scheduler.AscendScheduler")
             else:
                 parallel_config.worker_cls = "vllm.worker.tt_worker.TTWorker"
 
@@ -82,8 +84,8 @@ class TTPlatform(Platform):
         cls.compat_sampling_possible = (  # type: ignore[attr-defined]
             sample_on_device_mode is None)
 
-        if cls.compat_sampling_possible and envs.VLLM_USE_V1:
-            cls.compat_sampling_possible = False
+        if cls.compat_sampling_possible and envs.VLLM_USE_V1:  # type: ignore[attr-defined]
+            cls.compat_sampling_possible = False  # type: ignore[attr-defined]
             logger.warning(
                 "Disabling compatibility sampling as it's not yet support for "
                 "V1 TT backend.")

--- a/vllm/v1/core/sched/ascend_scheduler.py
+++ b/vllm/v1/core/sched/ascend_scheduler.py
@@ -1,22 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# SPDX-FileCopyrightText: Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# SPDX-FileCopyrightText: Copyright 2025 Huawei Technologies Co., Ltd.
 #
-# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# This file was copied from the vllm-ascend project (original at
+# This file was copied and modified from the vllm-ascend project (original at
 # https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/core/scheduler.py @ df0ec55)  # noqa: E501
 
 import time

--- a/vllm/v1/core/sched/ascend_scheduler.py
+++ b/vllm/v1/core/sched/ascend_scheduler.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Copyright (c) 2025 Huawei Technologies Co., Ltd.
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file was copied from the vllm-ascend project (original at
+# https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/core/scheduler.py @ df0ec55)  # noqa: E501
+
+import time
+from collections import deque
+from collections.abc import Iterable
+from typing import Union
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_events import KVEventBatch
+from vllm.logger import logger
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.utils import cdiv
+from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutputs
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+
+class AscendScheduler(Scheduler):
+    """This Scheduler extends vllm's original v1 scheduler
+    with prefill-first scheduling strategy."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        super().__init__(vllm_config, kv_cache_config,
+                         structured_output_manager, mm_registry,
+                         include_finished_set, log_stats)
+        self.scheduled_req_ids: set[str] = set()
+        self.running: list[Request] = []
+
+    def schedule(self) -> SchedulerOutput:
+        if self.scheduler_config.chunked_prefill_enabled:
+            return super().schedule()
+        scheduled_new_reqs: list[Request] = []
+        scheduled_resumed_reqs: list[Request] = []
+        scheduled_running_reqs: list[Request] = []
+        preempted_reqs: list[Request] = []
+
+        req_to_new_block_ids: dict[str, tuple[list[int], ...]] = {}
+        num_scheduled_tokens: dict[str, int] = {}
+        token_budget = self.max_num_scheduled_tokens
+        # Spec decode-related.
+        scheduled_spec_decode_tokens: dict[str, list[int]] = {}
+
+        # For logging.
+        scheduled_timestamp = time.monotonic()
+
+        # Record scheduled LoRA requests.
+        scheduled_loras: set[int] = set()
+
+        # Use a temporary deque to collect requests that need to be skipped
+        # and put back at the head of the waiting queue later
+        skipped_waiting_requests: deque[Request] = deque()
+
+        # Schedule prefill requests first.
+        while self.waiting and token_budget > 0:
+            if len(self.running) == self.max_num_running_reqs:
+                break
+
+            request = self.waiting.peek_request()
+
+            def skip_cur_request(req=request):
+                self.waiting.pop_request()
+                skipped_waiting_requests.appendleft(req)
+
+            # P/D: skip request if still waiting for remote kvs.
+            if request.status == RequestStatus.WAITING_FOR_REMOTE_KVS:
+                is_ready = self._update_waiting_for_remote_kv(request)
+                if is_ready:
+                    request.status = RequestStatus.WAITING
+                else:
+                    skip_cur_request()
+                    continue
+
+            # Check that adding the request still respects the max_loras
+            # constraint.
+            if (self.lora_config and request.lora_request and
+                (len(scheduled_loras) == self.lora_config.max_loras
+                 and request.lora_request.lora_int_id not in scheduled_loras)):
+                # Scheduling would exceed max_loras, skip.
+                skip_cur_request()
+                continue
+
+            num_external_computed_tokens = 0
+            load_kv_async = False
+
+            # Get already-cached tokens.
+            if request.num_computed_tokens == 0:
+                new_computed_blocks, num_new_local_computed_tokens = \
+                    self.kv_cache_manager.get_computed_blocks(
+                        request)
+
+                # Get externally-cached tokens if using a KVConnector.
+                if self.connector is not None:
+                    num_external_computed_tokens, load_kv_async = (
+                        self.connector.get_num_new_matched_tokens(
+                            request, num_new_local_computed_tokens))
+
+                # Total computed tokens (local + external).
+                num_computed_tokens = (num_new_local_computed_tokens +
+                                       num_external_computed_tokens)
+            else:
+                # P/D: skip checking prefix cache if loaded from remote kvs.
+                new_computed_blocks = (
+                    self.kv_cache_manager.create_empty_block_list())
+                num_new_local_computed_tokens = 0
+                num_computed_tokens = request.num_computed_tokens
+
+            # P/D: loading remote KV, do not allocate for new work.
+            if load_kv_async:
+                assert num_external_computed_tokens > 0
+                num_new_tokens = 0
+                blocks = None
+            # Number of tokens to be scheduled.
+            else:
+                prompt_limit = self._get_prompt_limit(request)
+                # We use `request.num_tokens` instead of
+                # `request.num_prompt_tokens` to consider the resumed
+                # requests, which have output tokens.
+                num_new_tokens = request.num_tokens - num_computed_tokens
+                max_tokens_in_kvcache = (self.kv_cache_config.num_blocks *
+                                         self.block_size)
+                prompt_limit = min(prompt_limit, max_tokens_in_kvcache)
+
+                # Finish request that exceeds prompt_limit or kv cache size.
+                if num_new_tokens > prompt_limit:
+                    logger.warning(
+                        "Input prompt (%d tokens) is too long"
+                        " and exceeds limit of %d",
+                        num_new_tokens,
+                        prompt_limit,
+                    )
+                    request.status = RequestStatus.FINISHED_IGNORED
+                    self.finished_req_ids.add(  # type: ignore
+                        request.request_id)  # type: ignore
+                    self.waiting.pop_request()
+                    continue
+
+                if num_new_tokens > token_budget:
+                    # Scheduling would exceed token_budget, skip.
+                    skip_cur_request()
+                    continue
+                assert num_new_tokens > 0
+                blocks = new_computed_blocks.blocks[0]
+
+            watermark = getattr(self.scheduler_config, "watermark", 0.01)
+            if not self._check_watermark_for_prefill(request, num_new_tokens,
+                                                     blocks, watermark):
+                # Scheduling would exceed watermark, skip.
+                skip_cur_request()
+                continue
+
+            new_blocks = self.kv_cache_manager.allocate_slots(
+                request,
+                num_new_tokens + num_external_computed_tokens,
+                num_new_local_computed_tokens,
+                new_computed_blocks=new_computed_blocks,
+                num_lookahead_tokens=self.num_lookahead_tokens,
+                delay_cache_blocks=load_kv_async)
+            if new_blocks is None:
+                # The request cannot be scheduled.
+                break
+
+            # KVConnector: update internal state after allocation.
+            # This information is used to determine if a load is
+            # needed for this request.
+            if self.connector is not None:
+                self.connector.update_state_after_alloc(
+                    request,
+                    new_computed_blocks + new_blocks,
+                    num_external_computed_tokens,
+                )
+
+            self.waiting.pop_request()
+            if load_kv_async:
+                # If loading async, allocate memory and put request
+                # into the WAITING_FOR_REMOTE_KV state.
+                skipped_waiting_requests.appendleft(request)
+                request.status = RequestStatus.WAITING_FOR_REMOTE_KVS
+                continue
+
+            self.running.append(request)
+            if self.log_stats:
+                request.record_event(EngineCoreEventType.SCHEDULED,
+                                     scheduled_timestamp)
+            self.scheduled_req_ids.add(request.request_id)
+            # Check request status.
+            if request.status == RequestStatus.WAITING:
+                scheduled_new_reqs.append(request)
+            elif request.status == RequestStatus.PREEMPTED:
+                scheduled_resumed_reqs.append(request)
+            else:
+                raise RuntimeError(f"Invalid request status: {request.status}")
+
+            if self.lora_config and request.lora_request:
+                scheduled_loras.add(request.lora_request.lora_int_id)
+            req_to_new_block_ids[request.request_id] = (
+                self.kv_cache_manager.get_block_ids(request.request_id))
+            # Update request info.
+            num_scheduled_tokens[request.request_id] = num_new_tokens
+            token_budget -= num_new_tokens
+            request.status = RequestStatus.RUNNING
+            request.num_computed_tokens = num_computed_tokens
+            # Count the number of prefix cached tokens.
+            if request.num_cached_tokens < 0:
+                request.num_cached_tokens = num_computed_tokens
+
+        # Put back any skipped requests at the head of the waiting queue
+        if skipped_waiting_requests:
+            self.waiting.extendleft(skipped_waiting_requests)  # type: ignore
+
+        # If no prefill requests are scheduled,
+        # Schedule decode requests next.
+        if len(self.scheduled_req_ids) == 0:
+            req_index = 0
+            while req_index < len(self.running) and token_budget > 0:
+                request = self.running[req_index]
+                if request.request_id in self.scheduled_req_ids:
+                    # This request has already been scheduled.
+                    req_index += 1
+                    continue
+
+                num_new_tokens = (request.num_tokens_with_spec -
+                                  request.num_computed_tokens)
+                assert (request.num_tokens - request.num_computed_tokens) == 1
+                num_new_tokens = min(num_new_tokens, token_budget)
+                # Make sure the input position does not exceed the
+                # max model len.
+                # This is necessary when using spec decoding.
+                num_new_tokens = min(
+                    num_new_tokens,
+                    self.max_model_len - request.num_computed_tokens)
+                # Check that adding the request still respects the max_loras
+                # constraint.
+                if self.lora_config and request.lora_request and (
+                        len(scheduled_loras) == self.lora_config.max_loras
+                        and request.lora_request.lora_int_id
+                        not in scheduled_loras):
+                    # Scheduling would exceed max_loras, skip.
+                    num_new_tokens = 0
+
+                if num_new_tokens == 0:
+                    # The request cannot be scheduled because one of the
+                    # following reason:
+                    # 1. No new tokens to schedule. This may happen when PP>1
+                    #    and we have already scheduled all prompt tokens but
+                    #    they are not finished yet.
+                    # 2. Adding the request exceeds the max_loras constraint.
+                    # NOTE(woosuk): Here, by doing `continue` instead of
+                    # `break`, we do not strictly follow the FCFS scheduling
+                    # policy and
+                    # allow the lower-priority requests to be scheduled.
+                    req_index += 1
+                    continue
+
+                while True:
+                    new_blocks = self.kv_cache_manager.allocate_slots(
+                        request,
+                        num_new_tokens,
+                        num_lookahead_tokens=self.num_lookahead_tokens)
+                    if new_blocks is None:
+                        # The request cannot be scheduled.
+                        # Preempt the lowest-priority request.
+                        preempted_req = self.running.pop()
+                        self.kv_cache_manager.free(preempted_req)
+                        preempted_req.status = RequestStatus.PREEMPTED
+                        preempted_req.num_computed_tokens = 0
+                        if self.log_stats:
+                            preempted_req.record_event(
+                                EngineCoreEventType.PREEMPTED,
+                                scheduled_timestamp)
+                        self.waiting.prepend_request(preempted_req)
+                        preempted_reqs.append(preempted_req)
+                        if preempted_req == request:
+                            # No more request to preempt.
+                            can_schedule = False
+                            break
+                    else:
+                        # The request can be scheduled.
+                        can_schedule = True
+                        break
+                if not can_schedule:
+                    break
+                assert new_blocks is not None
+
+                # Schedule the request.
+                scheduled_running_reqs.append(request)
+                self.scheduled_req_ids.add(request.request_id)
+                req_to_new_block_ids[request.request_id] = (
+                    new_blocks.get_block_ids())
+                num_scheduled_tokens[request.request_id] = num_new_tokens
+                token_budget -= num_new_tokens
+                req_index += 1
+
+                # Speculative decode related.
+                if request.spec_token_ids:
+                    num_scheduled_spec_tokens = (num_new_tokens +
+                                                 request.num_computed_tokens -
+                                                 request.num_tokens)
+                    if num_scheduled_spec_tokens > 0:
+                        # Trim spec_token_ids list to num_scheduled_spec_tokens.
+                        del request.spec_token_ids[num_scheduled_spec_tokens:]
+                        scheduled_spec_decode_tokens[request.request_id] = (
+                            request.spec_token_ids)
+
+                # Record scheduled LoRA requests.
+                if self.lora_config and request.lora_request:
+                    scheduled_loras.add(request.lora_request.lora_int_id)
+
+        # Check if the scheduling constraints are satisfied.
+        total_num_scheduled_tokens = sum(num_scheduled_tokens.values())
+        assert total_num_scheduled_tokens <= self.max_num_scheduled_tokens
+        assert token_budget >= 0
+        assert len(self.running) <= self.max_num_running_reqs
+        assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(
+            scheduled_running_reqs) <= len(self.running)
+
+        # Get the longest common prefix among all requests in the running queue.
+        # This can be potentially used for cascade attention.
+        num_common_prefix_blocks: list[int] = [0] * len(
+            self.kv_cache_config.kv_cache_groups)
+        if self.running:
+            any_request = self.running[0]
+            num_common_prefix_blocks = (
+                self.kv_cache_manager.get_num_common_prefix_blocks(
+                    any_request, len(self.running)))
+
+        # Construct the scheduler output.
+        new_reqs_data = [
+            NewRequestData.from_request(req,
+                                        req_to_new_block_ids[req.request_id])
+            for req in scheduled_new_reqs
+        ]
+
+        cached_reqs_data = self._make_cached_request_data(
+            scheduled_running_reqs, scheduled_resumed_reqs,
+            num_scheduled_tokens, scheduled_spec_decode_tokens,
+            req_to_new_block_ids)
+        scheduled_cached_reqs = cached_reqs_data
+
+        scheduler_output = SchedulerOutput(
+            scheduled_new_reqs=new_reqs_data,
+            scheduled_cached_reqs=scheduled_cached_reqs,
+            num_scheduled_tokens=num_scheduled_tokens,
+            total_num_scheduled_tokens=total_num_scheduled_tokens,
+            scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=num_common_prefix_blocks,
+            # finished_req_ids is an existing state in the scheduler,
+            # instead of being newly scheduled in this step.
+            # It contains the request IDs that are finished in between
+            # the previous and the current steps.
+            finished_req_ids=self.finished_req_ids,  # type: ignore
+            free_encoder_input_ids=self.encoder_cache_manager.get_freed_ids(),
+            structured_output_request_ids={},
+            grammar_bitmask=None,
+        )
+
+        # NOTE(Kuntai): this function is designed for multiple purposes:
+        # 1. Plan the KV cache store
+        # 2. Wrap up all the KV cache load / save ops into an opaque object
+        # 3. Clear the internal states of the connector
+        if self.connector is not None:
+            meta = self.connector.build_connector_meta(scheduler_output)
+            scheduler_output.kv_connector_metadata = meta
+
+        events = self.kv_cache_manager.take_events()
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # Advance the number of computed tokens for the request AFTER
+        # the request is scheduled.
+        # 1. The scheduler_output of the current step has to include the
+        #    original number of scheduled tokens to determine input IDs.
+        # 2. Advance the number of computed tokens here allowing us to
+        #    schedule the prefill request again immediately in the next
+        #    scheduling step.
+        # 3. If some tokens (e.g. spec tokens) are rejected later, the number of
+        #    computed tokens will be adjusted in update_from_output.
+        for req_id, num_scheduled_token in num_scheduled_tokens.items():
+            self.requests[req_id].num_computed_tokens += num_scheduled_token
+
+        self.finished_req_ids = set()  # type: ignore
+        return scheduler_output
+
+    def _check_watermark_for_prefill(self,
+                                     request,
+                                     num_new_tokens,
+                                     computed_blocks,
+                                     watermark=0.01):
+        computed_blocks = computed_blocks or []
+        watermark_blocks = self.kv_cache_config.num_blocks * watermark
+        num_computed_tokens = (request.num_computed_tokens +
+                               len(computed_blocks) * self.block_size)
+        num_required_blocks = cdiv(num_new_tokens + num_computed_tokens,
+                                   self.block_size)
+        req_blocks = self.kv_cache_manager.coordinator.get_blocks(
+            request.request_id)
+        num_new_blocks = (num_required_blocks - len(req_blocks) -
+                          len(computed_blocks))
+        num_evictable_computed_blocks = sum(1 for blk in computed_blocks
+                                            if blk.ref_cnt == 0)
+        # If number of free blocks is less than water mark after allocating,
+        # don't allocate.
+        return (self.kv_cache_manager.block_pool.get_num_free_blocks() -
+                num_evictable_computed_blocks -
+                num_new_blocks) >= watermark_blocks
+
+    def _get_prompt_limit(self, request: Request) -> int:
+        if (self.scheduler_config.chunked_prefill_enabled
+                and not self.scheduler_config.is_multi_step):
+            prompt_limit = self.scheduler_config.max_model_len
+        else:
+            prompt_limit = min(
+                self.scheduler_config.max_model_len,
+                self.scheduler_config.max_num_batched_tokens,
+            )
+
+        # Model is fine tuned with long context. Return the fine tuned max_len.
+        if request.lora_request and request.lora_request.long_lora_max_len:
+            assert prompt_limit <= request.lora_request.long_lora_max_len
+            return request.lora_request.long_lora_max_len
+        else:
+            return prompt_limit
+
+    def finish_requests(
+        self,
+        request_ids: Union[str, Iterable[str]],
+        finished_status: RequestStatus,
+    ) -> None:
+        """Handles the finish signal from outside the scheduler.
+
+        For example, the API server can abort a request when the client
+        disconnects.
+        """
+        for req_id in request_ids:
+            request = self.requests.get(req_id)
+            if request is None:
+                # Invalid request ID.
+                continue
+            if request.status == RequestStatus.RUNNING:
+                self.scheduled_req_ids.discard(request.request_id)
+        super().finish_requests(request_ids, finished_status)
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+
+        # NOTE(woosuk): As len(self.running) can be up to 1K or more, the below
+        # loop can be a performance bottleneck. We should do our best to avoid
+        # expensive operations inside the loop.
+        for request in self.running:
+            req_id = request.request_id
+            num_tokens_scheduled = num_scheduled_tokens.get(req_id, 0)
+            if num_tokens_scheduled == 0:
+                # The request was not scheduled in this step.
+                continue
+            if req_id in self.scheduled_req_ids:
+                self.scheduled_req_ids.remove(req_id)
+
+        return super().update_from_output(scheduler_output,
+                                          model_runner_output)

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -120,6 +120,7 @@ class LLMEngine:
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: Optional[list[StatLoggerFactory]] = None,
         disable_log_stats: bool = False,
+        log_global_stats: bool = False,  # Currently ignored in V1 (used in V0)
     ) -> "LLMEngine":
         return cls(vllm_config=vllm_config,
                    executor_class=Executor.get_class(vllm_config),

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -28,8 +28,8 @@ from vllm.v1.engine.output_processor import OutputProcessor
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.engine.processor import Processor
 from vllm.v1.executor.abstract import Executor
-from vllm.v1.metrics.loggers import (PrometheusStatLogger, StatLoggerBase,
-                                     StatLoggerFactory)
+from vllm.v1.metrics.loggers import (GlobalStatLogger, PrometheusStatLogger,
+                                     StatLoggerBase, StatLoggerFactory)
 from vllm.v1.metrics.reader import Metric, get_metrics_snapshot
 from vllm.v1.metrics.stats import IterationStats
 
@@ -46,6 +46,8 @@ class LLMEngine:
         vllm_config: VllmConfig,
         executor_class: type[Executor],
         log_stats: bool,
+        log_global_stats: bool = False,  # if True and log_stats is True, 
+        # log with GlobalStatLogger instead
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: Optional[list[StatLoggerFactory]] = None,
         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
@@ -69,9 +71,13 @@ class LLMEngine:
         self.cache_config = vllm_config.cache_config
 
         self.log_stats = log_stats
+        self.log_global_stats = log_global_stats
         self.stat_logger: Optional[StatLoggerBase] = None
         if self.log_stats:
-            self.stat_logger = PrometheusStatLogger(vllm_config)
+            if self.log_global_stats:
+                self.stat_logger = GlobalStatLogger(vllm_config)
+            else:
+                self.stat_logger = PrometheusStatLogger(vllm_config)
 
         # important: init dp group before init the engine_core
         # In the decoupled engine case this is handled in EngineCoreProc.
@@ -120,11 +126,12 @@ class LLMEngine:
         usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
         stat_loggers: Optional[list[StatLoggerFactory]] = None,
         disable_log_stats: bool = False,
-        log_global_stats: bool = False,  # Currently ignored in V1 (used in V0)
+        log_global_stats: bool = False,
     ) -> "LLMEngine":
         return cls(vllm_config=vllm_config,
                    executor_class=Executor.get_class(vllm_config),
                    log_stats=(not disable_log_stats),
+                   log_global_stats=log_global_stats,
                    usage_context=usage_context,
                    stat_loggers=stat_loggers,
                    multiprocess_mode=envs.VLLM_ENABLE_V1_MULTIPROCESSING)
@@ -252,6 +259,12 @@ class LLMEngine:
             assert outputs.scheduler_stats is not None
             self.stat_logger.record(scheduler_stats=outputs.scheduler_stats,
                                     iteration_stats=iteration_stats)
+
+        if (self.log_stats and self.log_global_stats
+                and not self.has_unfinished_requests()):
+            assert isinstance(self.stat_logger, GlobalStatLogger)
+            self.stat_logger.log_out()
+            self.stat_logger.reset()
 
         return processed_outputs.request_outputs
 

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -63,7 +63,7 @@ class AvgTracker:
 
 class GlobalStatLogger(StatLoggerBase):
     """GlobalStatLogger is used in LLMEngine to track stats across the entire 
-    generation (until manually reset)"""
+    generation (until manually reset) """
 
     def __init__(self, vllm_config: VllmConfig, engine_index: int = 0):
         self.engine_index = engine_index

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -49,6 +49,67 @@ class StatLoggerBase(ABC):
         pass
 
 
+class AvgTracker:
+    """Tracks running average of a value."""
+
+    def __init__(self) -> None:
+        self.avg = 0.0
+        self.count = 0
+
+    def update(self, new_val: float) -> None:
+        self.count += 1
+        self.avg += (new_val - self.avg) / self.count
+
+
+class GlobalStatLogger(StatLoggerBase):
+    """GlobalStatLogger is used in LLMEngine to track stats across the entire 
+    generation (until manually reset)"""
+
+    def __init__(self, vllm_config: VllmConfig, engine_index: int = 0):
+        self.engine_index = engine_index
+        self.vllm_config = vllm_config
+        self.time_to_first_token = AvgTracker()
+        self.time_per_output_token = AvgTracker()
+
+    def record(self,
+               scheduler_stats: Optional[SchedulerStats],
+               iteration_stats: Optional[IterationStats],
+               engine_idx: int = 0):
+        """Called by LLMEngine. Updates stats at end of each step"""
+
+        def avg_list(list):
+            return sum(list) / len(list)
+
+        assert isinstance(iteration_stats, IterationStats)
+        if len(iteration_stats.time_to_first_tokens_iter) > 0:
+            self.time_to_first_token.update(
+                avg_list(iteration_stats.time_to_first_tokens_iter))
+        if len(iteration_stats.time_per_output_tokens_iter) > 0:
+            self.time_per_output_token.update(
+                avg_list(iteration_stats.time_per_output_tokens_iter))
+
+    def log_out(self):
+        ttft = self.time_to_first_token
+        tpot = self.time_per_output_token
+        if ttft.count != 0:
+            logger.info("Average time to first token (batch): %f s", ttft.avg)
+        if tpot.count != 0:
+            decode_throughput = 1 / tpot.avg if tpot.avg != 0 else 0
+            logger.info("Average decode throughput: %f t/s/u",
+                        decode_throughput)
+
+    def reset(self) -> None:
+        self.time_to_first_token = AvgTracker()
+        self.time_per_output_token = AvgTracker()
+
+    def log_engine_initialized(self):
+        if self.vllm_config.cache_config.num_gpu_blocks:
+            logger.info(
+                "Engine %03d: vllm cache_config_info with initialization "
+                "after num_gpu_blocks is: %d", self.engine_index,
+                self.vllm_config.cache_config.num_gpu_blocks)
+
+
 class LoggingStatLogger(StatLoggerBase):
 
     def __init__(self, vllm_config: VllmConfig, engine_index: int = 0):

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import Optional, cast
+
+import numpy as np
+
+from vllm.v1.worker.block_table import MultiGroupBlockTable
+from vllm.v1.worker.gpu_input_batch import CachedRequestState
+
+
+class InputBatch:
+    """Persistent input batch, based on InputBatch for GPU/TPU backends."""
+
+    def __init__(
+            self,
+            max_num_reqs: int,
+            max_model_len: int,
+            max_num_batched_tokens: int,
+            block_sizes: list[int],  # The block_size of each kv cache group
+    ):
+        self.max_num_reqs = max_num_reqs
+
+        self._req_ids: list[Optional[str]] = []
+        self.req_id_to_index: dict[str, int] = {}
+
+        # TODO(woosuk): This buffer could be too large if max_model_len is big.
+        # Find a way to reduce the CPU memory usage.
+        self.token_ids_cpu = np.zeros(
+            (max_num_reqs, max_model_len),
+            dtype=np.int32,
+        )
+
+        self.num_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.num_prompt_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.num_computed_tokens_cpu = np.zeros(max_num_reqs, dtype=np.int32)
+
+        # Block table.
+        self.block_table = MultiGroupBlockTable(
+            max_num_reqs=max_num_reqs,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=max_num_batched_tokens,
+            pin_memory=False,
+            device="cpu",
+            block_sizes=block_sizes,
+        )
+
+        self.req_output_token_ids: list[Optional[list[int]]] = []
+
+    @property
+    def req_ids(self) -> list[str]:
+        # None elements should only be present transiently
+        # while performing state updates to the batch.
+        return cast(list[str], self._req_ids)
+
+    @property
+    def num_reqs(self) -> int:
+        return len(self.req_id_to_index)
+
+    def add_request(
+        self,
+        request: "CachedRequestState",
+        req_index: Optional[int] = None,
+    ) -> None:
+        if req_index is None:
+            req_index = self.num_reqs
+        assert req_index < self.max_num_reqs
+
+        req_id = request.req_id
+        if req_index == len(self._req_ids):
+            self._req_ids.append(req_id)
+            self.req_output_token_ids.append(request.output_token_ids)
+        else:
+            self._req_ids[req_index] = req_id
+            self.req_output_token_ids[req_index] = request.output_token_ids
+
+        self.req_id_to_index[req_id] = req_index
+
+        # Copy the prompt token ids and output token ids.
+        num_prompt_tokens = len(request.prompt_token_ids)
+        self.num_prompt_tokens[req_index] = num_prompt_tokens
+        self.token_ids_cpu[
+            req_index, :num_prompt_tokens] = request.prompt_token_ids
+        start_idx = num_prompt_tokens
+        end_idx = start_idx + len(request.output_token_ids)
+        self.token_ids_cpu[req_index,
+                           start_idx:end_idx] = request.output_token_ids
+        # Number of token ids in token_ids_cpu.
+        self.num_tokens[req_index] = request.num_tokens
+
+        self.num_computed_tokens_cpu[req_index] = request.num_computed_tokens
+        self.block_table.add_row(request.block_ids, req_index)
+
+    def remove_request(self, req_id: str) -> Optional[int]:
+        """This method must always be followed by a call to condense()."""
+
+        req_index = self.req_id_to_index.pop(req_id, None)
+        if req_index is None:
+            return None
+        self._req_ids[req_index] = None
+        self.req_output_token_ids[req_index] = None
+
+        return req_index
+
+    def condense(self, empty_req_indices: list[int]) -> None:
+        """Move non-empty requests down into lower, empty indices.
+        
+        Args:
+          empty_req_indices: empty batch indices, sorted descending.
+        """
+        num_reqs = self.num_reqs
+        if num_reqs == 0:
+            # The batched states are empty.
+            self._req_ids.clear()
+            self.req_output_token_ids.clear()
+            return
+
+        # NOTE(woosuk): This function assumes that the empty_req_indices
+        # is sorted in descending order.
+        last_req_index = num_reqs + len(empty_req_indices) - 1
+        while empty_req_indices:
+            # Find the largest non-empty index.
+            while last_req_index in empty_req_indices:
+                last_req_index -= 1
+
+            # Find the smallest empty index.
+            empty_index = empty_req_indices.pop()
+            if empty_index >= last_req_index:
+                break
+
+            # Swap the states.
+            req_id = self._req_ids[last_req_index]
+            output_token_ids = self.req_output_token_ids[last_req_index]
+            assert req_id is not None
+            self._req_ids[empty_index] = req_id
+            self._req_ids[last_req_index] = None
+            self.req_output_token_ids[empty_index] = output_token_ids
+            self.req_output_token_ids[last_req_index] = None
+            self.req_id_to_index[req_id] = empty_index
+
+            num_tokens = self.num_tokens[last_req_index]
+            self.token_ids_cpu[empty_index, :num_tokens] = self.token_ids_cpu[
+                last_req_index, :num_tokens]
+            self.num_tokens[empty_index] = num_tokens
+            self.num_prompt_tokens[empty_index] = self.num_prompt_tokens[
+                last_req_index]
+            self.num_computed_tokens_cpu[
+                empty_index] = self.num_computed_tokens_cpu[last_req_index]
+            self.block_table.move_row(last_req_index, empty_index)
+
+            # Decrement last_req_index since it is now empty.
+            last_req_index -= 1
+
+        # Trim lists to the batch size.
+        del self._req_ids[self.num_reqs:]
+        del self.req_output_token_ids[self.num_reqs:]

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -126,7 +126,7 @@ class InputBatch:
         """Move non-empty requests down into lower, empty indices.
         
         Args:
-          empty_req_indices: empty batch indices, sorted descending.
+            empty_req_indices: empty batch indices, sorted descending.
         """
         num_reqs = self.num_reqs
         if num_reqs == 0:

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import ttnn
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader.tt_loader import TTModelLoader
+
+logger = init_logger(__name__)
+
+
+class TTModelRunner:
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        mesh_device: ttnn.MeshDevice,
+        trace_mode: bool,
+    ):
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.cache_config = vllm_config.cache_config
+        self.lora_config = vllm_config.lora_config
+        self.load_config = vllm_config.load_config
+        self.parallel_config = vllm_config.parallel_config
+        self.scheduler_config = vllm_config.scheduler_config
+        self.speculative_config = vllm_config.speculative_config
+        self.prompt_adapter_config = vllm_config.prompt_adapter_config
+        self.observability_config = vllm_config.observability_config
+        self.device_config = vllm_config.device_config
+
+        # Currently, TT model runner doesn't support chunked prefill.
+        assert self.scheduler_config.chunked_prefill_enabled is False
+
+        self.mesh_device = mesh_device
+        self.trace_mode = trace_mode
+
+        # Whether to sample on device
+        override_tt_config = self.model_config.override_tt_config
+        sample_key = "sample_on_device_mode"
+        self.sample_on_device_mode = None
+        if (override_tt_config and sample_key in override_tt_config):
+            assert override_tt_config[sample_key] in [
+                "all", "decode_only"
+            ], f"Invalid {sample_key}: {self.sample_on_device_mode}"
+            self.sample_on_device_mode = override_tt_config[sample_key]
+
+        logger.info(
+            "TTModelRunner: trace_mode=%s, %s=%s",
+            self.trace_mode,
+            sample_key,
+            self.sample_on_device_mode,
+        )
+
+    def load_model(self) -> None:
+        loader = TTModelLoader(self.load_config)
+        self.model = loader.load_model(vllm_config=self.vllm_config,
+                                       model_config=self.model_config)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1,13 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from typing import TYPE_CHECKING, Optional
+
+import torch
 import ttnn
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.tt_loader import TTModelLoader
+from vllm.sequence import IntermediateTensors
 from vllm.utils import LayerBlockType
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
+from vllm.v1.outputs import ModelRunnerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
 
 logger = init_logger(__name__)
 
@@ -103,3 +111,12 @@ class TTModelRunner:
         # Allocate KV cache tensors.
         self.kv_caches = self.model.allocate_kv_cache(kv_cache_shape, dtype,
                                                       num_layers)
+
+    @torch.no_grad()
+    def execute_model(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+    ) -> ModelRunnerOutput:
+
+        raise NotImplementedError

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -12,7 +12,8 @@ from vllm.model_executor.model_loader.tt_loader import TTModelLoader
 from vllm.sequence import IntermediateTensors
 from vllm.utils import LayerBlockType
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
-from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
+from vllm.v1.worker.tt_input_batch import CachedRequestState, InputBatch
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -63,6 +64,15 @@ class TTModelRunner:
             self.sample_on_device_mode,
         )
 
+        # req_id -> (input_id -> encoder_output)
+        self.encoder_cache: dict[str, dict[int, torch.Tensor]] = {}
+
+        # Cached request states. Request states are tracked in the runner so
+        # they don't need to be re-sent every scheduling step. For requests
+        # that have been scheduled before, only the diff is received from
+        # the scheduler output.
+        self.requests: dict[str, CachedRequestState] = {}
+
     def load_model(self) -> None:
         loader = TTModelLoader(self.load_config)
         self.model = loader.load_model(vllm_config=self.vllm_config,
@@ -90,6 +100,19 @@ class TTModelRunner:
             assert len(kv_cache_tensor.shared_by) == 1, (
                 "KV cache shared by multiple layers is not supported for TT")
 
+        # Initialize persistent input batch with block size from kv_cache_spec.
+        # The persistent batch optimization reduces overhead between steps
+        # when consecutive batches contain mostly the same requests.
+        max_num_reqs = self.scheduler_config.max_num_seqs
+        max_model_len = self.model_config.max_model_len
+        max_num_batched_tokens = self.scheduler_config.max_num_batched_tokens
+        self.input_batch = InputBatch(
+            max_num_reqs=max_num_reqs,
+            max_model_len=max_model_len,
+            max_num_batched_tokens=max_num_batched_tokens,
+            block_sizes=[kv_cache_spec.block_size],
+        )
+
         # Make the assumption that we are tensor parallel by
         # min(number of devices, number of KV heads).
         # TODO: move this into model.allocate_kv_cache.
@@ -112,11 +135,146 @@ class TTModelRunner:
         self.kv_caches = self.model.allocate_kv_cache(kv_cache_shape, dtype,
                                                       num_layers)
 
+    def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
+        """Update the cached states and the persistent batch with the 
+        scheduler output.
+        The updated states are used in `_prepare_model_inputs` to create the 
+        input tensors for the model.
+        Based on _update_states for GPU/TPU backends.
+        """
+        # Remove finished requests from the cached states.
+        for req_id in scheduler_output.finished_req_ids:
+            self.requests.pop(req_id, None)
+            self.encoder_cache.pop(req_id, None)
+
+        # Remove the finished requests from the persistent batch.
+        # NOTE(woosuk): There could be an edge case where finished_req_ids and
+        # scheduled_req_ids overlap. This happens when a request is aborted and
+        # then resubmitted with the same ID. In this case, we treat them as two
+        # distinct requests - clearing the cached states for the first request
+        # and handling the second as a new request.
+        removed_req_indices: list[int] = []
+        for req_id in scheduler_output.finished_req_ids:
+            req_index = self.input_batch.remove_request(req_id)
+            if req_index is not None:
+                removed_req_indices.append(req_index)
+
+        # Free the cached encoder outputs.
+        for req_id, input_id in scheduler_output.free_encoder_input_ids:
+            encoder_outputs = self.encoder_cache.get(req_id)
+            if encoder_outputs is not None:
+                encoder_outputs.pop(input_id, None)
+                if not encoder_outputs:
+                    self.encoder_cache.pop(req_id, None)
+
+        # Remove the unscheduled requests from the persistent batch.
+        # NOTE(woosuk): The unscheduled requests are either preempted requests
+        # or running requests that are not scheduled in this step. We remove
+        # them from the persistent batch but keep their cached states since
+        # they will be scheduled again sometime in the future.
+        scheduled_req_ids = scheduler_output.num_scheduled_tokens.keys()
+        cached_req_ids = self.input_batch.req_id_to_index.keys()
+        unscheduled_req_ids = cached_req_ids - scheduled_req_ids
+        # NOTE(woosuk): The persistent batch optimization assumes that
+        # consecutive batches contain mostly the same requests. If batches
+        # have low request overlap (e.g., alternating between two distinct
+        # sets of requests), this optimization becomes very inefficient.
+        for req_id in unscheduled_req_ids:
+            req_index = self.input_batch.remove_request(req_id)
+            assert req_index is not None
+            removed_req_indices.append(req_index)
+
+        req_ids_to_add: list[str] = []
+        # Add new requests to the cached states.
+        for new_req_data in scheduler_output.scheduled_new_reqs:
+            assert new_req_data.sampling_params is not None,\
+                "Pooling is not supported for TT yet"
+            req_id = new_req_data.req_id
+            sampling_params = new_req_data.sampling_params
+
+            self.requests[req_id] = CachedRequestState(
+                req_id=req_id,
+                prompt_token_ids=new_req_data.prompt_token_ids,
+                mm_inputs=new_req_data.mm_inputs,
+                mm_positions=new_req_data.mm_positions,
+                sampling_params=sampling_params,
+                pooling_params=None,
+                generator=None,
+                block_ids=new_req_data.block_ids,
+                num_computed_tokens=new_req_data.num_computed_tokens,
+                output_token_ids=[],
+                lora_request=new_req_data.lora_request,
+            )
+
+            req_ids_to_add.append(req_id)
+
+        # Update the states of the running/resumed requests.
+        req_data = scheduler_output.scheduled_cached_reqs
+        for i, req_id in enumerate(req_data.req_ids):
+            req_state = self.requests[req_id]
+            num_computed_tokens = req_data.num_computed_tokens[i]
+            new_block_ids = req_data.new_block_ids[i]
+            resumed_from_preemption = req_data.resumed_from_preemption[i]
+
+            # Update the cached states.
+            req_state.num_computed_tokens = num_computed_tokens
+            if not resumed_from_preemption:
+                # Append the new blocks to the existing block IDs.
+                for block_ids, new_ids in zip(req_state.block_ids,
+                                              new_block_ids):
+                    block_ids.extend(new_ids)
+            else:
+                # The request is resumed from preemption.
+                # Replace the existing block IDs with the new ones.
+                req_state.block_ids = new_block_ids
+
+            req_index = self.input_batch.req_id_to_index.get(req_id)
+            if req_index is None:
+                # The request is not in the persistent batch.
+                # The request was either preempted and resumed later, or was not
+                # scheduled in the previous step and needs to be added again.
+                req_ids_to_add.append(req_id)
+                continue
+
+            # Update the persistent batch.
+            self.input_batch.num_computed_tokens_cpu[req_index] = (
+                num_computed_tokens)
+            self.input_batch.block_table.append_row(new_block_ids, req_index)
+
+        # Add the new or resumed requests to the persistent batch.
+        # The smaller empty indices are filled first.
+        removed_req_indices = sorted(removed_req_indices, reverse=True)
+        for req_id in req_ids_to_add:
+            req_state = self.requests[req_id]
+            if removed_req_indices:
+                # Fill the empty index.
+                req_index = removed_req_indices.pop()
+            else:
+                # Append to the end.
+                req_index = None
+            self.input_batch.add_request(req_state, req_index)
+
+        # Condense the batched states if there are empty indices.
+        if removed_req_indices:
+            self.input_batch.condense(removed_req_indices)
+
+    def _prepare_model_inputs(self, scheduler_output: "SchedulerOutput"):
+        raise NotImplementedError
+
     @torch.no_grad()
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> ModelRunnerOutput:
+        ''' Execute the model with the given scheduler output.'''
+
+        # Update cached state
+        self._update_states(scheduler_output)
+        if not scheduler_output.total_num_scheduled_tokens:
+            # Return empty ModelRunnerOutput if there's no work to do.
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        model_inputs = self._prepare_model_inputs(scheduler_output)
 
         raise NotImplementedError

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -6,6 +6,8 @@ import ttnn
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.tt_loader import TTModelLoader
+from vllm.utils import LayerBlockType
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
 
 logger = init_logger(__name__)
 
@@ -57,3 +59,47 @@ class TTModelRunner:
         loader = TTModelLoader(self.load_config)
         self.model = loader.load_model(vllm_config=self.vllm_config,
                                        model_config=self.model_config)
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """
+        Initialize KV cache based on `kv_cache_config`.
+        Args:
+            kv_cache_config: Configuration for the KV cache, including the KV
+            cache size of each layer
+        """
+
+        kv_cache_groups = kv_cache_config.kv_cache_groups
+        if len(kv_cache_groups) > 1:
+            raise NotImplementedError(
+                "Hybrid models with more than one KV cache type are not "
+                "supported yet.")
+        if isinstance(kv_cache_groups[0].kv_cache_spec, AttentionSpec):
+            kv_cache_spec = kv_cache_groups[0].kv_cache_spec
+        else:
+            raise TypeError("Expected AttentionSpec")
+
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            assert len(kv_cache_tensor.shared_by) == 1, (
+                "KV cache shared by multiple layers is not supported for TT")
+
+        # Make the assumption that we are tensor parallel by
+        # min(number of devices, number of KV heads).
+        # TODO: move this into model.allocate_kv_cache.
+        model_config = self.model_config
+        data_parallel = 1
+        if (self.model_config.override_tt_config
+                and "data_parallel" in model_config.override_tt_config):
+            data_parallel = model_config.override_tt_config["data_parallel"]
+        num_devices = self.mesh_device.get_num_devices() // data_parallel
+        total_kv_heads = kv_cache_spec.num_kv_heads
+        num_kv_heads = total_kv_heads // min(num_devices, total_kv_heads)
+
+        kv_cache_shape = (kv_cache_config.num_blocks, num_kv_heads,
+                          kv_cache_spec.block_size, kv_cache_spec.head_size)
+        dtype = kv_cache_spec.dtype
+        num_layers = model_config.get_num_layers_by_block_type(
+            self.parallel_config, LayerBlockType.attention)
+
+        # Allocate KV cache tensors.
+        self.kv_caches = self.model.allocate_kv_cache(kv_cache_shape, dtype,
+                                                      num_layers)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -55,14 +55,6 @@ class TTModelRunner:
         # Currently, TT model runner doesn't support chunked prefill.
         assert self.scheduler_config.chunked_prefill_enabled is False
 
-        if self.model_config.is_encoder_decoder:
-            raise NotImplementedError(
-                "Encoder-decoder models are not yet supported in V1 TT backend"
-            )
-        elif self.model_config.is_multimodal_model:
-            raise NotImplementedError(
-                "Multimodal models are not yet supported in V1 TT backend")
-
         self.mesh_device = mesh_device
         self.trace_mode = trace_mode
 

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -1,0 +1,50 @@
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.v1.worker.worker_base import WorkerBase
+from vllm.worker.tt_worker import open_mesh_device, close_mesh_device
+
+
+logger = init_logger(__name__)
+
+class TTWorker(WorkerBase):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        local_rank: int,
+        rank: int,
+        distributed_init_method: str,
+        is_driver_worker: bool = True,
+    ):
+        super().__init__(vllm_config, local_rank, rank, distributed_init_method, is_driver_worker)
+        
+        # initialized by init_device
+        self.mesh_device = None
+        
+        # whether to use ttnn tracing for model execution,
+        # TODO: make this configurable
+        self.trace_mode = True
+    
+    def init_device(self) -> None:
+        self.mesh_device = open_mesh_device(
+            self.model_config.override_tt_config,
+            self.trace_mode
+        )
+        self.device_config.device = self.mesh_device
+        
+    def load_model(self):
+        raise NotImplementedError
+        
+    ## Destructor (used to close devices)
+
+    def __del__(self):
+        # Delete model runner first in case there are model arifacts
+        del self.model_runner
+
+        if self.mesh_device:
+            close_mesh_device(self.mesh_device, self.model_config.override_tt_config)
+            del self.mesh_device
+
+        if hasattr(super(), '__del__'):
+            super().__del__()  # type: ignore
+    

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -1,13 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
+from vllm.v1.kv_cache_interface import KVCacheSpec
+from vllm.v1.worker.tt_model_runner import TTModelRunner
 from vllm.v1.worker.worker_base import WorkerBase
-from vllm.worker.tt_worker import open_mesh_device, close_mesh_device
-
+from vllm.worker.tt_worker import close_mesh_device, open_mesh_device
 
 logger = init_logger(__name__)
 
+
 class TTWorker(WorkerBase):
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -16,25 +21,40 @@ class TTWorker(WorkerBase):
         distributed_init_method: str,
         is_driver_worker: bool = True,
     ):
-        super().__init__(vllm_config, local_rank, rank, distributed_init_method, is_driver_worker)
-        
-        # initialized by init_device
+        super().__init__(vllm_config, local_rank, rank,
+                         distributed_init_method, is_driver_worker)
+
+        # Initialized by init_device
         self.mesh_device = None
-        
-        # whether to use ttnn tracing for model execution,
-        # TODO: make this configurable
+
+        # Whether to use ttnn tracing for model execution
+        override_tt_config = self.model_config.override_tt_config
+        trace_key = "trace_mode"
         self.trace_mode = True
-    
+        if override_tt_config and trace_key in override_tt_config:
+            assert override_tt_config[trace_key] in [True, False], \
+                f"Invalid {trace_key}: {override_tt_config[trace_key]}"
+            self.trace_mode = override_tt_config[trace_key]
+
     def init_device(self) -> None:
         self.mesh_device = open_mesh_device(
-            self.model_config.override_tt_config,
-            self.trace_mode
-        )
+            self.model_config.override_tt_config, self.trace_mode)
         self.device_config.device = self.mesh_device
-        
+
+        # Init ModelRunner here, so that we have access to self.mesh_device.
+        self.model_runner: TTModelRunner = TTModelRunner(
+            vllm_config=self.vllm_config,
+            mesh_device=self.mesh_device,
+            trace_mode=self.trace_mode,
+        )
+
     def load_model(self):
+        self.model_runner.load_model()
+
+    def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
+        """Get specifications for KV cache implementation."""
         raise NotImplementedError
-        
+
     ## Destructor (used to close devices)
 
     def __del__(self):
@@ -42,9 +62,9 @@ class TTWorker(WorkerBase):
         del self.model_runner
 
         if self.mesh_device:
-            close_mesh_device(self.mesh_device, self.model_config.override_tt_config)
+            close_mesh_device(self.mesh_device,
+                              self.model_config.override_tt_config)
             del self.mesh_device
 
         if hasattr(super(), '__del__'):
             super().__del__()  # type: ignore
-    

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -150,7 +150,7 @@ class TTWorker(WorkerBase):
     ## Destructor (used to close devices)
 
     def __del__(self):
-        # Delete model runner first in case there are model arifacts
+        # Delete model runner first in case there are model artifacts
         with suppress(AttributeError):
             # attributes may be already torn down when destructor is called
             del self.model_runner

--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 import dataclasses
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Type, Union
@@ -152,7 +154,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
         # instead of selecting from default vllm loaders
         loader = TTModelLoader(self.load_config)
 
-        self.model = loader.load_model(vllm_config=self.vllm_config)
+        self.model = loader.load_model(vllm_config=self.vllm_config,
+                                       model_config=self.model_config)
         if self.model_config.is_encoder_decoder:
             self.max_cross_blocks = (self.model.max_cross_attn_tokens //
                                      self.cache_config.block_size)

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -429,17 +429,8 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
 # TT-NN utilities, also used by V1 TTWorker
 
 
-def get_dispatch_core_type():
-    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
-    if ("WH_ARCH_YAML" in os.environ) and os.environ[
-            "WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
-        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
-    return dispatch_core_type
-
-
-def get_dispatch_core_config(override_tt_config, device_params):
-    dispatch_core_type = get_dispatch_core_type()
-
+def get_dispatch_core_config(override_tt_config):
+    dispatch_core_axis: ttnn.DispatchCoreAxis = None
     if (override_tt_config is not None
             and "dispatch_core_axis" in override_tt_config):
         assert override_tt_config["dispatch_core_axis"] in [
@@ -450,16 +441,8 @@ def get_dispatch_core_config(override_tt_config, device_params):
         dispatch_core_axis = (ttnn.DispatchCoreAxis.COL
                               if override_tt_config["dispatch_core_axis"]
                               == "col" else ttnn.DispatchCoreAxis.ROW)
-    else:
-        dispatch_core_axis = device_params.pop(
-            "dispatch_core_axis",
-            ttnn.DispatchCoreAxis.COL if "blackhole" in ttnn.get_arch_name()
-            else ttnn.DispatchCoreAxis.ROW,
-        )
 
-    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type,
-                                                   dispatch_core_axis)
-    return dispatch_core_config
+    return ttnn.DispatchCoreConfig(axis=dispatch_core_axis)
 
 
 def get_fabric_config(override_tt_config):
@@ -553,8 +536,7 @@ def open_mesh_device(override_tt_config, trace_mode):
 
     mesh_device = ttnn.open_mesh_device(
         ttnn.MeshShape(*mesh_grid),
-        dispatch_core_config=get_dispatch_core_config(override_tt_config,
-                                                      device_params),
+        dispatch_core_config=get_dispatch_core_config(override_tt_config),
         **device_params,
     )
     logger.info("multidevice with %d devices and grid %s is created",

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 import dataclasses
 import math
 import os
@@ -177,9 +179,7 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
     def init_device(self) -> None:
         self.mesh_device = open_mesh_device(
-            self.model_config.override_tt_config,
-            self.trace_mode
-        )
+            self.model_config.override_tt_config, self.trace_mode)
         self.device_config.device = self.mesh_device
 
     def load_model(self):
@@ -399,7 +399,8 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         del self.model_runner
 
         if self.mesh_device:
-            close_mesh_device(self.mesh_device, self.model_config.override_tt_config)
+            close_mesh_device(self.mesh_device,
+                              self.model_config.override_tt_config)
             del self.mesh_device
 
         if hasattr(super(), '__del__'):
@@ -408,12 +409,14 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
 
 # TT-NN utilities, also used by V1 TTWorker
 
+
 def get_dispatch_core_type():
     dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
     if ("WH_ARCH_YAML" in os.environ) and os.environ[
             "WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
         dispatch_core_type = ttnn.device.DispatchCoreType.ETH
     return dispatch_core_type
+
 
 def get_dispatch_core_config(override_tt_config, device_params):
     dispatch_core_type = get_dispatch_core_type()
@@ -426,18 +429,19 @@ def get_dispatch_core_config(override_tt_config, device_params):
             f"{override_tt_config['dispatch_core_axis']}. "
             "Expected: row, col.")
         dispatch_core_axis = (ttnn.DispatchCoreAxis.COL
-                                if override_tt_config["dispatch_core_axis"]
-                                == "col" else ttnn.DispatchCoreAxis.ROW)
+                              if override_tt_config["dispatch_core_axis"]
+                              == "col" else ttnn.DispatchCoreAxis.ROW)
     else:
         dispatch_core_axis = device_params.pop(
             "dispatch_core_axis",
-            ttnn.DispatchCoreAxis.COL if "blackhole"
-            in ttnn.get_arch_name() else ttnn.DispatchCoreAxis.ROW,
+            ttnn.DispatchCoreAxis.COL if "blackhole" in ttnn.get_arch_name()
+            else ttnn.DispatchCoreAxis.ROW,
         )
 
     dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type,
-                                                    dispatch_core_axis)
+                                                   dispatch_core_axis)
     return dispatch_core_config
+
 
 def get_fabric_config(override_tt_config):
     if (override_tt_config is not None
@@ -457,6 +461,7 @@ def get_fabric_config(override_tt_config):
         return fabric_config
     return None
 
+
 # From tt-metal/conftest.py:
 # Set fabric config to passed in value
 # Do nothing if not set
@@ -465,6 +470,7 @@ def set_fabric(override_tt_config):
     fabric_config = get_fabric_config(override_tt_config)
     if fabric_config:
         ttnn.set_fabric_config(fabric_config)
+
 
 # From tt-metal/conftest.py:
 # Reset fabric config to DISABLED if not None, and do nothing otherwise
@@ -477,6 +483,7 @@ def reset_fabric(override_tt_config):
     if fabric_config:
         ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
 
+
 def device_params_from_override_tt_config(override_tt_config, trace_mode):
     device_params = {}
 
@@ -488,10 +495,10 @@ def device_params_from_override_tt_config(override_tt_config, trace_mode):
                 "trace_region_size"]
 
     if override_tt_config and "worker_l1_size" in override_tt_config:
-        device_params["worker_l1_size"] = override_tt_config[
-            "worker_l1_size"]
+        device_params["worker_l1_size"] = override_tt_config["worker_l1_size"]
 
     return device_params
+
 
 def open_mesh_device(override_tt_config, trace_mode):
     num_devices_available = len(ttnn.get_device_ids())
@@ -519,19 +526,22 @@ def open_mesh_device(override_tt_config, trace_mode):
         assert (f"Requested mesh grid shape {mesh_grid} is larger than "
                 f"number of available devices {num_devices_available}")
 
-    device_params = device_params_from_override_tt_config(override_tt_config, trace_mode)
+    device_params = device_params_from_override_tt_config(
+        override_tt_config, trace_mode)
 
     # Set fabric before opening the device
     set_fabric(override_tt_config)
 
     mesh_device = ttnn.open_mesh_device(
         ttnn.MeshShape(*mesh_grid),
-        dispatch_core_config=get_dispatch_core_config(override_tt_config, device_params),
+        dispatch_core_config=get_dispatch_core_config(override_tt_config,
+                                                      device_params),
         **device_params,
     )
     logger.info("multidevice with %d devices and grid %s is created",
                 mesh_device.get_num_devices(), mesh_grid)
     return mesh_device
+
 
 def close_mesh_device(mesh_device, override_tt_config):
     # Dump device profiler

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -176,7 +176,10 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         return self.tt_cache
 
     def init_device(self) -> None:
-        self.mesh_device = self._open_mesh_device()
+        self.mesh_device = open_mesh_device(
+            self.model_config.override_tt_config,
+            self.trace_mode
+        )
         self.device_config.device = self.mesh_device
 
     def load_model(self):
@@ -389,136 +392,6 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         # output is List[SamplerOutput]
         return output
 
-    # TT-NN utilities
-
-    def _get_dispatch_core_type(self):
-        dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
-        if ("WH_ARCH_YAML" in os.environ) and os.environ[
-                "WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
-            dispatch_core_type = ttnn.device.DispatchCoreType.ETH
-        return dispatch_core_type
-
-    def _get_dispatch_core_config(self, device_params):
-        dispatch_core_type = self._get_dispatch_core_type()
-
-        override_tt_config = self.model_config.override_tt_config
-        if (override_tt_config is not None
-                and "dispatch_core_axis" in override_tt_config):
-            assert override_tt_config["dispatch_core_axis"] in [
-                "row", "col"
-            ], ("Invalid dispatch_core_axis:"
-                f"{override_tt_config['dispatch_core_axis']}. "
-                "Expected: row, col.")
-            dispatch_core_axis = (ttnn.DispatchCoreAxis.COL
-                                  if override_tt_config["dispatch_core_axis"]
-                                  == "col" else ttnn.DispatchCoreAxis.ROW)
-        else:
-            dispatch_core_axis = device_params.pop(
-                "dispatch_core_axis",
-                ttnn.DispatchCoreAxis.COL if "blackhole"
-                in ttnn.get_arch_name() else ttnn.DispatchCoreAxis.ROW,
-            )
-
-        dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type,
-                                                       dispatch_core_axis)
-        return dispatch_core_config
-
-    def _get_fabric_config(self):
-        override_tt_config = self.model_config.override_tt_config
-        if (override_tt_config is not None
-                and "fabric_config" in override_tt_config):
-            fabric_config_str = override_tt_config["fabric_config"]
-            fabric_config_map = {
-                "DISABLED": ttnn.FabricConfig.DISABLED,
-                "FABRIC_1D": ttnn.FabricConfig.FABRIC_1D,
-                "FABRIC_1D_RING": ttnn.FabricConfig.FABRIC_1D_RING,
-                "FABRIC_2D": ttnn.FabricConfig.FABRIC_2D,
-                "CUSTOM": ttnn.FabricConfig.CUSTOM,
-            }
-            fabric_config = fabric_config_map.get(fabric_config_str)
-            assert fabric_config is not None, (
-                f"Invalid fabric_config: {fabric_config_str}. "
-                f"Expected one of {list(fabric_config_map.keys())}.")
-            return fabric_config
-        return None
-
-    # From tt-metal/conftest.py:
-    # Set fabric config to passed in value
-    # Do nothing if not set
-    # Must be called before creating the mesh device
-    def _set_fabric(self):
-        fabric_config = self._get_fabric_config()
-        if fabric_config:
-            ttnn.set_fabric_config(fabric_config)
-
-    # From tt-metal/conftest.py:
-    # Reset fabric config to DISABLED if not None, and do nothing otherwise
-    # Temporarily require previous state to be passed
-    # in as even setting it to DISABLED might be unstable
-    # This is to ensure that we don't propagate
-    # the instability to the rest of CI
-    def _reset_fabric(self):
-        fabric_config = self._get_fabric_config()
-        if fabric_config:
-            ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
-
-    def _device_params_from_override_tt_config(self):
-        override_tt_config = self.model_config.override_tt_config
-        device_params = {}
-
-        if self.trace_mode:
-            # Set the most common value as default, override later
-            device_params["trace_region_size"] = 25000000
-            if override_tt_config and "trace_region_size" in override_tt_config:
-                device_params["trace_region_size"] = override_tt_config[
-                    "trace_region_size"]
-
-        if override_tt_config and "worker_l1_size" in override_tt_config:
-            device_params["worker_l1_size"] = override_tt_config[
-                "worker_l1_size"]
-
-        return device_params
-
-    def _open_mesh_device(self):
-        num_devices_available = len(ttnn.get_device_ids())
-        mesh_grid_dict = {
-            "N150": (1, 1),
-            "P100": (1, 1),
-            "P150": (1, 1),
-            "P150x2": (1, 2),
-            "N300": (1, 2),
-            "P300": (1, 2),
-            "N150x4": (1, 4),
-            "P150x4": (1, 4),
-            "T3K": (1, 8),
-            "TG": (8, 4)
-        }
-        mesh_device_env = os.environ.get("MESH_DEVICE")
-        if mesh_device_env is not None:
-            assert mesh_device_env in mesh_grid_dict, (
-                f"Invalid MESH_DEVICE: {mesh_device_env}")
-            mesh_grid = mesh_grid_dict[mesh_device_env]
-        else:
-            mesh_grid = (1, num_devices_available)
-
-        if mesh_grid[0] * mesh_grid[1] > num_devices_available:
-            assert (f"Requested mesh grid shape {mesh_grid} is larger than "
-                    f"number of available devices {num_devices_available}")
-
-        device_params = self._device_params_from_override_tt_config()
-
-        # Set fabric before opening the device
-        self._set_fabric()
-
-        mesh_device = ttnn.open_mesh_device(
-            ttnn.MeshShape(*mesh_grid),
-            dispatch_core_config=self._get_dispatch_core_config(device_params),
-            **device_params,
-        )
-        logger.info("multidevice with %d devices and grid %s is created",
-                    mesh_device.get_num_devices(), mesh_grid)
-        return mesh_device
-
     ## Destructor (used to close devices)
 
     def __del__(self):
@@ -526,16 +399,146 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         del self.model_runner
 
         if self.mesh_device:
-            # Dump device profiler
-            ttnn.DumpDeviceProfiler(self.mesh_device)
-
-            # Close devices
-            ttnn.close_mesh_device(self.mesh_device)
-
-            # Reset fabric
-            self._reset_fabric()
-
+            close_mesh_device(self.mesh_device, self.model_config.override_tt_config)
             del self.mesh_device
 
         if hasattr(super(), '__del__'):
             super().__del__()  # type: ignore
+
+
+# TT-NN utilities, also used by V1 TTWorker
+
+def get_dispatch_core_type():
+    dispatch_core_type = ttnn.device.DispatchCoreType.WORKER
+    if ("WH_ARCH_YAML" in os.environ) and os.environ[
+            "WH_ARCH_YAML"] == "wormhole_b0_80_arch_eth_dispatch.yaml":
+        dispatch_core_type = ttnn.device.DispatchCoreType.ETH
+    return dispatch_core_type
+
+def get_dispatch_core_config(override_tt_config, device_params):
+    dispatch_core_type = get_dispatch_core_type()
+
+    if (override_tt_config is not None
+            and "dispatch_core_axis" in override_tt_config):
+        assert override_tt_config["dispatch_core_axis"] in [
+            "row", "col"
+        ], ("Invalid dispatch_core_axis:"
+            f"{override_tt_config['dispatch_core_axis']}. "
+            "Expected: row, col.")
+        dispatch_core_axis = (ttnn.DispatchCoreAxis.COL
+                                if override_tt_config["dispatch_core_axis"]
+                                == "col" else ttnn.DispatchCoreAxis.ROW)
+    else:
+        dispatch_core_axis = device_params.pop(
+            "dispatch_core_axis",
+            ttnn.DispatchCoreAxis.COL if "blackhole"
+            in ttnn.get_arch_name() else ttnn.DispatchCoreAxis.ROW,
+        )
+
+    dispatch_core_config = ttnn.DispatchCoreConfig(dispatch_core_type,
+                                                    dispatch_core_axis)
+    return dispatch_core_config
+
+def get_fabric_config(override_tt_config):
+    if (override_tt_config is not None
+            and "fabric_config" in override_tt_config):
+        fabric_config_str = override_tt_config["fabric_config"]
+        fabric_config_map = {
+            "DISABLED": ttnn.FabricConfig.DISABLED,
+            "FABRIC_1D": ttnn.FabricConfig.FABRIC_1D,
+            "FABRIC_1D_RING": ttnn.FabricConfig.FABRIC_1D_RING,
+            "FABRIC_2D": ttnn.FabricConfig.FABRIC_2D,
+            "CUSTOM": ttnn.FabricConfig.CUSTOM,
+        }
+        fabric_config = fabric_config_map.get(fabric_config_str)
+        assert fabric_config is not None, (
+            f"Invalid fabric_config: {fabric_config_str}. "
+            f"Expected one of {list(fabric_config_map.keys())}.")
+        return fabric_config
+    return None
+
+# From tt-metal/conftest.py:
+# Set fabric config to passed in value
+# Do nothing if not set
+# Must be called before creating the mesh device
+def set_fabric(override_tt_config):
+    fabric_config = get_fabric_config(override_tt_config)
+    if fabric_config:
+        ttnn.set_fabric_config(fabric_config)
+
+# From tt-metal/conftest.py:
+# Reset fabric config to DISABLED if not None, and do nothing otherwise
+# Temporarily require previous state to be passed
+# in as even setting it to DISABLED might be unstable
+# This is to ensure that we don't propagate
+# the instability to the rest of CI
+def reset_fabric(override_tt_config):
+    fabric_config = get_fabric_config(override_tt_config)
+    if fabric_config:
+        ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
+
+def device_params_from_override_tt_config(override_tt_config, trace_mode):
+    device_params = {}
+
+    if trace_mode:
+        # Set the most common value as default, override later
+        device_params["trace_region_size"] = 25000000
+        if override_tt_config and "trace_region_size" in override_tt_config:
+            device_params["trace_region_size"] = override_tt_config[
+                "trace_region_size"]
+
+    if override_tt_config and "worker_l1_size" in override_tt_config:
+        device_params["worker_l1_size"] = override_tt_config[
+            "worker_l1_size"]
+
+    return device_params
+
+def open_mesh_device(override_tt_config, trace_mode):
+    num_devices_available = len(ttnn.get_device_ids())
+    mesh_grid_dict = {
+        "N150": (1, 1),
+        "P100": (1, 1),
+        "P150": (1, 1),
+        "P150x2": (1, 2),
+        "N300": (1, 2),
+        "P300": (1, 2),
+        "N150x4": (1, 4),
+        "P150x4": (1, 4),
+        "T3K": (1, 8),
+        "TG": (8, 4)
+    }
+    mesh_device_env = os.environ.get("MESH_DEVICE")
+    if mesh_device_env is not None:
+        assert mesh_device_env in mesh_grid_dict, (
+            f"Invalid MESH_DEVICE: {mesh_device_env}")
+        mesh_grid = mesh_grid_dict[mesh_device_env]
+    else:
+        mesh_grid = (1, num_devices_available)
+
+    if mesh_grid[0] * mesh_grid[1] > num_devices_available:
+        assert (f"Requested mesh grid shape {mesh_grid} is larger than "
+                f"number of available devices {num_devices_available}")
+
+    device_params = device_params_from_override_tt_config(override_tt_config, trace_mode)
+
+    # Set fabric before opening the device
+    set_fabric(override_tt_config)
+
+    mesh_device = ttnn.open_mesh_device(
+        ttnn.MeshShape(*mesh_grid),
+        dispatch_core_config=get_dispatch_core_config(override_tt_config, device_params),
+        **device_params,
+    )
+    logger.info("multidevice with %d devices and grid %s is created",
+                mesh_device.get_num_devices(), mesh_grid)
+    return mesh_device
+
+def close_mesh_device(mesh_device, override_tt_config):
+    # Dump device profiler
+    ttnn.DumpDeviceProfiler(mesh_device)
+
+    # Close devices
+    ttnn.close_mesh_device(mesh_device)
+
+    # Reset fabric
+    reset_fabric(override_tt_config)

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -372,7 +372,7 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
     ## Destructor (used to close devices)
 
     def __del__(self):
-        # Delete model runner first in case there are model arifacts
+        # Delete model runner first in case there are model artifacts
         with suppress(AttributeError):
             # attributes may be already torn down when destructor is called
             del self.model_runner

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -153,9 +153,14 @@ class TTWorker(LoRANotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             self.cache_dtype = STR_DTYPE_TO_TORCH_DTYPE[
                 self.cache_config.cache_dtype]
 
-        # whether to use ttnn tracing for model execution,
-        # TODO: make this configurable
+        # Whether to use ttnn tracing for model execution
+        override_tt_config = self.model_config.override_tt_config
+        trace_key = "trace_mode"
         self.trace_mode = True
+        if override_tt_config and trace_key in override_tt_config:
+            assert override_tt_config[trace_key] in [True, False], \
+                f"Invalid {trace_key}: {override_tt_config[trace_key]}"
+            self.trace_mode = override_tt_config[trace_key]
 
         self.model_runner: TTModelRunner = TTModelRunner(
             vllm_config=vllm_config,


### PR DESCRIPTION
- This PR adds the initial version of the TT V1 backend, which currently only supports text-only non-DP models and can be enabled by setting `VLLM_USE_V1=1` and `--num_scheduler_steps 1`. It is disabled by default for now, but will be made the default in a later PR. Updated readme to include instructions.
- The V1 TT backend does not use the default V1 scheduler as we currently do not support chunked prefill / mixed prefill-decode batches. Instead, the Ascend plugin's prefill-first (V0-like) scheduler has been added at `vllm/v1/core/sched/ascend_scheduler.py` and plugged into the TT backend. This is subject to change in the future, particularly if a V0-like scheduler is added in-tree to vLLM upstream.
- Added V1 `TTWorker` at `vllm/v1/worker/tt_worker.py`. Device management code has been commonized with V0 backend. Code for determining number of kv cache blocks has been commonized with V0 backend. In `get_kv_cache_spec`, only the `FullAttentionSpec` is supported currently, other attention specs will be added later.
- Added V1 `TTModelRunner` at `vllm/v1/worker/tt_model_runner.py`. Unlike V0 model runner, cached states of requests and persistent batch are managed manually in `_update_states` (similar to GPU/TPU backends), and there is no multi-step logic (since that is a V0 feature). 
- Added V1 persistent batch class `InputBatch` at `vllm/v1/worker/tt_input_batch.py`, which is a simplified version of the input batch classes from the GPU/TPU backends, without most of the sampling options (to be added later).
- Added `GlobalStatLogger` class to `vllm/v1/metrics/loggers.py` and integrated in V1 `LLMEngine` for measuring decode/prefill performance across a full generation (until no more unfinished requests) with offline_inference_tt.py script.
- Updated torch requirements from 2.7.0 to 2.7.1.

vLLM nightly tests (only testing for now that no existing functionality has been broken, as V1 is still disabled by default): https://github.com/tenstorrent/tt-metal/actions/runs/17959304189