### PR TITLE
For multimodal inputs use prompt instead of tokens

### DIFF
--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -940,6 +940,7 @@ class OpenAIServing:
                 prompt_token_ids=request_prompt)
 
         engine_prompt = EngineTokensPrompt(
+            prompt=prompt_inputs["prompt"],
             prompt_token_ids=prompt_inputs["prompt_token_ids"])
         if mm_data is not None:
             engine_prompt["multi_modal_data"] = mm_data

--- a/vllm/inputs/data.py
+++ b/vllm/inputs/data.py
@@ -39,6 +39,9 @@ class TextPrompt(TypedDict):
 class TokensPrompt(TypedDict):
     """Schema for a tokenized prompt."""
 
+    prompt: str
+    """The original input text with applied chat template."""
+
     prompt_token_ids: list[int]
     """A list of token IDs to pass to the model."""
 

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -350,13 +350,14 @@ class InputPreprocessor:
         lora_request: Optional[LoRARequest] = None,
         return_mm_hashes: bool = False,
     ) -> Union[TokenInputs, MultiModalInputs]:
+        prompt = parsed_content["prompt"]
         prompt_token_ids = parsed_content["prompt_token_ids"]
         token_type_ids = parsed_content.get("token_type_ids")
 
         inputs: Union[TokenInputs, MultiModalInputs]
         if multi_modal_data := parsed_content.get("multi_modal_data"):
             inputs = self._process_multimodal(
-                prompt_token_ids,
+                prompt,
                 multi_modal_data,
                 parsed_content.get("mm_processor_kwargs"),
                 tokenization_kwargs=tokenization_kwargs,


### PR DESCRIPTION
Follow up the workaround from tt-metal: https://github.com/tenstorrent/tt-metal/pull/28910
I found out that the same workaround exists in vLLM main: https://github.com/vllm-project/vllm/pull/21353

If we propagate the original prompt and use it for multimodal input processing, we will align the expectations by Processors implementations in Transformers library (expecting string(s) instead of tokens)
