### PR TITLE
Pad sampling params to max_batch_size and permute in batch order for DP models 

### DIFF
--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -408,17 +408,14 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                 pass
             elif (TTPlatform.non_greedy_decoding_on_device
                   and perform_device_sampling):
-                # non-uniform sampling - supports per-request sampling params
-                temp = sampling_params.temperature
-                top_k = sampling_params.top_k
-                top_p = sampling_params.top_p
+                # non greedy actually means
+                # that it also supports non-uniform sampling
+                # initializing an empty list for each value on first iter
+                # fill values after first iter
+                for key in ["temperature", "top_k", "top_p"]:
+                    top_pk_sampling_params.setdefault(key, []).append(
+                        getattr(sampling_params, key))
 
-                # Collect per-request sampling params as lists for
-                # permutation support
-                top_pk_sampling_params.setdefault("temperature",
-                                                  []).append(temp)
-                top_pk_sampling_params.setdefault("top_k", []).append(top_k)
-                top_pk_sampling_params.setdefault("top_p", []).append(top_p)
             else:
                 # uniform sampling - all requests must have same params
                 if len(top_pk_sampling_params) == 0:


### PR DESCRIPTION
https://github.com/tenstorrent/vllm/issues/225

This PR enhances sampling parameter handling for the TT model runner to support per-request sampling parameters with proper permutation when using data parallel KV cache. The changes enable non-uniform sampling across requests in a batch by maintaining sampling parameters as lists and applying the same permutation logic used for tokens and page tables.

Key Changes:

Introduced default value overrides for sampling parameters when temperature > 0 to improve sampling behavior
Modified sampling parameter collection to always use lists for permutation support
Added padding logic for sampling parameters in decode mode to match max_num_seqs
Implemented permutation of sampling parameters during DP KV cache reordering
