### PR TITLE
Add link to TT readme in main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Find the full list of supported models [here](https://docs.vllm.ai/en/latest/mod
 
 ## Getting Started
 
-**⚠️ Running on Tenstorrent hardware**: To use vLLM with Tenstorrent hardware, please follow the instructions in [tt_metal/README.md](https://github.com/tenstorrent/vllm/blob/dev/tt_metal/README.md).
+**⚠️ Running on Tenstorrent hardware**: To use vLLM with Tenstorrent hardware, please follow the instructions in [tt_metal/README.md](https://github.com/tenstorrent/vllm/blob/dev/tt_metal/README.md) (Note: `dev` is the main development branch).
 
 Install vLLM with `pip` or [from source](https://docs.vllm.ai/en/latest/getting_started/installation/gpu/index.html#build-wheel-from-source):
 


### PR DESCRIPTION
- Users were having difficulty finding the TT readme; link it in the main vLLM readme on the main branch.