### PR TITLE
Explicitly set PyTorch CPU-only index so that we can install with uv and not break vLLM CI on Metal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -356,3 +356,17 @@ extend-ignore-re = []
 windo = "windo"
 
 [tool.typos.type.vimscript.extend-words]
+
+[tool.uv.sources]
+torch = { index = "pytorch-cpu-only" }
+
+# Install torch only from from cpu-only index
+# explicit here means packages in tool.uv.sources must specifically
+# request this index if they would like to use it. The only thing
+# we want to use from it is the torch package. We had issues with certain
+# packages not falling back to PyPI. Some of those packages didn't have the
+# version we needed
+[[tool.uv.index]]
+name = "pytorch-cpu-only"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true


### PR DESCRIPTION
…
<!-- markdownlint-disable -->

## Purpose

vLLM installation broke on Metal CI: https://github.com/tenstorrent/tt-metal/actions/runs/20986819672

because of a recent change to use `uv` across the CI stack.

We set an extra index to get the CPU-only torch release.

`uv` does something defensive, where it looks at packages in the extra index. If it doesn't find a package we need, it just dies.

Why does this not need a change to the current install script? Because we don't use uv in the install script. We can change this in a separate PR.

## Test Plan

Central commands:

```
git clone https://github.com/tenstorrent/vllm --branch <target branch>
uv pip install vllm
```

- [ ] Run locally in a docker container 
- [ ] Run vLLM Metal CI on my branch without the extra index
- [ ] Merge this into dev
- [ ] Change command on Metal side to have no extra index!

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

