### PR TITLE
Modify TT-vLLM install script to use uv pip after tt-metal venv changes

### DIFF
--- a/tt_metal/install-vllm-tt.sh
+++ b/tt_metal/install-vllm-tt.sh
@@ -1,3 +1,2 @@
 export VLLM_TARGET_DEVICE="tt"
-pip3 install --upgrade pip
-pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu
+uv pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match


### PR DESCRIPTION
- tt-metal has been modified to install with uv pip instead of pip in https://github.com/tenstorrent/tt-metal/pull/35707
- Modified tt_metal/install-vllm-tt.sh to use uv pip