### PR TITLE
Fix DP KV cache slot tracking to cleanup orphaned slots during decode where safe

### DIFF
--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -289,13 +289,12 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
             multi_modal_kwargs = {"images": []}
         cross_block_tables_list: List[List[int]] = []
 
-        # For DP KV cache: Build seq_groups_list FIRST before any cleanup
+        # create seq_groups_list before any cleanup to active batch slots
         for seq_group_metadata in seq_group_metadata_list:
-            seq_ids = list(seq_group_metadata.seq_data.keys())
-            assert len(seq_ids) == 1, (
+            _seq_ids = list(seq_group_metadata.seq_data.keys())
+            assert len(_seq_ids) == 1, (
                 "Currently only supporting one sequence per request group")
-            seq_id = seq_ids[0]
-            seq_groups_list.append(seq_id)
+            seq_groups_list.append(_seq_ids[0])
 
         if self.dp_kv_cache and finished_requests_ids is not None:
             # Delete finished requests from req_id_to_seq_id
@@ -320,6 +319,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                     break
 
         for seq_group_metadata in seq_group_metadata_list:
+            seq_ids = list(seq_group_metadata.seq_data.keys())
+            seq_id = seq_ids[0]
             if self.dp_kv_cache:
                 # Add new request id to req_id_to_seq_id
                 self.req_id_to_seq_id[seq_group_metadata.request_id] = seq_id


### PR DESCRIPTION
## Purpose

Addresses issues:
* https://github.com/tenstorrent/vllm/issues/145
* https://github.com/tenstorrent/vllm/issues/166

@rdraskicTT is this related to https://github.com/tenstorrent/vllm/tree/rdraskic/fix-dp-slot-bug?

## Test Plan

These changes pass the repros for https://github.com/tenstorrent/vllm/issues/145 and https://github.com/tenstorrent/vllm/issues/166
tt-metal: https://github.com/tenstorrent/tt-metal/commit/473248d 
from https://github.com/tstescoTT/llm-repro-scripts?tab=readme-ov-file#repro_concurrent_llm_requestspy

Running vLLM server:
```
export MESH_DEVICE=TG
export VLLM_TARGET_DEVICE=tt
export TT_LLAMA_TEXT_VER=llama3_70b_galaxy
export LLAMA_DIR=/home/container_app_user/cache_root/model_file_symlinks_map/Llama3.3-70B-Instruct
VLLM_RPC_TIMEOUT=900000 python examples/server_example_tt.py --model "meta-llama/Llama-3.3-70B-Instruct" --max-log-len 32 --override_tt_config '{"dispatch_core_axis": "col", "always_compat_sampling": true, "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 171103232}' --num_scheduler_steps 1 --enable-auto-tool-choice true --tool-call-parser "llama3_json"
```

repro test
```
curl -L -o repro_concurrent_llm_requests.py https://raw.githubusercontent.com/tstescoTT/llm-repro-scripts/refs/heads/main/repro_concurrent_llm_requests.py
# run with timeouts to abort on vLLM server and inter batch delay 
python3 repro_concurrent_llm_requests.py --concurrency 32 --loops 20 --timeout 2 --batch-delay 3
python3 repro_concurrent_llm_requests.py --concurrency 32 --loops 10 --timeout 0.1 --batch-delay 0 --skip-trace
python3 repro_concurrent_llm_requests.py --concurrency 32 --loops 10 --timeout 0.1 --batch-delay 1 --skip-trace
python3 repro_concurrent_llm_requests.py --concurrency 4 --loops 20 --timeout 0.1 --batch-delay 0 --skip-trace
python3 repro_concurrent_llm_requests.py --concurrency 32 --loops 200 --timeout 600 --batch-delay 0 --skip-trace
```

long-stress test
```
python3 repro_concurrent_llm_requests.py --concurrency 32 --loops 100000 --timeout 6000 --batch-delay 0
```

## Test Result


Passing repro test scripts and stress test. Repro test still showing some cases where sequences are orphaned and sometimes need to be cleaned up. Recommend keeping the warning logs.

```
...
INFO 09-29 21:25:28 [engine.py:339] Added request chatcmpl-ce8c3fb3b468470681d2395ea035f5ae.
INFO 09-29 21:25:28 [engine.py:339] Added request chatcmpl-b5c97e0d3c974f19a2ea086caa3047e2.
INFO 09-29 21:25:28 [engine.py:339] Added request chatcmpl-c99d28299cd74a5db40a73910dd437ae.
INFO 09-29 21:25:28 [engine.py:339] Added request chatcmpl-20fd118200e340feb903cb398804de05.
WARNING 09-29 21:25:28 [tt_model_runner.py:536] SLOT_DEBUG: Detected 1 orphaned sequences: [545]
WARNING 09-29 21:25:28 [tt_model_runner.py:537] SLOT_DEBUG: These sequences have slots but are not in current batch
DEBUG 09-29 21:25:28 [tt_model_runner.py:558] SLOT_DEBUG: Sufficient slots available, deferring cleanup to decode phase
DEBUG 09-29 21:25:28 [tt_model_runner.py:560] SLOT_DEBUG: After cleanup - empty_slots (len=31)=[17, 18, 19, 20, 21, 22, 23, 31, 0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 8, 9, 10, 11, 12, 13, 14, 15]
DEBUG 09-29 21:25:28 [tt_model_runner.py:561] SLOT_DEBUG: After cleanup - seq_groups_to_batch_slot={545: 16}
```
