### PR TITLE
Lower max-tokens for Llama8B-N150 to 32k since 64k was causing OOM with ISL 1K

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -97,7 +97,7 @@ MESH_DEVICE=T3K python examples/offline_inference_tt.py --measure_perf
 - `"llama2_70b"` for the old Llama implementation
 
 **Note 4 (Other Models)**: By default, the inference example will run with Llama-3.1-70B. To run with other Llama models, or Qwen-2.5, ensure that the apprioriate environment variables are set as per the [demo instructions](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers), then set `MESH_DEVICE=<device>` (valid options for `<device>` are `N150`, `N300`, `T3K`, or `TG`) or the mesh_shape (eg, "(4,8)", "(4,4)") and one of the following:
-- Llama-3.1-8B: `--model "meta-llama/Llama-3.1-8B"` (Note that on N150, `--max_model_len 65536` must be set for this model, see the [tt_transformers demo](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers) for details about the max context length)
+- Llama-3.1-8B: `--model "meta-llama/Llama-3.1-8B"` (Note that on N150, `--max_model_len 32768` must be set for this model, see the [tt_transformers demo](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers) for details about the max context length)
 - Llama-3.2-1B: `--model "meta-llama/Llama-3.2-1B"`
 - Llama-3.2-3B: `--model "meta-llama/Llama-3.2-3B"`
 - Qwen-2.5-7B: `--model "Qwen/Qwen2.5-7B"` (currently only supported on N300)

--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -430,10 +430,14 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
     is_wormhole = "wormhole_b0" in ttnn.get_arch_name()
     num_devices_per_model = (device_config.num_devices // data_parallel)
 
-    if (("Llama-3.1-8B" in model_config.model or "Mistral-7B"
-         in model_config.model or "gemma-3-4b" in model_config.model)
-            and num_devices_per_model == 1 and is_wormhole):
-        # Llama8B, Mistral7B, and gemma3-4b on N150
+    if ("Llama-3.1-8B" in model_config.model and num_devices_per_model == 1
+            and is_wormhole):
+        # Llama8B on N150
+        max_tokens_all_users = 32768
+    elif (("Mistral-7B" in model_config.model
+           or "gemma-3-4b" in model_config.model)
+          and num_devices_per_model == 1 and is_wormhole):
+        # Mistral7B, and gemma3-4b on N150
         max_tokens_all_users = 65536
     elif (("DeepSeek-R1-Distill-Qwen-14B" in model_config.model
            or "Qwen2.5-14B" in model_config.model)


### PR DESCRIPTION
- Issue: https://github.com/tenstorrent/vllm/issues/285
- 64K tokens in kv cache for Llama8B causes OOM for short ISL (1K). Max chunk size cannot be lowered further, so lowering max tokens in kv cache to 32k until the model can support more blocks.
- Corresponding tt-metal PR - https://github.com/tenstorrent/tt-metal/pull/34913.
- vLLM nightly - https://github.com/tenstorrent/tt-metal/actions/runs/20440472321