### PR TITLE
Add support for cached rope deltas needed in V1 for Qwen25_VL.

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -70,6 +70,8 @@ class TTModelRunner:
         # Detect if the model has "mrope" rope_scaling type.
         # mrope requires keeping "rope_deltas" between prefill/decode phases.
         self.request_specific_rope = bool(self.model_config.uses_mrope)
+        if self.request_specific_rope:
+            self.previous_req_ids: set[str] = set()
 
         # Because of multiprocessing, the config-dependent
         # class attributes might not have been set in this process,
@@ -853,13 +855,19 @@ class TTModelRunner:
             # TODO: Add encoder-decoder support
             enc_dec_kwargs: dict[str, Any] = {}
             if self.request_specific_rope:
-                # Gather and pass rope_deltas from prefill step to decode
-                enc_dec_kwargs = {
-                    "rope_deltas_all_users": [
-                        self.requests[req_id].mrope_position_delta
-                        for req_id in self.input_batch.req_ids
-                    ]
-                }
+                if any(req_id not in self.previous_req_ids
+                       for req_id in self.input_batch.req_ids):
+                    # Gather and pass rope_deltas from prefill step to decode
+                    enc_dec_kwargs = {
+                        "rope_deltas_all_users": [
+                            self.requests[req_id].mrope_position_delta
+                            for req_id in self.input_batch.req_ids
+                        ]
+                    }
+                else:
+                    enc_dec_kwargs = {"rope_deltas_all_users": None}
+                self.previous_req_ids = set(self.input_batch.req_ids)
+
             tt_out = self.model.decode_forward(**kwargs,
                                                **enc_dec_kwargs,
                                                enable_trace=self.trace_mode,


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
https://github.com/tenstorrent/vllm/issues/231
Add support for cached rope deltas needed in V1 for Qwen25_VL.

Related PR in tt-metal: https://github.com/tenstorrent/tt-metal/pull/33347

## Test Plan
CI

## Test Result
https://github.com/tenstorrent/tt-metal/actions/runs/19859950135

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

