### PR TITLE
Update trace region size in README for Llama 70b Galaxy

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -102,7 +102,7 @@ MESH_DEVICE=T3K python examples/offline_inference_tt.py --measure_perf
 The command to run Llama70B on Galaxy is:
 
 ```sh
-MESH_DEVICE=TG LLAMA_DIR=<path to weights> TT_LLAMA_TEXT_VER="llama3_70b_galaxy" python examples/offline_inference_tt.py --model "meta-llama/Llama-3.1-70B-Instruct" --override_tt_config '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D", "worker_l1_size": 1344544, "trace_region_size": 62000000}'
+MESH_DEVICE=TG LLAMA_DIR=<path to weights> TT_LLAMA_TEXT_VER="llama3_70b_galaxy" python examples/offline_inference_tt.py --model "meta-llama/Llama-3.1-70B-Instruct" --override_tt_config '{"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D", "worker_l1_size": 1344544, "trace_region_size": 184915840}'
 ```
 
 ### Llama-3.2 (11B and 90B) and Qwen-2.5-VL (32B and 72B) Vision models


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Purpose of this PR is to update the trace region size specified in the vLLM read me the region size needed to be increased because during prefill we must run warm up iterations to capture prefill traces for all sequence lengths which requires more memory in our trace region. We should update the README to reflect this change so that people who run the model will not get trace region errors.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

