### PR TITLE
Fix OoM for Qwen3-8B on N150

### DIFF
--- a/vllm/worker/tt_worker.py
+++ b/vllm/worker/tt_worker.py
@@ -434,6 +434,10 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
             and is_wormhole):
         # Llama8B on N150
         max_tokens_all_users = 32768
+    elif ("Qwen3-8B" in model_config.model and devices_per_dp_cache == 1
+          and is_wormhole):
+        # Qwen3-8B on N150 (same constraint as Llama8B-N150)
+        max_tokens_all_users = 32768
     elif (("Mistral-7B" in model_config.model
            or "gemma-3-4b" in model_config.model) and devices_per_dp_cache == 1
           and is_wormhole):


### PR DESCRIPTION
Related to https://github.com/tenstorrent/tt-inference-server/issues/1869

Add max_tokens_all_users constraint (32768) for Qwen3-8B on N150. Without this, the default large value (131072) is used, causing DRAM out-of-memory error when running Qwen3-8B on N150 device.

I believe this issue is same as https://github.com/tenstorrent/vllm/pull/289