### PR TITLE
Explicitly pass async_read=False to read_decode_output in V0 model runner when not expecting async reads

### DIFF
--- a/vllm/worker/tt_model_runner.py
+++ b/vllm/worker/tt_model_runner.py
@@ -1387,7 +1387,8 @@ class TTModelRunner(ModelRunnerBase[TTModelInput]):
                     tt_out, async_read=True)
             else:
                 # outputs ttnn host tensors
-                tt_out = self.model.read_decode_output(tt_out)
+                tt_out = self.model.read_decode_output(tt_out,
+                                                       async_read=False)
                 # outputs torch tensor
                 tt_out = self.model.process_decode_output_host(
                     tt_out, is_tokens=model_input.perform_device_sampling)


### PR DESCRIPTION
- Issue & fix discovered by @viktorpusTT
- In the V0 model runner, read_decode_output was being called without passing in async_read in the non-async path, assuming the model defaults to False (true for TT-Transformers, but not Llama70B-GLX).
- vLLM nightly (v0 only tests) - https://github.com/tenstorrent/tt-metal/actions/runs/20311384041