### PR TITLE
V1 support for remaining sampling parameters

### DIFF
--- a/tests/tt/test_host_only_params.py
+++ b/tests/tt/test_host_only_params.py
@@ -6,7 +6,8 @@ Tests for sampling parameters which require host ("compat") sampling.
 Note: Custom user-provided logits_processors are NOT supported in V1.
 V1 only supports built-in logits processors (min_p, logit_bias, min_tokens)
 which are configured via their respective sampling parameters.
-This has been added to V1 since the version we have checked out.
+This has been added to V1 since the version we have checked out
+around https://github.com/vllm-project/vllm/pull/19912.
 """
 
 import string

--- a/tests/tt/test_host_only_params.py
+++ b/tests/tt/test_host_only_params.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Tests for v1 sampling parameters.
+Tests for sampling parameters which require host ("compat") sampling.
 
 Note: Custom user-provided logits_processors are NOT supported in V1.
 V1 only supports built-in logits processors (min_p, logit_bias, min_tokens)
@@ -11,87 +11,10 @@ This has been added to V1 since the version we have checked out.
 
 import string
 
-import pytest
-
 from tests.tt.utils import RequestConfig, run_concurrent_batch
 
 
-class TestV1Sampling:
-    """
-    Verify v1 sampling parameters work correctly via the OpenAI API.
-    """
-
-    @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1, 1.5])
-    @pytest.mark.parametrize("num_logprobs", [1, 3, 5, 10])
-    def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
-                      batch_fraction, num_logprobs):
-        """Test logprobs parameter returns actual logprobs data.
-
-        Parametrized by batch size to verify logprobs work correctly across
-        all DP ranks. On multi-device setups (num_devices > 1), logprobs can
-        be computed on device. On single-device setups, logprobs fall back to
-        host sampling.
-
-        Note: Device-sampled logprobs only include the sampled token's logprob,
-        not top-k alternatives or ranks. Host-sampled logprobs include full
-        top-k alternatives and ranks.
-
-        batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
-        num_logprobs: number of top logprobs alternatives to return
-        """
-        if batch_fraction == 0:
-            num_requests = 1
-        else:
-            num_requests = max(1, int(max_batch_size * batch_fraction))
-
-        # Use return_tokens_as_token_ids to ensure unique keys in top_logprobs
-        # dict. Without this, different token IDs that decode to the same
-        # string would collide, reducing the count below num_logprobs.
-        configs = [
-            RequestConfig(prompt=f"Count from {i}: ",
-                          max_tokens=10,
-                          logprobs=num_logprobs,
-                          return_tokens_as_token_ids=True)
-            for i in range(num_requests)
-        ]
-        results = run_concurrent_batch(tt_server,
-                                       tt_model_name,
-                                       configs,
-                                       return_full_response=True)
-        assert len(results) == len(configs)
-
-        # Verify ALL responses have valid logprobs (catches DP rank issues)
-        for i, response in enumerate(results):
-            choice = response.choices[0]
-
-            # Verify logprobs are returned for every request
-            assert choice.logprobs is not None, \
-                f"logprobs should be returned for request {i}"
-            assert choice.logprobs.tokens is not None, \
-                f"logprobs.tokens should exist for request {i}"
-            assert len(choice.logprobs.tokens) > 0, \
-                f"should have at least one token for request {i}"
-
-            # Verify top_logprobs contains the requested number of alternatives
-            assert choice.logprobs.top_logprobs is not None, \
-                f"top_logprobs should be returned for request {i}"
-            assert len(choice.logprobs.top_logprobs) > 0, \
-                f"should have top_logprobs for tokens for request {i}"
-            # Each position should have up to num_logprobs+1 alternatives
-            for j, top_lp in enumerate(choice.logprobs.top_logprobs):
-                assert len(top_lp) >= num_logprobs, \
-                    f"request {i}, token {j}: should have at least " \
-                    f"{num_logprobs} alternatives per token"
-                assert len(top_lp) <= num_logprobs + 1, \
-                    f"request {i}, token {j}: should have at most " \
-                    f"{num_logprobs+1} alternatives per token"
-
-            # Verify actual logprob values exist (not just structure)
-            assert choice.logprobs.token_logprobs is not None, \
-                f"request {i}: token_logprobs is None"
-            for j, lp in enumerate(choice.logprobs.token_logprobs):
-                assert lp is not None, \
-                    f"request {i}, token {j}: logprob value is None"
+class TestHostOnlyParameters:
 
     def test_min_p(self, tt_server, tt_model_name, max_batch_size):
         """Test min_p parameter (smoke test - verifies it doesn't error)."""

--- a/tests/tt/test_logprobs.py
+++ b/tests/tt/test_logprobs.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+
+from tests.tt.utils import RequestConfig, run_concurrent_batch
+
+
+class TestLogprobs:
+
+    @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1, 1.5])
+    @pytest.mark.parametrize("num_logprobs", [1, 3, 5, 10])
+    def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
+                      batch_fraction, num_logprobs):
+        """Test logprobs parameter returns actual logprobs data.
+
+        Parametrized by batch size to verify logprobs work correctly across
+        all DP ranks. On multi-device setups (num_devices > 1), logprobs can
+        be computed on device. On single-device setups, logprobs fall back to
+        host sampling.
+
+        Note: Device-sampled logprobs only include the sampled token's logprob,
+        not top-k alternatives or ranks. Host-sampled logprobs include full
+        top-k alternatives and ranks.
+
+        batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
+        num_logprobs: number of top logprobs alternatives to return
+        """
+        if batch_fraction == 0:
+            num_requests = 1
+        else:
+            num_requests = max(1, int(max_batch_size * batch_fraction))
+
+        # Use return_tokens_as_token_ids to ensure unique keys in top_logprobs
+        # dict. Without this, different token IDs that decode to the same
+        # string would collide, reducing the count below num_logprobs.
+        configs = [
+            RequestConfig(prompt=f"Count from {i}: ",
+                          max_tokens=10,
+                          logprobs=num_logprobs,
+                          return_tokens_as_token_ids=True)
+            for i in range(num_requests)
+        ]
+        results = run_concurrent_batch(tt_server,
+                                       tt_model_name,
+                                       configs,
+                                       return_full_response=True)
+        assert len(results) == len(configs)
+
+        # Verify ALL responses have valid logprobs (catches DP rank issues)
+        for i, response in enumerate(results):
+            choice = response.choices[0]
+
+            # Verify logprobs are returned for every request
+            assert choice.logprobs is not None, \
+                f"logprobs should be returned for request {i}"
+            assert choice.logprobs.tokens is not None, \
+                f"logprobs.tokens should exist for request {i}"
+            assert len(choice.logprobs.tokens) > 0, \
+                f"should have at least one token for request {i}"
+
+            # Verify top_logprobs contains the requested number of alternatives
+            assert choice.logprobs.top_logprobs is not None, \
+                f"top_logprobs should be returned for request {i}"
+            assert len(choice.logprobs.top_logprobs) > 0, \
+                f"should have top_logprobs for tokens for request {i}"
+            # Each position should have up to num_logprobs+1 alternatives
+            for j, top_lp in enumerate(choice.logprobs.top_logprobs):
+                assert len(top_lp) >= num_logprobs, \
+                    f"request {i}, token {j}: should have at least " \
+                    f"{num_logprobs} alternatives per token"
+                assert len(top_lp) <= num_logprobs + 1, \
+                    f"request {i}, token {j}: should have at most " \
+                    f"{num_logprobs+1} alternatives per token"
+
+            # Verify actual logprob values exist (not just structure)
+            assert choice.logprobs.token_logprobs is not None, \
+                f"request {i}: token_logprobs is None"
+            for j, lp in enumerate(choice.logprobs.token_logprobs):
+                assert lp is not None, \
+                    f"request {i}, token {j}: logprob value is None"

--- a/tests/tt/test_logprobs.py
+++ b/tests/tt/test_logprobs.py
@@ -13,16 +13,8 @@ class TestLogprobs:
                       batch_fraction, num_logprobs):
         """Test logprobs parameter returns actual logprobs data.
 
-        Parametrized by batch size to verify logprobs work correctly across
-        all DP ranks. On multi-device setups (num_devices > 1), logprobs can
-        be computed on device. On single-device setups, logprobs fall back to
-        host sampling.
-
-        Note: Device-sampled logprobs only include the sampled token's logprob,
-        not top-k alternatives or ranks. Host-sampled logprobs include full
-        top-k alternatives and ranks.
-
-        batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
+        batch_fraction: 1.5 = one and a half batches, 1 = full batch, 
+            0.5 = half batch, 0 = single request
         num_logprobs: number of top logprobs alternatives to return
         """
         if batch_fraction == 0:

--- a/tests/tt/test_tt_penalties.py
+++ b/tests/tt/test_tt_penalties.py
@@ -14,7 +14,7 @@ class TestRepetitionPenalty:
         """
         Each request has different repetition penalty.
         """
-        prompt = "hello hello hello hello. Say: "
+        prompt = "a a a a a a a a a"
         penalties = [0.1, 0.2, 0.5, 1.0, 1.5, 2.0, 3.0][:max_batch_size]
 
         # Requests otherwise reproducible
@@ -24,7 +24,6 @@ class TestRepetitionPenalty:
                 max_tokens=10,
                 temperature=0,
                 repetition_penalty=penalty,
-                seed=42,
             ) for penalty in penalties
         ]
 
@@ -36,7 +35,7 @@ class TestRepetitionPenalty:
     # Caught https://github.com/tenstorrent/vllm/issues/286
     def test_repetition_penalty_mixed_batch(self, tt_server, tt_model_name,
                                             max_batch_size):
-        prompt = "test test test test. Word: "
+        prompt = "a a a a a a a a a"
 
         configs = []
         for i in range(max_batch_size):
@@ -48,7 +47,6 @@ class TestRepetitionPenalty:
                         max_tokens=10,
                         temperature=0,
                         repetition_penalty=1.0,
-                        seed=42,
                     ))
             else:
                 # High penalty
@@ -58,7 +56,6 @@ class TestRepetitionPenalty:
                         max_tokens=10,
                         temperature=0,
                         repetition_penalty=2.0,
-                        seed=42,
                     ))
 
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -81,17 +78,16 @@ class TestPresencePenalty:
 
     def test_different_presence_penalties(self, tt_server, tt_model_name,
                                           max_batch_size):
-        prompt = "test test test test. Word: "
+        prompt = "a b c a b c a b c"
         penalties = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5,
                      2.0][:max_batch_size]
 
         configs = [
             RequestConfig(
                 prompt=prompt,
-                max_tokens=30,
-                temperature=0.7,
+                max_tokens=40,
+                temperature=0,
                 presence_penalty=penalty,
-                seed=42,
             ) for penalty in penalties
         ]
 
@@ -102,17 +98,17 @@ class TestPresencePenalty:
 
     def test_presence_penalty_mixed_batch(self, tt_server, tt_model_name,
                                           max_batch_size):
-        prompt = "test test test test. Word: "
-
+        # Presence penalty is only applied once regardless of the repetition,
+        # so we use a weaker prompt for more even logits
+        prompt = "a b c a b c a b c"
         configs = []
         for i in range(max_batch_size):
             configs.append(
                 RequestConfig(
                     prompt=prompt,
-                    max_tokens=20,
-                    temperature=0.5,
+                    max_tokens=40,
+                    temperature=0,
                     presence_penalty=0.0 if i % 2 == 0 else 2.0,
-                    seed=42,
                 ))
 
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -135,7 +131,7 @@ class TestFrequencyPenalty:
 
     def test_different_frequency_penalties(self, tt_server, tt_model_name,
                                            max_batch_size):
-        prompt = "5 5 5 5. Continue: "
+        prompt = "5 5 5 5 5 5 5 5"
 
         penalties = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5,
                      2.0][:max_batch_size]
@@ -144,9 +140,8 @@ class TestFrequencyPenalty:
             RequestConfig(
                 prompt=prompt,
                 max_tokens=20,
-                temperature=0.5,
+                temperature=0,
                 frequency_penalty=penalty,
-                seed=42,
             ) for penalty in penalties
         ]
 
@@ -157,7 +152,7 @@ class TestFrequencyPenalty:
 
     def test_frequency_penalty_mixed_batch(self, tt_server, tt_model_name,
                                            max_batch_size):
-        prompt = "a a a a. Letter: "
+        prompt = "a a a a a a a a a"
 
         configs = []
         for i in range(max_batch_size):
@@ -165,9 +160,8 @@ class TestFrequencyPenalty:
                 RequestConfig(
                     prompt=prompt,
                     max_tokens=15,
-                    temperature=0.5,
+                    temperature=0,
                     frequency_penalty=0.0 if i % 2 == 0 else 2.0,
-                    seed=42,
                 ))
 
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -175,9 +169,15 @@ class TestFrequencyPenalty:
         no_penalty = [results[i] for i in range(0, max_batch_size, 2)]
         with_penalty = [results[i] for i in range(1, max_batch_size, 2)]
 
+        # Count "a"s in each output
+        no_penalty_a_count = no_penalty[0].count("a")
+        with_penalty_a_count = with_penalty[0].count("a")
+
+        assert no_penalty_a_count > with_penalty_a_count, (
+            f"Frequency penalty should reduce 'a' repetitions: "
+            f"no_penalty={no_penalty_a_count}, with_penalty={with_penalty_a_count}"
+        )
         assert_deterministic(no_penalty,
                              "No penalty requests should be identical.")
         assert_deterministic(with_penalty,
                              "With penalty requests should be identical.")
-        assert_varied([no_penalty[0], with_penalty[0]], 2,
-                      "Penalty should change output.")

--- a/tests/tt/test_tt_penalties.py
+++ b/tests/tt/test_tt_penalties.py
@@ -175,8 +175,8 @@ class TestFrequencyPenalty:
 
         assert no_penalty_a_count > with_penalty_a_count, (
             f"Frequency penalty should reduce 'a' repetitions: "
-            f"no_penalty={no_penalty_a_count}, with_penalty={with_penalty_a_count}"
-        )
+            f"no_penalty={no_penalty_a_count},"
+            f"with_penalty={with_penalty_a_count}")
         assert_deterministic(no_penalty,
                              "No penalty requests should be identical.")
         assert_deterministic(with_penalty,

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -19,7 +19,7 @@ class TestV1Sampling:
     Verify v1 sampling parameters work correctly via the OpenAI API.
     """
 
-    @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1])
+    @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1, 1.5])
     def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
                       batch_fraction):
         """Test logprobs parameter returns actual logprobs data.
@@ -80,6 +80,15 @@ class TestV1Sampling:
         """Test min_p parameter (smoke test - verifies it doesn't error)."""
         configs = [
             RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.1),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.2),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.3),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.4),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.5),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.6),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.7),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.8),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.9),
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=1.0),
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
         assert len(results) == len(configs)
@@ -111,6 +120,14 @@ class TestV1Sampling:
         configs = [
             RequestConfig(prompt="Logit bias: ", max_tokens=10,
                           logit_bias={1: 0.1}),
+            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+                          logit_bias={4: 0.2}),
+            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+                          logit_bias={2: 0.3}),
+            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+                          logit_bias={16: 0.4}),
+            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+                          logit_bias={7: 0.5}),
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
         assert len(results) == len(configs)
@@ -121,12 +138,23 @@ class TestV1Sampling:
         configs = [
             RequestConfig(prompt="Allowed: ", max_tokens=10,
                           allowed_token_ids=[1, 2, 3]),
+            RequestConfig(prompt="Allowed: ", max_tokens=10,
+                          allowed_token_ids=[4, 5, 6]),
+            RequestConfig(prompt="Allowed: ", max_tokens=10,
+                          allowed_token_ids=[7, 8, 9]),
+            RequestConfig(prompt="Allowed: ", max_tokens=10,
+                          allowed_token_ids=[10, 11, 12]),
+            RequestConfig(prompt="Allowed: ", max_tokens=10,
+                          allowed_token_ids=[13, 14, 15]),
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
         assert len(results) == len(configs)
         # With only 3 allowed tokens, output should be limited
-        assert results[0] is not None, \
-            "should produce output with allowed_token_ids"
+        for i, result in enumerate(results):
+            assert result is not None, \
+                f"should produce output for request {i}"
+            assert len(result) > 0, \
+                f"should produce non-empty output for request {i}"
 
     def test_min_tokens(self, tt_server, tt_model_name, max_batch_size):
         """Test min_tokens parameter ensures minimum output length."""

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -20,8 +20,9 @@ class TestV1Sampling:
     """
 
     @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1, 1.5])
+    @pytest.mark.parametrize("num_logprobs", [1, 3, 5, 10])
     def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
-                      batch_fraction):
+                      batch_fraction, num_logprobs):
         """Test logprobs parameter returns actual logprobs data.
 
         Parametrized by batch size to verify logprobs work correctly across
@@ -34,8 +35,8 @@ class TestV1Sampling:
         top-k alternatives and ranks.
 
         batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
+        num_logprobs: number of top logprobs alternatives to return
         """
-        num_logprobs = 5
         if batch_fraction == 0:
             num_requests = 1
         else:
@@ -184,50 +185,3 @@ class TestV1Sampling:
         assert response.usage.completion_tokens >= min_tokens, \
             f"should produce at least {min_tokens} tokens, " \
             f"got {response.usage.completion_tokens}"
-
-    @pytest.mark.parametrize("temperature", [0.0, 0.8, 1.5])
-    def test_logprobs_with_sampling(self, tt_server, tt_model_name,
-                                    max_batch_size, temperature):
-        """Test logprobs work with different sampling temperatures.
-
-        On multi-device setups, this tests that logprobs work with both:
-        - Greedy sampling (temperature=0.0) on device
-        - Random sampling (temperature > 0.0) on device
-
-        Device-sampled logprobs only include the sampled token's logprob,
-        not top-k alternatives, but should still be valid values.
-        """
-        num_requests = max(1, max_batch_size // 2)
-        configs = [
-            RequestConfig(
-                prompt=f"Random text {i}: ",
-                max_tokens=5,
-                logprobs=1,
-                temperature=temperature,
-            )
-            for i in range(num_requests)
-        ]
-        results = run_concurrent_batch(tt_server, tt_model_name, configs,
-                                       return_full_response=True)
-        assert len(results) == len(configs)
-
-        # Verify all responses have valid logprobs
-        for i, response in enumerate(results):
-            choice = response.choices[0]
-            assert choice.logprobs is not None, \
-                f"request {i}: logprobs should be returned"
-            assert choice.logprobs.token_logprobs is not None, \
-                f"request {i}: token_logprobs should exist"
-            assert len(choice.logprobs.token_logprobs) > 0, \
-                f"request {i}: should have logprobs for tokens"
-
-            # Verify logprob values are reasonable (not dummy values)
-            for j, lp in enumerate(choice.logprobs.token_logprobs):
-                assert lp is not None, \
-                    f"request {i}, token {j}: logprob is None"
-                # Log probabilities should be <= 0 (log of probability <= 1)
-                assert lp <= 0.0, \
-                    f"request {i}, token {j}: logprob {lp} should be <= 0"
-                # Sanity check: should not be extremely low (e.g., not -1000)
-                assert lp > -100.0, \
-                    f"request {i}, token {j}: logprob {lp} seems invalid"

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -138,10 +138,11 @@ class TestV1Sampling:
             # Check if any bad word appears as a whole word (case-insensitive)
             for bad_word in bad_words:
                 assert bad_word not in words, \
-                    f"bad_word '{bad_word}' found as whole word in response {i}: {text!r}"
+                    f"bad_word '{bad_word}' found as whole word" \
+                    f"in response {i}: {text!r}"
 
     def test_logit_bias(self, tt_server, tt_model_name, max_batch_size):
-        """Test logit_bias parameter (smoke test - verifies it doesn't error)."""
+        """Test logit_bias parameter (smoke test)."""
         configs = [
             RequestConfig(prompt="Logit bias: ",
                           max_tokens=10,

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for v1 sampling parameters.
+
+Note: Custom user-provided logits_processors are NOT supported in V1.
+V1 only supports built-in logits processors (min_p, logit_bias, min_tokens)
+which are configured via their respective sampling parameters.
+This has been added to V1 since the version we have checked out.
+"""
+
+from tests.tt.utils import RequestConfig, run_concurrent_batch
+
+
+class TestV1Sampling:
+    """
+    Verify v1 sampling parameters work correctly via the OpenAI API.
+    """
+
+    def test_logprobs(self, tt_server, tt_model_name, max_batch_size):
+        """Test logprobs parameter returns actual logprobs data."""
+        num_logprobs = 5
+        configs = [
+            RequestConfig(prompt="Count: ", max_tokens=10, logprobs=num_logprobs),
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+                                       return_full_response=True)
+        assert len(results) == len(configs)
+
+        response = results[0]
+        choice = response.choices[0]
+
+        # Verify logprobs are returned
+        assert choice.logprobs is not None, "logprobs should be returned"
+        assert choice.logprobs.tokens is not None, "logprobs.tokens should exist"
+        assert len(choice.logprobs.tokens) > 0, "should have at least one token"
+
+        # Verify top_logprobs contains the requested number of alternatives
+        assert choice.logprobs.top_logprobs is not None, \
+            "top_logprobs should be returned"
+        assert len(choice.logprobs.top_logprobs) > 0, \
+            "should have top_logprobs for tokens"
+        # Each position should have up to num_logprobs+1 alternatives
+        for top_lp in choice.logprobs.top_logprobs:
+            assert len(top_lp) <= num_logprobs + 1, \
+                f"should have at most {num_logprobs+1} alternatives per token"
+
+    def test_min_p(self, tt_server, tt_model_name, max_batch_size):
+        """Test min_p parameter (smoke test - verifies it doesn't error)."""
+        configs = [
+            RequestConfig(prompt="Random: ", max_tokens=10, min_p=0.1),
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs)
+        assert len(results) == len(configs)
+        # min_p affects sampling distribution - just verify we get output
+        assert results[0] is not None and len(results[0]) > 0, \
+            "should produce non-empty output"
+
+    def test_bad_words(self, tt_server, tt_model_name, max_batch_size):
+        """Test bad_words parameter prevents specified words from appearing."""
+        bad_words = ["hello", "Hello", "hi", "Hi", "hey", "Hey"]
+        configs = [
+            # Run multiple times with high temperature to increase coverage
+            RequestConfig(prompt="Say hello to me", max_tokens=20,
+                          bad_words=bad_words, temperature=1.0, seed=i)
+            for i in range(5)
+        ]
+        # bad_words is only available in chat completions API
+        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+                                       use_chat=True)
+        assert len(results) == len(configs)
+
+        for i, text in enumerate(results):
+            for bad_word in bad_words:
+                assert bad_word not in text, \
+                    f"bad_word '{bad_word}' found in response {i}: {text!r}"
+
+    def test_logit_bias(self, tt_server, tt_model_name, max_batch_size):
+        """Test logit_bias parameter (smoke test - verifies it doesn't error)."""
+        configs = [
+            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+                          logit_bias={1: 0.1}),
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs)
+        assert len(results) == len(configs)
+        assert results[0] is not None, "should produce output with logit_bias"
+
+    def test_allowed_token_ids(self, tt_server, tt_model_name, max_batch_size):
+        """Test allowed_token_ids parameter (smoke test)."""
+        configs = [
+            RequestConfig(prompt="Allowed: ", max_tokens=10,
+                          allowed_token_ids=[1, 2, 3]),
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs)
+        assert len(results) == len(configs)
+        # With only 3 allowed tokens, output should be limited
+        assert results[0] is not None, \
+            "should produce output with allowed_token_ids"
+
+    def test_min_tokens(self, tt_server, tt_model_name, max_batch_size):
+        """Test min_tokens parameter ensures minimum output length."""
+        min_tokens = 5
+        configs = [
+            # Use a prompt that might naturally produce short output
+            RequestConfig(prompt="Say OK.", max_tokens=20, min_tokens=min_tokens),
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+                                       return_full_response=True)
+        assert len(results) == len(configs)
+
+        response = results[0]
+        # Check usage stats for token count
+        assert response.usage is not None, "usage stats should be returned"
+        assert response.usage.completion_tokens >= min_tokens, \
+            f"should produce at least {min_tokens} tokens, " \
+            f"got {response.usage.completion_tokens}"

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -23,12 +23,16 @@ class TestV1Sampling:
     def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
                       batch_fraction):
         """Test logprobs parameter returns actual logprobs data.
-        
+
         Parametrized by batch size to verify logprobs work correctly across
-        all DP ranks. In DP mode, logprobs are computed on rank 0 and must
-        be properly distributed to all ranks. Testing with full batch size
-        maximizes coverage across DP ranks.
-        
+        all DP ranks. On multi-device setups (num_devices > 1), logprobs can
+        be computed on device. On single-device setups, logprobs fall back to
+        host sampling.
+
+        Note: Device-sampled logprobs only include the sampled token's logprob,
+        not top-k alternatives or ranks. Host-sampled logprobs include full
+        top-k alternatives and ranks.
+
         batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
         """
         num_logprobs = 5
@@ -37,9 +41,13 @@ class TestV1Sampling:
         else:
             num_requests = max(1, int(max_batch_size * batch_fraction))
         
+        # Use return_tokens_as_token_ids to ensure unique keys in top_logprobs
+        # dict. Without this, different token IDs that decode to the same
+        # string would collide, reducing the count below num_logprobs.
         configs = [
             RequestConfig(prompt=f"Count from {i}: ", max_tokens=10,
-                          logprobs=num_logprobs)
+                          logprobs=num_logprobs,
+                          return_tokens_as_token_ids=True)
             for i in range(num_requests)
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs,
@@ -65,6 +73,9 @@ class TestV1Sampling:
                 f"should have top_logprobs for tokens for request {i}"
             # Each position should have up to num_logprobs+1 alternatives
             for j, top_lp in enumerate(choice.logprobs.top_logprobs):
+                assert len(top_lp) >= num_logprobs, \
+                    f"request {i}, token {j}: should have at least " \
+                    f"{num_logprobs} alternatives per token"
                 assert len(top_lp) <= num_logprobs + 1, \
                     f"request {i}, token {j}: should have at most " \
                     f"{num_logprobs+1} alternatives per token"
@@ -173,3 +184,50 @@ class TestV1Sampling:
         assert response.usage.completion_tokens >= min_tokens, \
             f"should produce at least {min_tokens} tokens, " \
             f"got {response.usage.completion_tokens}"
+
+    @pytest.mark.parametrize("temperature", [0.0, 0.8, 1.5])
+    def test_logprobs_with_sampling(self, tt_server, tt_model_name,
+                                    max_batch_size, temperature):
+        """Test logprobs work with different sampling temperatures.
+
+        On multi-device setups, this tests that logprobs work with both:
+        - Greedy sampling (temperature=0.0) on device
+        - Random sampling (temperature > 0.0) on device
+
+        Device-sampled logprobs only include the sampled token's logprob,
+        not top-k alternatives, but should still be valid values.
+        """
+        num_requests = max(1, max_batch_size // 2)
+        configs = [
+            RequestConfig(
+                prompt=f"Random text {i}: ",
+                max_tokens=5,
+                logprobs=1,
+                temperature=temperature,
+            )
+            for i in range(num_requests)
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+                                       return_full_response=True)
+        assert len(results) == len(configs)
+
+        # Verify all responses have valid logprobs
+        for i, response in enumerate(results):
+            choice = response.choices[0]
+            assert choice.logprobs is not None, \
+                f"request {i}: logprobs should be returned"
+            assert choice.logprobs.token_logprobs is not None, \
+                f"request {i}: token_logprobs should exist"
+            assert len(choice.logprobs.token_logprobs) > 0, \
+                f"request {i}: should have logprobs for tokens"
+
+            # Verify logprob values are reasonable (not dummy values)
+            for j, lp in enumerate(choice.logprobs.token_logprobs):
+                assert lp is not None, \
+                    f"request {i}, token {j}: logprob is None"
+                # Log probabilities should be <= 0 (log of probability <= 1)
+                assert lp <= 0.0, \
+                    f"request {i}, token {j}: logprob {lp} should be <= 0"
+                # Sanity check: should not be extremely low (e.g., not -1000)
+                assert lp > -100.0, \
+                    f"request {i}, token {j}: logprob {lp} seems invalid"

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -9,8 +9,9 @@ which are configured via their respective sampling parameters.
 This has been added to V1 since the version we have checked out.
 """
 
-import pytest
 import string
+
+import pytest
 
 from tests.tt.utils import RequestConfig, run_concurrent_batch
 
@@ -42,17 +43,20 @@ class TestV1Sampling:
             num_requests = 1
         else:
             num_requests = max(1, int(max_batch_size * batch_fraction))
-        
+
         # Use return_tokens_as_token_ids to ensure unique keys in top_logprobs
         # dict. Without this, different token IDs that decode to the same
         # string would collide, reducing the count below num_logprobs.
         configs = [
-            RequestConfig(prompt=f"Count from {i}: ", max_tokens=10,
+            RequestConfig(prompt=f"Count from {i}: ",
+                          max_tokens=10,
                           logprobs=num_logprobs,
                           return_tokens_as_token_ids=True)
             for i in range(num_requests)
         ]
-        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+        results = run_concurrent_batch(tt_server,
+                                       tt_model_name,
+                                       configs,
                                        return_full_response=True)
         assert len(results) == len(configs)
 
@@ -114,20 +118,23 @@ class TestV1Sampling:
         bad_words = ["hello", "Hello", "hi", "Hi", "hey", "Hey"]
         configs = [
             # Run multiple times with high temperature to increase coverage
-            RequestConfig(prompt="Say hello to me", max_tokens=20,
-                          bad_words=bad_words, temperature=1.0, seed=i)
-            for i in range(5)
+            RequestConfig(prompt="Say hello to me",
+                          max_tokens=20,
+                          bad_words=bad_words,
+                          temperature=1.0,
+                          seed=i) for i in range(5)
         ]
         # bad_words is only available in chat completions API
-        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+        results = run_concurrent_batch(tt_server,
+                                       tt_model_name,
+                                       configs,
                                        use_chat=True)
         assert len(results) == len(configs)
 
         for i, text in enumerate(results):
             # Extract words by splitting and stripping punctuation
-            words = [word.strip(string.punctuation)
-                     for word in text.split()]
-            
+            words = [word.strip(string.punctuation) for word in text.split()]
+
             # Check if any bad word appears as a whole word (case-insensitive)
             for bad_word in bad_words:
                 assert bad_word not in words, \
@@ -136,15 +143,20 @@ class TestV1Sampling:
     def test_logit_bias(self, tt_server, tt_model_name, max_batch_size):
         """Test logit_bias parameter (smoke test - verifies it doesn't error)."""
         configs = [
-            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+            RequestConfig(prompt="Logit bias: ",
+                          max_tokens=10,
                           logit_bias={1: 0.1}),
-            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+            RequestConfig(prompt="Logit bias: ",
+                          max_tokens=10,
                           logit_bias={4: 0.2}),
-            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+            RequestConfig(prompt="Logit bias: ",
+                          max_tokens=10,
                           logit_bias={2: 0.3}),
-            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+            RequestConfig(prompt="Logit bias: ",
+                          max_tokens=10,
                           logit_bias={16: 0.4}),
-            RequestConfig(prompt="Logit bias: ", max_tokens=10,
+            RequestConfig(prompt="Logit bias: ",
+                          max_tokens=10,
                           logit_bias={7: 0.5}),
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -154,15 +166,20 @@ class TestV1Sampling:
     def test_allowed_token_ids(self, tt_server, tt_model_name, max_batch_size):
         """Test allowed_token_ids parameter (smoke test)."""
         configs = [
-            RequestConfig(prompt="Allowed: ", max_tokens=10,
+            RequestConfig(prompt="Allowed: ",
+                          max_tokens=10,
                           allowed_token_ids=[1, 2, 3]),
-            RequestConfig(prompt="Allowed: ", max_tokens=10,
+            RequestConfig(prompt="Allowed: ",
+                          max_tokens=10,
                           allowed_token_ids=[4, 5, 6]),
-            RequestConfig(prompt="Allowed: ", max_tokens=10,
+            RequestConfig(prompt="Allowed: ",
+                          max_tokens=10,
                           allowed_token_ids=[7, 8, 9]),
-            RequestConfig(prompt="Allowed: ", max_tokens=10,
+            RequestConfig(prompt="Allowed: ",
+                          max_tokens=10,
                           allowed_token_ids=[10, 11, 12]),
-            RequestConfig(prompt="Allowed: ", max_tokens=10,
+            RequestConfig(prompt="Allowed: ",
+                          max_tokens=10,
                           allowed_token_ids=[13, 14, 15]),
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs)
@@ -179,9 +196,13 @@ class TestV1Sampling:
         min_tokens = 5
         configs = [
             # Use a prompt that might naturally produce short output
-            RequestConfig(prompt="Say OK.", max_tokens=20, min_tokens=min_tokens),
+            RequestConfig(prompt="Say OK.",
+                          max_tokens=20,
+                          min_tokens=min_tokens),
         ]
-        results = run_concurrent_batch(tt_server, tt_model_name, configs,
+        results = run_concurrent_batch(tt_server,
+                                       tt_model_name,
+                                       configs,
                                        return_full_response=True)
         assert len(results) == len(configs)
 

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -9,6 +9,8 @@ which are configured via their respective sampling parameters.
 This has been added to V1 since the version we have checked out.
 """
 
+import pytest
+
 from tests.tt.utils import RequestConfig, run_concurrent_batch
 
 
@@ -17,33 +19,62 @@ class TestV1Sampling:
     Verify v1 sampling parameters work correctly via the OpenAI API.
     """
 
-    def test_logprobs(self, tt_server, tt_model_name, max_batch_size):
-        """Test logprobs parameter returns actual logprobs data."""
+    @pytest.mark.parametrize("batch_fraction", [0, 0.5, 1])
+    def test_logprobs(self, tt_server, tt_model_name, max_batch_size,
+                      batch_fraction):
+        """Test logprobs parameter returns actual logprobs data.
+        
+        Parametrized by batch size to verify logprobs work correctly across
+        all DP ranks. In DP mode, logprobs are computed on rank 0 and must
+        be properly distributed to all ranks. Testing with full batch size
+        maximizes coverage across DP ranks.
+        
+        batch_fraction: 1 = full batch, 0.5 = half batch, 0 = single request
+        """
         num_logprobs = 5
+        if batch_fraction == 0:
+            num_requests = 1
+        else:
+            num_requests = max(1, int(max_batch_size * batch_fraction))
+        
         configs = [
-            RequestConfig(prompt="Count: ", max_tokens=10, logprobs=num_logprobs),
+            RequestConfig(prompt=f"Count from {i}: ", max_tokens=10,
+                          logprobs=num_logprobs)
+            for i in range(num_requests)
         ]
         results = run_concurrent_batch(tt_server, tt_model_name, configs,
                                        return_full_response=True)
         assert len(results) == len(configs)
 
-        response = results[0]
-        choice = response.choices[0]
+        # Verify ALL responses have valid logprobs (catches DP rank issues)
+        for i, response in enumerate(results):
+            choice = response.choices[0]
 
-        # Verify logprobs are returned
-        assert choice.logprobs is not None, "logprobs should be returned"
-        assert choice.logprobs.tokens is not None, "logprobs.tokens should exist"
-        assert len(choice.logprobs.tokens) > 0, "should have at least one token"
+            # Verify logprobs are returned for every request
+            assert choice.logprobs is not None, \
+                f"logprobs should be returned for request {i}"
+            assert choice.logprobs.tokens is not None, \
+                f"logprobs.tokens should exist for request {i}"
+            assert len(choice.logprobs.tokens) > 0, \
+                f"should have at least one token for request {i}"
 
-        # Verify top_logprobs contains the requested number of alternatives
-        assert choice.logprobs.top_logprobs is not None, \
-            "top_logprobs should be returned"
-        assert len(choice.logprobs.top_logprobs) > 0, \
-            "should have top_logprobs for tokens"
-        # Each position should have up to num_logprobs+1 alternatives
-        for top_lp in choice.logprobs.top_logprobs:
-            assert len(top_lp) <= num_logprobs + 1, \
-                f"should have at most {num_logprobs+1} alternatives per token"
+            # Verify top_logprobs contains the requested number of alternatives
+            assert choice.logprobs.top_logprobs is not None, \
+                f"top_logprobs should be returned for request {i}"
+            assert len(choice.logprobs.top_logprobs) > 0, \
+                f"should have top_logprobs for tokens for request {i}"
+            # Each position should have up to num_logprobs+1 alternatives
+            for j, top_lp in enumerate(choice.logprobs.top_logprobs):
+                assert len(top_lp) <= num_logprobs + 1, \
+                    f"request {i}, token {j}: should have at most " \
+                    f"{num_logprobs+1} alternatives per token"
+
+            # Verify actual logprob values exist (not just structure)
+            assert choice.logprobs.token_logprobs is not None, \
+                f"request {i}: token_logprobs is None"
+            for j, lp in enumerate(choice.logprobs.token_logprobs):
+                assert lp is not None, \
+                    f"request {i}, token {j}: logprob value is None"
 
     def test_min_p(self, tt_server, tt_model_name, max_batch_size):
         """Test min_p parameter (smoke test - verifies it doesn't error)."""

--- a/tests/tt/test_v1_sampling.py
+++ b/tests/tt/test_v1_sampling.py
@@ -10,6 +10,7 @@ This has been added to V1 since the version we have checked out.
 """
 
 import pytest
+import string
 
 from tests.tt.utils import RequestConfig, run_concurrent_batch
 
@@ -123,9 +124,14 @@ class TestV1Sampling:
         assert len(results) == len(configs)
 
         for i, text in enumerate(results):
+            # Extract words by splitting and stripping punctuation
+            words = [word.strip(string.punctuation)
+                     for word in text.split()]
+            
+            # Check if any bad word appears as a whole word (case-insensitive)
             for bad_word in bad_words:
-                assert bad_word not in text, \
-                    f"bad_word '{bad_word}' found in response {i}: {text!r}"
+                assert bad_word not in words, \
+                    f"bad_word '{bad_word}' found as whole word in response {i}: {text!r}"
 
     def test_logit_bias(self, tt_server, tt_model_name, max_batch_size):
         """Test logit_bias parameter (smoke test - verifies it doesn't error)."""

--- a/tests/tt/utils.py
+++ b/tests/tt/utils.py
@@ -23,6 +23,7 @@ class RequestConfig:
     logit_bias: Union[dict[int, float], None] = None
     allowed_token_ids: Union[list[int], None] = None
     min_tokens: int = 0
+    return_tokens_as_token_ids: bool = False
     # Note: Custom logits_processors are NOT supported in V1.
     # V1 only supports built-in processors via their respective params
     # (min_p, logit_bias, min_tokens, bad_words, allowed_token_ids).
@@ -44,6 +45,8 @@ async def send_request(async_client, model: str, config: RequestConfig,
         extra_body["logit_bias"] = config.logit_bias
     if config.allowed_token_ids is not None:
         extra_body["allowed_token_ids"] = config.allowed_token_ids
+    if config.return_tokens_as_token_ids:
+        extra_body["return_tokens_as_token_ids"] = True
     if config.bad_words is not None:
         raise ValueError("bad_words is not supported in legacy completions API")
 

--- a/tests/tt/utils.py
+++ b/tests/tt/utils.py
@@ -29,7 +29,9 @@ class RequestConfig:
     # (min_p, logit_bias, min_tokens, bad_words, allowed_token_ids).
 
 
-async def send_request(async_client, model: str, config: RequestConfig,
+async def send_request(async_client,
+                       model: str,
+                       config: RequestConfig,
                        return_full_response: bool = False):
     """Send a single async legacy completion request (old API)."""
     extra_body: dict[str, Any] = {}
@@ -48,7 +50,8 @@ async def send_request(async_client, model: str, config: RequestConfig,
     if config.return_tokens_as_token_ids:
         extra_body["return_tokens_as_token_ids"] = True
     if config.bad_words is not None:
-        raise ValueError("bad_words is not supported in legacy completions API")
+        raise ValueError(
+            "bad_words is not supported in legacy completions API")
 
     response = await async_client.completions.create(
         model=model,
@@ -67,7 +70,9 @@ async def send_request(async_client, model: str, config: RequestConfig,
     return response.choices[0].text
 
 
-async def send_chat_request(async_client, model: str, config: RequestConfig,
+async def send_chat_request(async_client,
+                            model: str,
+                            config: RequestConfig,
                             return_full_response: bool = False):
     """Send a single async chat completion request (new API).
     """
@@ -89,7 +94,10 @@ async def send_chat_request(async_client, model: str, config: RequestConfig,
 
     response = await async_client.chat.completions.create(
         model=model,
-        messages=[{"role": "user", "content": config.prompt}],
+        messages=[{
+            "role": "user",
+            "content": config.prompt
+        }],
         max_tokens=config.max_tokens,
         temperature=config.temperature,
         top_p=config.top_p,
@@ -105,7 +113,8 @@ async def send_chat_request(async_client, model: str, config: RequestConfig,
     return response.choices[0].message.content
 
 
-async def send_batch_concurrent(async_client, model: str,
+async def send_batch_concurrent(async_client,
+                                model: str,
                                 configs: list[RequestConfig],
                                 use_chat: bool = False,
                                 return_full_response: bool = False):
@@ -118,13 +127,17 @@ async def send_batch_concurrent(async_client, model: str,
         return_full_response: If True, return full response objects instead of just text.
     """
     send_fn = send_chat_request if use_chat else send_request
-    tasks = [send_fn(async_client, model, cfg,
-                     return_full_response=return_full_response)
-             for cfg in configs]
+    tasks = [
+        send_fn(async_client,
+                model,
+                cfg,
+                return_full_response=return_full_response) for cfg in configs
+    ]
     return await asyncio.gather(*tasks)
 
 
-def run_concurrent_batch(tt_server, tt_model_name,
+def run_concurrent_batch(tt_server,
+                         tt_model_name,
                          configs: list[RequestConfig],
                          use_chat: bool = False,
                          return_full_response: bool = False):
@@ -140,9 +153,12 @@ def run_concurrent_batch(tt_server, tt_model_name,
     async def _run():
         async_client = tt_server.get_async_client()
         try:
-            return await send_batch_concurrent(async_client, tt_model_name,
-                                               configs, use_chat=use_chat,
-                                               return_full_response=return_full_response)
+            return await send_batch_concurrent(
+                async_client,
+                tt_model_name,
+                configs,
+                use_chat=use_chat,
+                return_full_response=return_full_response)
         finally:
             await async_client.close()
 

--- a/tests/tt/utils.py
+++ b/tests/tt/utils.py
@@ -24,9 +24,6 @@ class RequestConfig:
     allowed_token_ids: Union[list[int], None] = None
     min_tokens: int = 0
     return_tokens_as_token_ids: bool = False
-    # Note: Custom logits_processors are NOT supported in V1.
-    # V1 only supports built-in processors via their respective params
-    # (min_p, logit_bias, min_tokens, bad_words, allowed_token_ids).
 
 
 async def send_request(async_client,

--- a/tests/tt/utils.py
+++ b/tests/tt/utils.py
@@ -123,8 +123,8 @@ async def send_batch_concurrent(async_client,
     The vLLM server will batch these together internally.
 
     Args:
-        use_chat: If True, use chat completions API instead of legacy completions API.
-        return_full_response: If True, return full response objects instead of just text.
+        use_chat: use chat completions API instead of legacy completions API.
+        return_full_response: return full response objects vs just text.
     """
     send_fn = send_chat_request if use_chat else send_request
     tasks = [
@@ -146,8 +146,8 @@ def run_concurrent_batch(tt_server,
     Returns list of output texts (or full responses) in same order as configs.
 
     Args:
-        use_chat: If True, use chat completions API instead of legacy completions API.
-        return_full_response: If True, return full response objects instead of just text.
+        use_chat: use chat completions API instead of legacy completions API.
+        return_full_response: return full response objects vs just text.
     """
 
     async def _run():

--- a/tests/tt/utils.py
+++ b/tests/tt/utils.py
@@ -17,15 +17,35 @@ class RequestConfig:
     presence_penalty: float = 0.0
     frequency_penalty: float = 0.0
     repetition_penalty: float = 1.0
+    logprobs: Union[int, None] = None
+    min_p: float = 0.0
+    bad_words: Union[list[str], None] = None
+    logit_bias: Union[dict[int, float], None] = None
+    allowed_token_ids: Union[list[int], None] = None
+    min_tokens: int = 0
+    # Note: Custom logits_processors are NOT supported in V1.
+    # V1 only supports built-in processors via their respective params
+    # (min_p, logit_bias, min_tokens, bad_words, allowed_token_ids).
 
 
-async def send_request(async_client, model: str, config: RequestConfig):
-    """Send a single async request with its own parameters."""
+async def send_request(async_client, model: str, config: RequestConfig,
+                       return_full_response: bool = False):
+    """Send a single async legacy completion request (old API)."""
     extra_body: dict[str, Any] = {}
     if config.top_k is not None:
         extra_body["top_k"] = config.top_k
     if config.repetition_penalty != 1.0:
         extra_body["repetition_penalty"] = config.repetition_penalty
+    if config.min_p != 0.0:
+        extra_body["min_p"] = config.min_p
+    if config.min_tokens != 0:
+        extra_body["min_tokens"] = config.min_tokens
+    if config.logit_bias is not None:
+        extra_body["logit_bias"] = config.logit_bias
+    if config.allowed_token_ids is not None:
+        extra_body["allowed_token_ids"] = config.allowed_token_ids
+    if config.bad_words is not None:
+        raise ValueError("bad_words is not supported in legacy completions API")
 
     response = await async_client.completions.create(
         model=model,
@@ -36,33 +56,90 @@ async def send_request(async_client, model: str, config: RequestConfig):
         seed=config.seed,
         presence_penalty=config.presence_penalty,
         frequency_penalty=config.frequency_penalty,
+        logprobs=config.logprobs,
         extra_body=extra_body if extra_body else None,
     )
+    if return_full_response:
+        return response
     return response.choices[0].text
 
 
+async def send_chat_request(async_client, model: str, config: RequestConfig,
+                            return_full_response: bool = False):
+    """Send a single async chat completion request (new API).
+    """
+    extra_body: dict[str, Any] = {}
+    if config.top_k is not None:
+        extra_body["top_k"] = config.top_k
+    if config.repetition_penalty != 1.0:
+        extra_body["repetition_penalty"] = config.repetition_penalty
+    if config.min_p != 0.0:
+        extra_body["min_p"] = config.min_p
+    if config.min_tokens != 0:
+        extra_body["min_tokens"] = config.min_tokens
+    if config.bad_words is not None:
+        extra_body["bad_words"] = config.bad_words
+    if config.logit_bias is not None:
+        extra_body["logit_bias"] = config.logit_bias
+    if config.allowed_token_ids is not None:
+        extra_body["allowed_token_ids"] = config.allowed_token_ids
+
+    response = await async_client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": config.prompt}],
+        max_tokens=config.max_tokens,
+        temperature=config.temperature,
+        top_p=config.top_p,
+        seed=config.seed,
+        presence_penalty=config.presence_penalty,
+        frequency_penalty=config.frequency_penalty,
+        logprobs=config.logprobs is not None,
+        top_logprobs=config.logprobs,
+        extra_body=extra_body if extra_body else None,
+    )
+    if return_full_response:
+        return response
+    return response.choices[0].message.content
+
+
 async def send_batch_concurrent(async_client, model: str,
-                                configs: list[RequestConfig]):
+                                configs: list[RequestConfig],
+                                use_chat: bool = False,
+                                return_full_response: bool = False):
     """
     Send multiple requests concurrently with different per-request parameters.
     The vLLM server will batch these together internally.
+
+    Args:
+        use_chat: If True, use chat completions API instead of legacy completions API.
+        return_full_response: If True, return full response objects instead of just text.
     """
-    tasks = [send_request(async_client, model, cfg) for cfg in configs]
+    send_fn = send_chat_request if use_chat else send_request
+    tasks = [send_fn(async_client, model, cfg,
+                     return_full_response=return_full_response)
+             for cfg in configs]
     return await asyncio.gather(*tasks)
 
 
 def run_concurrent_batch(tt_server, tt_model_name,
-                         configs: list[RequestConfig]):
+                         configs: list[RequestConfig],
+                         use_chat: bool = False,
+                         return_full_response: bool = False):
     """
     Synchronous wrapper to run concurrent requests.
-    Returns list of output texts in same order as configs.
+    Returns list of output texts (or full responses) in same order as configs.
+
+    Args:
+        use_chat: If True, use chat completions API instead of legacy completions API.
+        return_full_response: If True, return full response objects instead of just text.
     """
 
     async def _run():
         async_client = tt_server.get_async_client()
         try:
             return await send_batch_concurrent(async_client, tt_model_name,
-                                               configs)
+                                               configs, use_chat=use_chat,
+                                               return_full_response=return_full_response)
         finally:
             await async_client.close()
 

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -213,7 +213,7 @@ class TTPlatform(Platform):
 
         # Compat sampling uses the full vLLM sampling pipeline,
         # with logit processors and sampler, instead of our custom sampling.
-        # It is enabled only on request if any of the requests in the batch require it,
+        # It is enabled only if any of the requests in the batch requires it,
         # or if always_compat_sampling is enabled.
 
         always_compat_sampling = False

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -134,6 +134,9 @@ class TTPlatform(Platform):
     _enum = PlatformEnum.TT
     device_name: str = "tt"
     device_type: str = "tt"
+    # Disable torch.compile on TT platform - the triton version in tt-metal
+    # is incompatible with torch's inductor backend.
+    simple_compile_backend: str = "eager"
 
     @classmethod
     def is_async_output_supported(cls, enforce_eager: Optional[bool]) -> bool:
@@ -210,14 +213,8 @@ class TTPlatform(Platform):
 
         # Compat sampling uses the full vLLM sampling pipeline,
         # with logit processors and sampler, instead of our custom sampling.
-        # It is off by default, and enabled only on request
-        # or if any of the requests in the batch require it.
-        # For now, it is only supported with host-side sampling.
-
-        if envs.VLLM_USE_V1:  # type: ignore[attr-defined]
-            logger.warning(
-                "Disabling compatibility sampling as it's not yet support for "
-                "V1 TT backend.")
+        # It is enabled only on request if any of the requests in the batch require it,
+        # or if always_compat_sampling is enabled.
 
         always_compat_sampling = False
         if override_tt_config is not None \
@@ -336,26 +333,12 @@ class TTPlatform(Platform):
             raise ValueError(f"Not yet supporting prompt_logprobs on "
                              f"{dev}")
 
-        if envs.VLLM_USE_V1:
-            if params.min_p != 0.0:
-                raise ValueError(f"Not yet supporting min_p on {dev} in V1")
-            if params.bad_words is not None and len(params.bad_words) > 0:
-                raise ValueError(
-                    f"Not yet supporting bad_words on {dev} in V1")
-            if params.logits_processors is not None:
-                raise ValueError(
-                    f"Not yet supporting logits_processors on {dev} in V1")
-            if params.logit_bias is not None:
-                raise ValueError(
-                    f"Not yet supporting logit_bias on {dev} in V1")
-            if params.allowed_token_ids is not None:
-                raise ValueError(
-                    f"Not yet supporting allowed_token_ids on {dev} in V1")
-            if params.min_tokens != 0:
-                raise ValueError(
-                    f"Not yet supporting min_tokens on {dev} in V1")
-            if params.logprobs is not None:
-                raise ValueError(f"Not yet supporting logprobs on {dev} in V1")
+        # Custom logits_processors are rejected by V1 processor before
+        # reaching here, but support has since been added in upstream.
+        # Defensive check so we remember to add support in the future.
+        if envs.VLLM_USE_V1 and params.logits_processors:
+            raise ValueError(
+                f"Custom logits_processors not supported on {dev} in V1")
 
     @staticmethod
     def compat_sampling_required(sampling_params, num_devices) -> bool:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1365,13 +1365,13 @@ class DPEngineCoreProc(EngineCoreProc):
 
             # Gather host-only sampling params (logprobs, allowed_token_ids,
             # bad_words, logit_bias, min_p, min_tokens) when sampling on host.
-            gathered_host_only_params = None
+            gathered_host_only_sample_params = None
             if not all_sample_device:
                 if rank == 0:
-                    gathered_host_only_params = [None for _ in range(world)]
-                local_host_only_params = decode_inputs.get("host_only_params")
-                dist.gather_object(local_host_only_params,
-                                   gathered_host_only_params,
+                    gathered_host_only_sample_params = [None for _ in range(world)]
+                local_host_only_sample_params = decode_inputs.get("host_only_sample_params")
+                dist.gather_object(local_host_only_sample_params,
+                                   gathered_host_only_sample_params,
                                    dst=0,
                                    group=group)
 
@@ -1379,7 +1379,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     if rank == 0:
                         # Rank 0 sends gathered host_only params to device ranks
                         pickled_host_only = pickle.dumps(
-                            gathered_host_only_params)
+                            gathered_host_only_sample_params)
                         host_only_tensor = torch.frombuffer(pickled_host_only,
                                                             dtype=torch.uint8)
                         host_only_size = torch.tensor(
@@ -1394,7 +1394,7 @@ class DPEngineCoreProc(EngineCoreProc):
                         host_only_tensor = torch.empty(host_only_size.item(),
                                                        dtype=torch.uint8)
                         dist.recv(host_only_tensor, src=0, group=group)
-                        gathered_host_only_params = pickle.loads(
+                        gathered_host_only_sample_params = pickle.loads(
                             host_only_tensor.numpy().tobytes())
 
             if local_rank == 0:
@@ -1402,7 +1402,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     "int_inputs": stacked_int,
                     "float_inputs": stacked_float,
                     "sampling_tokens_inputs": gathered_tokens_inputs,
-                    "host_only_params": gathered_host_only_params,
+                    "host_only_sample_params": gathered_host_only_sample_params,
                     "reset_batch": any_reset_batch,
                     "all_sample_device": all_sample_device,
                 }

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1368,8 +1368,11 @@ class DPEngineCoreProc(EngineCoreProc):
             gathered_host_only_sample_params = None
             if not all_sample_device:
                 if rank == 0:
-                    gathered_host_only_sample_params = [None for _ in range(world)]
-                local_host_only_sample_params = decode_inputs.get("host_only_sample_params")
+                    gathered_host_only_sample_params = [
+                        None for _ in range(world)
+                    ]
+                local_host_only_sample_params = decode_inputs.get(
+                    "host_only_sample_params")
                 dist.gather_object(local_host_only_sample_params,
                                    gathered_host_only_sample_params,
                                    dst=0,
@@ -1402,7 +1405,8 @@ class DPEngineCoreProc(EngineCoreProc):
                     "int_inputs": stacked_int,
                     "float_inputs": stacked_float,
                     "sampling_tokens_inputs": gathered_tokens_inputs,
-                    "host_only_sample_params": gathered_host_only_sample_params,
+                    "host_only_sample_params":
+                    gathered_host_only_sample_params,
                     "reset_batch": any_reset_batch,
                     "all_sample_device": all_sample_device,
                 }

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1256,13 +1256,14 @@ class DPEngineCoreProc(EngineCoreProc):
             "build_dp_model_input", args=(scheduler_output, ))[0]
         (local_input, local_max_blocks, local_has_structured,
          local_has_penalties, local_reset_batch,
-         local_can_sample_device) = all_local_inputs
+         local_can_sample_device, local_needs_logprobs) = all_local_inputs
         max_blocks_decode = None  # Only used for decode.
         any_structured_inputs = False  # Only used for decode.
+        any_needs_logprobs = False
 
         if is_decode:
             # Gather max_blocks, has_structured, has_penalties, reset_batch,
-            # and cannot_sample_on_device from all ranks.
+            # cannot_sample_on_device, and needs_logprobs from all ranks.
             input_info_t = torch.tensor(
                 [
                     local_max_blocks,
@@ -1272,6 +1273,7 @@ class DPEngineCoreProc(EngineCoreProc):
                     # Invert so we can use MAX reduction and still compute
                     # "all ranks can sample on device".
                     1 - local_can_sample_device,
+                    local_needs_logprobs,
                 ],
                 dtype=torch.int32)
             dist.all_reduce(input_info_t, op=dist.ReduceOp.MAX, group=group)
@@ -1280,6 +1282,7 @@ class DPEngineCoreProc(EngineCoreProc):
             any_penalties_inputs = input_info_t[2].item() > 0
             any_reset_batch = input_info_t[3].item() > 0
             all_sample_device = input_info_t[4].item() == 0
+            any_needs_logprobs = input_info_t[5].item() > 0
 
             # Build tensorized gather input for decode.
             decode_inputs = self.model_executor.collective_rpc(
@@ -1360,11 +1363,46 @@ class DPEngineCoreProc(EngineCoreProc):
                         gathered_tokens_inputs = pickle.loads(
                             tokens_tensor.numpy().tobytes())
 
+            # Gather host-only sampling params (logprobs, allowed_token_ids,
+            # bad_words, logit_bias, min_p, min_tokens) when sampling on host.
+            gathered_host_only_params = None
+            if not all_sample_device:
+                if rank == 0:
+                    gathered_host_only_params = [None for _ in range(world)]
+                local_host_only_params = decode_inputs.get("host_only_params")
+                dist.gather_object(local_host_only_params,
+                                   gathered_host_only_params,
+                                   dst=0,
+                                   group=group)
+
+                if len(self.dp_device_ranks) > 1:
+                    if rank == 0:
+                        # Rank 0 sends gathered host_only params to device ranks
+                        pickled_host_only = pickle.dumps(
+                            gathered_host_only_params)
+                        host_only_tensor = torch.frombuffer(pickled_host_only,
+                                                            dtype=torch.uint8)
+                        host_only_size = torch.tensor(
+                            [host_only_tensor.numel()], dtype=torch.long)
+                        for dst in self.dp_device_ranks[1:]:
+                            dist.send(host_only_size, dst=dst, group=group)
+                            dist.send(host_only_tensor, dst=dst, group=group)
+                    elif local_rank == 0:  # other device ranks
+                        # Other device ranks receive from rank 0
+                        host_only_size = torch.zeros(1, dtype=torch.long)
+                        dist.recv(host_only_size, src=0, group=group)
+                        host_only_tensor = torch.empty(host_only_size.item(),
+                                                       dtype=torch.uint8)
+                        dist.recv(host_only_tensor, src=0, group=group)
+                        gathered_host_only_params = pickle.loads(
+                            host_only_tensor.numpy().tobytes())
+
             if local_rank == 0:
                 gathered_inputs = {
                     "int_inputs": stacked_int,
                     "float_inputs": stacked_float,
                     "sampling_tokens_inputs": gathered_tokens_inputs,
+                    "host_only_params": gathered_host_only_params,
                     "reset_batch": any_reset_batch,
                     "all_sample_device": all_sample_device,
                 }
@@ -1374,6 +1412,12 @@ class DPEngineCoreProc(EngineCoreProc):
             gathered_inputs = None
             if rank == 0:
                 gathered_inputs = [None for _ in range(world)]  # type: ignore
+
+            # All_reduce to determine if any rank needs logprobs (for prefill).
+            logprobs_flag_t = torch.tensor([local_needs_logprobs],
+                                           dtype=torch.int32)
+            dist.all_reduce(logprobs_flag_t, op=dist.ReduceOp.MAX, group=group)
+            any_needs_logprobs = logprobs_flag_t[0].item() > 0
 
             # Gather to rank 0, then send to other device ranks (local rank 0).
             # Note: if num device ranks == num world ranks, then this could be
@@ -1405,14 +1449,18 @@ class DPEngineCoreProc(EngineCoreProc):
         self.dlog("after_inputs_gather")
 
         # Concatenate and execute DP inputs on local DP rank 0 (device ranks).
+        logprobs_per_dp: list = [None] * world
         if local_rank == 0 and (is_decode or
                                 (isinstance(gathered_inputs, list)
                                  and any(x is not None
                                          for x in gathered_inputs))):
-            send_tensor = self.model_executor.collective_rpc(
+            result = self.model_executor.collective_rpc(
                 "concat_and_execute_dp",
                 args=(gathered_inputs, is_decode, max_blocks_decode,
                       any_structured_inputs))[0]
+            # Result is (send_tensor, logprobs_lists_per_dp)
+            assert isinstance(result, tuple) and len(result) == 2
+            send_tensor, logprobs_per_dp = result
             assert isinstance(send_tensor, torch.Tensor)
         else:
             B = self.vllm_config.scheduler_config.max_num_seqs
@@ -1428,10 +1476,20 @@ class DPEngineCoreProc(EngineCoreProc):
         dist.scatter(my_ids, scatter_list, src=0, group=group)
         self.dlog("after_results_gather my_ids_shape=%s", tuple(my_ids.shape))
 
+        # Scatter logprobs only if any rank needs them (determined in all_reduce).
+        my_logprobs_val = None
+        if any_needs_logprobs:
+            my_logprobs: list = [None]
+            logprobs_scatter_list = logprobs_per_dp if rank == 0 else None
+            dist.scatter_object_list(my_logprobs, logprobs_scatter_list,
+                                     src=0, group=group)
+            my_logprobs_val = my_logprobs[0]
+
         # If rank had scheduled tokens, apply results locally and return output
         if local_has_requests:
             output = self.model_executor.collective_rpc(
-                "apply_dp_execution_result", args=(my_ids, ))[0]
+                "apply_dp_execution_result",
+                args=(my_ids, my_logprobs_val))[0]
             return output
         else:
             return EMPTY_MODEL_RUNNER_OUTPUT

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1476,7 +1476,8 @@ class DPEngineCoreProc(EngineCoreProc):
         dist.scatter(my_ids, scatter_list, src=0, group=group)
         self.dlog("after_results_gather my_ids_shape=%s", tuple(my_ids.shape))
 
-        # Scatter logprobs only if any rank needs them (determined in all_reduce).
+        # Scatter logprobs only if any rank needs them
+        # (determined in all_reduce).
         my_logprobs_val = None
         if any_needs_logprobs:
             my_logprobs: list = [None]

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1255,8 +1255,8 @@ class DPEngineCoreProc(EngineCoreProc):
         all_local_inputs = self.model_executor.collective_rpc(
             "build_dp_model_input", args=(scheduler_output, ))[0]
         (local_input, local_max_blocks, local_has_structured,
-         local_has_penalties, local_reset_batch,
-         local_can_sample_device, local_needs_logprobs) = all_local_inputs
+         local_has_penalties, local_reset_batch, local_can_sample_device,
+         local_needs_logprobs) = all_local_inputs
         max_blocks_decode = None  # Only used for decode.
         any_structured_inputs = False  # Only used for decode.
         any_needs_logprobs = False
@@ -1481,15 +1481,16 @@ class DPEngineCoreProc(EngineCoreProc):
         if any_needs_logprobs:
             my_logprobs: list = [None]
             logprobs_scatter_list = logprobs_per_dp if rank == 0 else None
-            dist.scatter_object_list(my_logprobs, logprobs_scatter_list,
-                                     src=0, group=group)
+            dist.scatter_object_list(my_logprobs,
+                                     logprobs_scatter_list,
+                                     src=0,
+                                     group=group)
             my_logprobs_val = my_logprobs[0]
 
         # If rank had scheduled tokens, apply results locally and return output
         if local_has_requests:
             output = self.model_executor.collective_rpc(
-                "apply_dp_execution_result",
-                args=(my_ids, my_logprobs_val))[0]
+                "apply_dp_execution_result", args=(my_ids, my_logprobs_val))[0]
             return output
         else:
             return EMPTY_MODEL_RUNNER_OUTPUT

--- a/vllm/v1/sample/logits_processor.py
+++ b/vllm/v1/sample/logits_processor.py
@@ -218,6 +218,21 @@ class LogitsProcessorManager:
         """Iterator over all logits processors."""
         return chain(self.argmax_invariant, self.non_argmax_invariant)
 
+    def has_active_processors(self) -> bool:
+        """Check if any processors have active requests.
+
+        This is used to determine if host sampling is required (e.g., for
+        min_p, logit_bias, min_tokens which are handled by built-in processors).
+        """
+        for proc in self.all:
+            if isinstance(proc, MinPLogitsProcessor) and proc.min_p_count:
+                return True
+            if isinstance(proc, LogitBiasLogitsProcessor) and proc.biases:
+                return True
+            if isinstance(proc, MinTokensLogitsProcessor) and proc.min_toks:
+                return True
+        return False
+
 
 ###### ----- Built-in LogitsProcessor impls below here
 

--- a/vllm/v1/sample/ops/logprobs.py
+++ b/vllm/v1/sample/ops/logprobs.py
@@ -7,7 +7,7 @@ import torch
 from vllm.platforms import current_platform
 
 
-# newer versions of upstream already pass current_platform.simple_compile_backend
+# newer versions already pass current_platform.simple_compile_backend
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def batched_count_greater_than(x: torch.Tensor,
                                values: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/sample/ops/logprobs.py
+++ b/vllm/v1/sample/ops/logprobs.py
@@ -4,8 +4,10 @@
 
 import torch
 
+from vllm.platforms import current_platform
 
-@torch.compile(dynamic=True)
+# newer versions of upstream already pass current_platform.simple_compile_backend
+@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def batched_count_greater_than(x: torch.Tensor,
                                values: torch.Tensor) -> torch.Tensor:
     """

--- a/vllm/v1/sample/ops/logprobs.py
+++ b/vllm/v1/sample/ops/logprobs.py
@@ -6,6 +6,7 @@ import torch
 
 from vllm.platforms import current_platform
 
+
 # newer versions of upstream already pass current_platform.simple_compile_backend
 @torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def batched_count_greater_than(x: torch.Tensor,

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -403,12 +403,12 @@ class InputBatch:
         del self.req_output_token_ids[self.num_reqs:]
 
     @property
-    def max_num_logprobs(self) -> Optional[int]:
+    def max_num_logprobs(self) -> int:
         """Returns the maximum logprobs value across all requests, or None."""
         if self.num_reqs == 0:
-            return None
+            return 0
         max_val = int(self.sampling.num_logprobs[:self.num_reqs].max().item())
-        return max_val if max_val > 0 else None
+        return max_val
 
     @property
     def no_allowed_token_ids(self) -> bool:
@@ -476,7 +476,7 @@ class InputBatch:
         return output_token_ids_tensor
 
     def advance_generators(self) -> None:
-        # This relies on the fact, that for a torch all_gather_object, 
+        # This relies on the fact, that for a torch all_gather_object,
         # the local object is also copied,
         # so the original object is not modified.
         # Otherwise, the generator at local_rank 0

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -27,7 +27,7 @@ class SamplingInputBatch:
         "frequency_penalty": 0.0,
         "repetition_penalty": 1.0,
         "seed": SEED_NONE_SENTINEL,  # Sentinel represents None (no seed)
-        "enable_log_probs": False,  # Default to no logprobs
+        "num_logprobs": 0,  # Default to no logprobs
     }
 
     def __init__(self, max_num_reqs: int):
@@ -42,7 +42,7 @@ class SamplingInputBatch:
         self.frequency_penalty = default_tensors["frequency_penalty"]
         self.repetition_penalty = default_tensors["repetition_penalty"]
         self.seed = default_tensors["seed"]
-        self.enable_log_probs = default_tensors["enable_log_probs"]
+        self.num_logprobs = default_tensors["num_logprobs"]
         # Asserting that all defaults have corresponding attributes.
         for name in self.DEFAULTS:
             assert hasattr(
@@ -54,9 +54,6 @@ class SamplingInputBatch:
         # NOTE: The indices of the requests that do not have their own
         # generator should not be included in the dictionary.
         self.generators: dict[int, torch.Generator] = {}
-
-        # Logprobs tracking
-        self.num_logprobs: dict[str, int] = {}
 
         # Internal representation of per-step batch state changes, used for
         # reordering persistent batch and generating logitsprocs batch state
@@ -266,10 +263,9 @@ class InputBatch:
 
         # Logprobs
         if sampling_params.logprobs is not None:
-            self.sampling.num_logprobs[req_id] = sampling_params.logprobs
-            self.sampling.enable_log_probs[req_index] = True
+            self.sampling.num_logprobs[req_index] = sampling_params.logprobs
         else:
-            self.sampling.enable_log_probs[req_index] = False
+            self.sampling.num_logprobs[req_index] = 0
 
         # Allowed token IDs
         if sampling_params.allowed_token_ids:
@@ -310,7 +306,6 @@ class InputBatch:
 
         # Clean up host-only sampling param tracking
         self.sampling.generators.pop(req_index, None)
-        self.sampling.num_logprobs.pop(req_id, None)
         self.sampling.has_allowed_token_ids.discard(req_id)
         self.sampling.bad_words_token_ids.pop(req_index, None)
 
@@ -384,6 +379,7 @@ class InputBatch:
             sampling.repetition_penalty[empty_index] = (
                 sampling.repetition_penalty[last_req_index])
             sampling.seed[empty_index] = sampling.seed[last_req_index]
+            sampling.num_logprobs[empty_index] = sampling.num_logprobs[last_req_index]
 
             # Move host-only sampling params
             if last_req_index in self.sampling.generators:
@@ -413,7 +409,10 @@ class InputBatch:
     @property
     def max_num_logprobs(self) -> Optional[int]:
         """Returns the maximum logprobs value across all requests, or None."""
-        return max(self.sampling.num_logprobs.values()) if self.sampling.num_logprobs else None
+        if self.num_reqs == 0:
+            return None
+        max_val = int(self.sampling.num_logprobs[:self.num_reqs].max().item())
+        return max_val if max_val > 0 else None
 
     @property
     def no_allowed_token_ids(self) -> bool:

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -27,6 +27,7 @@ class SamplingInputBatch:
         "frequency_penalty": 0.0,
         "repetition_penalty": 1.0,
         "seed": SEED_NONE_SENTINEL,  # Sentinel represents None (no seed)
+        "enable_log_probs": False,  # Default to no logprobs
     }
 
     def __init__(self, max_num_reqs: int):
@@ -41,6 +42,7 @@ class SamplingInputBatch:
         self.frequency_penalty = default_tensors["frequency_penalty"]
         self.repetition_penalty = default_tensors["repetition_penalty"]
         self.seed = default_tensors["seed"]
+        self.enable_log_probs = default_tensors["enable_log_probs"]
         # Asserting that all defaults have corresponding attributes.
         for name in self.DEFAULTS:
             assert hasattr(
@@ -270,6 +272,9 @@ class InputBatch:
         # Logprobs
         if sampling_params.logprobs is not None:
             self.num_logprobs[req_id] = sampling_params.logprobs
+            self.sampling.enable_log_probs[req_index] = True
+        else:
+            self.sampling.enable_log_probs[req_index] = False
 
         # Allowed token IDs
         if sampling_params.allowed_token_ids:

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -474,3 +474,11 @@ class InputBatch:
                 output_token_ids[i, :output_len] = self.token_ids_cpu[
                     i, prompt_len:total_len]
         return output_token_ids_tensor
+
+    def advance_generators(self) -> None:
+        # This relies on the fact, that for a torch all_gather_object,
+        # the local object is also copied, so the original object is not modified.
+        # Otherwise, the generator at local_rank 0 would get out of sync with the others.
+        for generator in self.generators.values():
+            # Sample once from the generator to advance its state.
+            torch.rand(1, generator=generator)

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -476,9 +476,11 @@ class InputBatch:
         return output_token_ids_tensor
 
     def advance_generators(self) -> None:
-        # This relies on the fact, that for a torch all_gather_object,
-        # the local object is also copied, so the original object is not modified.
-        # Otherwise, the generator at local_rank 0 would get out of sync with the others.
+        # This relies on the fact, that for a torch all_gather_object, 
+        # the local object is also copied,
+        # so the original object is not modified.
+        # Otherwise, the generator at local_rank 0
+        # would get out of sync with the others.
         for generator in self.sampling.generators.values():
             # Sample once from the generator to advance its state.
             torch.rand(1, generator=generator)

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -323,11 +323,6 @@ class InputBatch:
             # The batched states are empty.
             self._req_ids.clear()
             self.req_output_token_ids.clear()
-            self.random_reqs.clear()
-            self.presence_penalties_reqs.clear()
-            self.frequency_penalties_reqs.clear()
-            self.repetition_penalties_reqs.clear(
-            )  #TODO I think these are taken care of by remove_request
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -50,6 +50,34 @@ class SamplingInputBatch:
                 name), (f"Missing attribute '{name}' in SamplingInputBatch")
         self.sampling_param_names = list(self.DEFAULTS.keys())
 
+        # req_index -> generator
+        # NOTE: The indices of the requests that do not have their own
+        # generator should not be included in the dictionary.
+        self.generators: dict[int, torch.Generator] = {}
+
+        # Logprobs tracking
+        self.num_logprobs: dict[str, int] = {}
+
+        # Internal representation of per-step batch state changes, used for
+        # reordering persistent batch and generating logitsprocs batch state
+        # updates. Should reset each step.
+        self.batch_update_builder = BatchUpdateBuilder()
+
+        # Define logits processors.
+        self.logitsprocs = init_builtin_logitsprocs(pin_memory_available=False,
+                                                    max_num_reqs=max_num_reqs +
+                                                    1, # not sure why but match gpu_input_batch
+                                                    device=torch.device("cpu"))
+
+        # Allowed token IDs tracking
+        self.has_allowed_token_ids: set[str] = set()
+        # NOTE: In the mask tensor, if the corresponding token is allowed,
+        # the value is False. Since we use masked_fill_ to set -inf.
+        self.allowed_token_ids_mask: Optional[torch.Tensor] = None
+
+        # req_index -> bad_words_token_ids
+        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
+
     def pad_with_defaults(self, num_reqs: int) -> None:
         """Pad sampling parameters with default values for indices >=
         num_reqs."""
@@ -128,34 +156,6 @@ class InputBatch:
         # Sampling-related.
         self.sampling = SamplingInputBatch(max_num_reqs)
 
-        # req_index -> generator
-        # NOTE: The indices of the requests that do not have their own
-        # generator should not be included in the dictionary.
-        self.generators: dict[int, torch.Generator] = {}
-
-        # Logprobs tracking
-        self.num_logprobs: dict[str, int] = {}
-
-        # Internal representation of per-step batch state changes, used for
-        # reordering persistent batch and generating logitsprocs batch state
-        # updates. Should reset each step.
-        self.batch_update_builder = BatchUpdateBuilder()
-
-        # Define logits processors.
-        self.logitsprocs = init_builtin_logitsprocs(pin_memory_available=False,
-                                                    max_num_reqs=max_num_reqs +
-                                                    1,
-                                                    device=torch.device("cpu"))
-
-        # Allowed token IDs tracking
-        self.has_allowed_token_ids: set[str] = set()
-        # NOTE: In the mask tensor, if the corresponding token is allowed,
-        # the value is False. Since we use masked_fill_ to set -inf.
-        self.allowed_token_ids_mask: Optional[torch.Tensor] = None
-
-        # req_index -> bad_words_token_ids
-        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
-
     @property
     def req_ids(self) -> list[str]:
         # None elements should only be present transiently
@@ -218,7 +218,7 @@ class InputBatch:
         assert sampling_params is not None, "pooling requests not supported yet"
 
         # Register with batch update builder for logits processors
-        self.batch_update_builder.added.append(
+        self.sampling.batch_update_builder.added.append(
             (req_index, sampling_params, request.output_token_ids))
 
         self.sampling.temperature[req_index] = sampling_params.temperature
@@ -262,33 +262,34 @@ class InputBatch:
 
         # Generator for random sampling
         if request.generator is not None:
-            self.generators[req_index] = request.generator
+            self.sampling.generators[req_index] = request.generator
 
         # Logprobs
         if sampling_params.logprobs is not None:
-            self.num_logprobs[req_id] = sampling_params.logprobs
+            self.sampling.num_logprobs[req_id] = sampling_params.logprobs
             self.sampling.enable_log_probs[req_index] = True
         else:
             self.sampling.enable_log_probs[req_index] = False
 
         # Allowed token IDs
         if sampling_params.allowed_token_ids:
-            self.has_allowed_token_ids.add(req_id)
-            if self.allowed_token_ids_mask is None:
+            self.sampling.has_allowed_token_ids.add(req_id)
+            if self.sampling.allowed_token_ids_mask is None:
                 # Lazy allocation for this tensor, which can be large.
                 # True means we fill with -inf (disallowed).
-                self.allowed_token_ids_mask = torch.zeros(self.max_num_reqs,
-                                                          self.vocab_size,
-                                                          dtype=torch.bool,
-                                                          device="cpu")
-            self.allowed_token_ids_mask[req_index] = True
+                self.sampling.allowed_token_ids_mask = torch.zeros(
+                    self.max_num_reqs,
+                    self.vocab_size,
+                    dtype=torch.bool,
+                    device="cpu")
+            self.sampling.allowed_token_ids_mask[req_index] = True
             # False means we don't fill with -inf (allowed).
-            self.allowed_token_ids_mask[req_index][
+            self.sampling.allowed_token_ids_mask[req_index][
                 sampling_params.allowed_token_ids] = False
 
         # Bad words
         if sampling_params.bad_words_token_ids:
-            self.bad_words_token_ids[
+            self.sampling.bad_words_token_ids[
                 req_index] = sampling_params.bad_words_token_ids
 
     def remove_request(self, req_id: str) -> Optional[int]:
@@ -297,7 +298,7 @@ class InputBatch:
         req_index = self.req_id_to_index.pop(req_id, None)
         if req_index is None:
             return None
-        self.batch_update_builder.removed_append(req_index)
+        self.sampling.batch_update_builder.removed_append(req_index)
         self._req_ids[req_index] = None
         self.req_output_token_ids[req_index] = None
 
@@ -308,10 +309,10 @@ class InputBatch:
         self.repetition_penalties_reqs.discard(req_id)
 
         # Clean up host-only sampling param tracking
-        self.generators.pop(req_index, None)
-        self.num_logprobs.pop(req_id, None)
-        self.has_allowed_token_ids.discard(req_id)
-        self.bad_words_token_ids.pop(req_index, None)
+        self.sampling.generators.pop(req_index, None)
+        self.sampling.num_logprobs.pop(req_id, None)
+        self.sampling.has_allowed_token_ids.discard(req_id)
+        self.sampling.bad_words_token_ids.pop(req_index, None)
 
         return req_index
 
@@ -346,7 +347,7 @@ class InputBatch:
                 break
 
             # Track the move for logits processors
-            self.batch_update_builder.moved.append(
+            self.sampling.batch_update_builder.moved.append(
                 (last_req_index, empty_index,
                  MoveDirectionality.UNIDIRECTIONAL))
 
@@ -385,18 +386,21 @@ class InputBatch:
             sampling.seed[empty_index] = sampling.seed[last_req_index]
 
             # Move host-only sampling params
-            if last_req_index in self.generators:
-                self.generators[empty_index] = self.generators.pop(
-                    last_req_index)
+            if last_req_index in self.sampling.generators:
+                self.sampling.generators[
+                    empty_index] = self.sampling.generators.pop(
+                        last_req_index)
 
-            if last_req_index in self.bad_words_token_ids:
-                self.bad_words_token_ids[
-                    empty_index] = self.bad_words_token_ids.pop(last_req_index)
+            if last_req_index in self.sampling.bad_words_token_ids:
+                self.sampling.bad_words_token_ids[
+                    empty_index] = self.sampling.bad_words_token_ids.pop(
+                        last_req_index)
 
             # Move allowed_token_ids_mask row
-            if self.allowed_token_ids_mask is not None:
-                self.allowed_token_ids_mask[
-                    empty_index] = self.allowed_token_ids_mask[last_req_index]
+            if self.sampling.allowed_token_ids_mask is not None:
+                self.sampling.allowed_token_ids_mask[
+                    empty_index] = self.sampling.allowed_token_ids_mask[
+                        last_req_index]
 
             # Decrement last_req_index since it is now empty.
             last_req_index -= 1
@@ -409,18 +413,18 @@ class InputBatch:
     @property
     def max_num_logprobs(self) -> Optional[int]:
         """Returns the maximum logprobs value across all requests, or None."""
-        return max(self.num_logprobs.values()) if self.num_logprobs else None
+        return max(self.sampling.num_logprobs.values()) if self.sampling.num_logprobs else None
 
     @property
     def no_allowed_token_ids(self) -> bool:
         """True if no requests have allowed_token_ids set."""
-        return len(self.has_allowed_token_ids) == 0
+        return len(self.sampling.has_allowed_token_ids) == 0
 
     def refresh_logitsprocs(self) -> None:
         """Update logits processors with batch state changes."""
-        batch_update = self.batch_update_builder.get_and_reset(self.num_reqs)
+        batch_update = self.sampling.batch_update_builder.get_and_reset(self.num_reqs)
         if batch_update:
-            for processor in self.logitsprocs.all:
+            for processor in self.sampling.logitsprocs.all:
                 processor.update_state(batch_update)
 
     def make_prompt_token_ids_tensor(self) -> torch.Tensor:
@@ -479,6 +483,6 @@ class InputBatch:
         # This relies on the fact, that for a torch all_gather_object,
         # the local object is also copied, so the original object is not modified.
         # Otherwise, the generator at local_rank 0 would get out of sync with the others.
-        for generator in self.generators.values():
+        for generator in self.sampling.generators.values():
             # Sample once from the generator to advance its state.
             torch.rand(1, generator=generator)

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -6,6 +6,9 @@ from typing import Optional, cast
 import numpy as np
 import torch
 
+from vllm.v1.sample.logits_processor import (BatchUpdateBuilder,
+                                             MoveDirectionality,
+                                             init_builtin_logitsprocs)
 from vllm.v1.worker.block_table import MultiGroupBlockTable
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 
@@ -123,6 +126,34 @@ class InputBatch:
         # Sampling-related.
         self.sampling = SamplingInputBatch(max_num_reqs)
 
+        # req_index -> generator
+        # NOTE: The indices of the requests that do not have their own
+        # generator should not be included in the dictionary.
+        self.generators: dict[int, torch.Generator] = {}
+
+        # Logprobs tracking
+        self.num_logprobs: dict[str, int] = {}
+
+        # Internal representation of per-step batch state changes, used for
+        # reordering persistent batch and generating logitsprocs batch state
+        # updates. Should reset each step.
+        self.batch_update_builder = BatchUpdateBuilder()
+
+        # Define logits processors.
+        self.logitsprocs = init_builtin_logitsprocs(
+            pin_memory_available=False,
+            max_num_reqs=max_num_reqs + 1,
+            device=torch.device("cpu"))
+
+        # Allowed token IDs tracking
+        self.has_allowed_token_ids: set[str] = set()
+        # NOTE: In the mask tensor, if the corresponding token is allowed,
+        # the value is False. Since we use masked_fill_ to set -inf.
+        self.allowed_token_ids_mask: Optional[torch.Tensor] = None
+
+        # req_index -> bad_words_token_ids
+        self.bad_words_token_ids: dict[int, list[list[int]]] = {}
+
     @property
     def req_ids(self) -> list[str]:
         # None elements should only be present transiently
@@ -145,13 +176,18 @@ class InputBatch:
                 and len(self.frequency_penalties_reqs) == 0
                 and len(self.repetition_penalties_reqs) == 0)
 
+    def _get_next_add_index(self) -> int:
+        # For TT, removed indices are managed by the model_runner, not here.
+        # Always append to end when req_index is not specified.
+        return self.num_reqs
+
     def add_request(
         self,
         request: "CachedRequestState",
         req_index: Optional[int] = None,
     ) -> None:
         if req_index is None:
-            req_index = self.num_reqs
+            req_index = self._get_next_add_index()
         assert req_index < self.max_num_reqs, (
             f"req_index={req_index} >= max_num_reqs={self.max_num_reqs}")
 
@@ -183,6 +219,11 @@ class InputBatch:
         # Sampling-related.
         sampling_params = request.sampling_params
         assert sampling_params is not None, "pooling requests not supported yet"
+
+        # Register with batch update builder for logits processors
+        self.batch_update_builder.added.append(
+            (req_index, sampling_params, request.output_token_ids))
+
         self.sampling.temperature[req_index] = sampling_params.temperature
         self.sampling.top_p[req_index] = sampling_params.top_p
         top_k = sampling_params.top_k
@@ -222,12 +263,42 @@ class InputBatch:
         else:
             self.repetition_penalties_reqs.add(req_id)
 
+        # Generator for random sampling
+        if request.generator is not None:
+            self.generators[req_index] = request.generator
+
+        # Logprobs
+        if sampling_params.logprobs is not None:
+            self.num_logprobs[req_id] = sampling_params.logprobs
+
+        # Allowed token IDs
+        if sampling_params.allowed_token_ids:
+            self.has_allowed_token_ids.add(req_id)
+            if self.allowed_token_ids_mask is None:
+                # Lazy allocation for this tensor, which can be large.
+                # True means we fill with -inf (disallowed).
+                self.allowed_token_ids_mask = torch.zeros(
+                    self.max_num_reqs,
+                    self.vocab_size,
+                    dtype=torch.bool,
+                    device="cpu")
+            self.allowed_token_ids_mask[req_index] = True
+            # False means we don't fill with -inf (allowed).
+            self.allowed_token_ids_mask[req_index][
+                sampling_params.allowed_token_ids] = False
+
+        # Bad words
+        if sampling_params.bad_words_token_ids:
+            self.bad_words_token_ids[
+                req_index] = sampling_params.bad_words_token_ids
+
     def remove_request(self, req_id: str) -> Optional[int]:
         """This method must always be followed by a call to condense()."""
 
         req_index = self.req_id_to_index.pop(req_id, None)
         if req_index is None:
             return None
+        self.batch_update_builder.removed_append(req_index)
         self._req_ids[req_index] = None
         self.req_output_token_ids[req_index] = None
 
@@ -236,6 +307,12 @@ class InputBatch:
         self.presence_penalties_reqs.discard(req_id)
         self.frequency_penalties_reqs.discard(req_id)
         self.repetition_penalties_reqs.discard(req_id)
+
+        # Clean up host-only sampling param tracking
+        self.generators.pop(req_index, None)
+        self.num_logprobs.pop(req_id, None)
+        self.has_allowed_token_ids.discard(req_id)
+        self.bad_words_token_ids.pop(req_index, None)
 
         return req_index
 
@@ -268,6 +345,10 @@ class InputBatch:
             empty_index = empty_req_indices.pop()
             if empty_index >= last_req_index:
                 break
+
+            # Track the move for logits processors
+            self.batch_update_builder.moved.append(
+                (last_req_index, empty_index, MoveDirectionality.UNIDIRECTIONAL))
 
             # Swap the states.
             req_id = self._req_ids[last_req_index]
@@ -303,12 +384,52 @@ class InputBatch:
                 sampling.repetition_penalty[last_req_index])
             sampling.seed[empty_index] = sampling.seed[last_req_index]
 
+            # Move host-only sampling params
+            if last_req_index in self.generators:
+                self.generators[empty_index] = self.generators.pop(
+                    last_req_index)
+            else:
+                self.generators.pop(empty_index, None)
+
+            if last_req_index in self.bad_words_token_ids:
+                self.bad_words_token_ids[
+                    empty_index] = self.bad_words_token_ids.pop(last_req_index)
+            else:
+                self.bad_words_token_ids.pop(empty_index, None)
+
+            # Move allowed_token_ids_mask row
+            if self.allowed_token_ids_mask is not None:
+                self.allowed_token_ids_mask[
+                    empty_index] = self.allowed_token_ids_mask[
+                        last_req_index]
+
             # Decrement last_req_index since it is now empty.
             last_req_index -= 1
 
         # Trim lists to the batch size.
         del self._req_ids[self.num_reqs:]
         del self.req_output_token_ids[self.num_reqs:]
+
+        # Clear removed indices since they've been compacted or are being
+        # managed by the caller (model_runner manages removed_req_indices)
+        self.batch_update_builder.removed.clear()
+
+    @property
+    def max_num_logprobs(self) -> Optional[int]:
+        """Returns the maximum logprobs value across all requests, or None."""
+        return max(self.num_logprobs.values()) if self.num_logprobs else None
+
+    @property
+    def no_allowed_token_ids(self) -> bool:
+        """True if no requests have allowed_token_ids set."""
+        return len(self.has_allowed_token_ids) == 0
+
+    def refresh_logitsprocs(self) -> None:
+        """Update logits processors with batch state changes."""
+        batch_update = self.batch_update_builder.get_and_reset(self.num_reqs)
+        if batch_update:
+            for processor in self.logitsprocs.all:
+                processor.update_state(batch_update)
 
     def make_prompt_token_ids_tensor(self) -> torch.Tensor:
         """Create a tensor of prompt token IDs, padded with -1.

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -142,10 +142,10 @@ class InputBatch:
         self.batch_update_builder = BatchUpdateBuilder()
 
         # Define logits processors.
-        self.logitsprocs = init_builtin_logitsprocs(
-            pin_memory_available=False,
-            max_num_reqs=max_num_reqs + 1,
-            device=torch.device("cpu"))
+        self.logitsprocs = init_builtin_logitsprocs(pin_memory_available=False,
+                                                    max_num_reqs=max_num_reqs +
+                                                    1,
+                                                    device=torch.device("cpu"))
 
         # Allowed token IDs tracking
         self.has_allowed_token_ids: set[str] = set()
@@ -282,11 +282,10 @@ class InputBatch:
             if self.allowed_token_ids_mask is None:
                 # Lazy allocation for this tensor, which can be large.
                 # True means we fill with -inf (disallowed).
-                self.allowed_token_ids_mask = torch.zeros(
-                    self.max_num_reqs,
-                    self.vocab_size,
-                    dtype=torch.bool,
-                    device="cpu")
+                self.allowed_token_ids_mask = torch.zeros(self.max_num_reqs,
+                                                          self.vocab_size,
+                                                          dtype=torch.bool,
+                                                          device="cpu")
             self.allowed_token_ids_mask[req_index] = True
             # False means we don't fill with -inf (allowed).
             self.allowed_token_ids_mask[req_index][
@@ -353,7 +352,8 @@ class InputBatch:
 
             # Track the move for logits processors
             self.batch_update_builder.moved.append(
-                (last_req_index, empty_index, MoveDirectionality.UNIDIRECTIONAL))
+                (last_req_index, empty_index,
+                 MoveDirectionality.UNIDIRECTIONAL))
 
             # Swap the states.
             req_id = self._req_ids[last_req_index]
@@ -405,8 +405,7 @@ class InputBatch:
             # Move allowed_token_ids_mask row
             if self.allowed_token_ids_mask is not None:
                 self.allowed_token_ids_mask[
-                    empty_index] = self.allowed_token_ids_mask[
-                        last_req_index]
+                    empty_index] = self.allowed_token_ids_mask[last_req_index]
 
             # Decrement last_req_index since it is now empty.
             last_req_index -= 1

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -61,10 +61,11 @@ class SamplingInputBatch:
         self.batch_update_builder = BatchUpdateBuilder()
 
         # Define logits processors.
-        self.logitsprocs = init_builtin_logitsprocs(pin_memory_available=False,
-                                                    max_num_reqs=max_num_reqs +
-                                                    1, # not sure why but match gpu_input_batch
-                                                    device=torch.device("cpu"))
+        self.logitsprocs = init_builtin_logitsprocs(
+            pin_memory_available=False,
+            max_num_reqs=max_num_reqs +
+            1,  # not sure why but match gpu_input_batch
+            device=torch.device("cpu"))
 
         # Allowed token IDs tracking
         self.has_allowed_token_ids: set[str] = set()
@@ -325,7 +326,8 @@ class InputBatch:
             self.random_reqs.clear()
             self.presence_penalties_reqs.clear()
             self.frequency_penalties_reqs.clear()
-            self.repetition_penalties_reqs.clear() #TODO I think these are taken care of by remove_request
+            self.repetition_penalties_reqs.clear(
+            )  #TODO I think these are taken care of by remove_request
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices
@@ -379,13 +381,13 @@ class InputBatch:
             sampling.repetition_penalty[empty_index] = (
                 sampling.repetition_penalty[last_req_index])
             sampling.seed[empty_index] = sampling.seed[last_req_index]
-            sampling.num_logprobs[empty_index] = sampling.num_logprobs[last_req_index]
+            sampling.num_logprobs[empty_index] = sampling.num_logprobs[
+                last_req_index]
 
             # Move host-only sampling params
             if last_req_index in self.sampling.generators:
                 self.sampling.generators[
-                    empty_index] = self.sampling.generators.pop(
-                        last_req_index)
+                    empty_index] = self.sampling.generators.pop(last_req_index)
 
             if last_req_index in self.sampling.bad_words_token_ids:
                 self.sampling.bad_words_token_ids[
@@ -405,7 +407,6 @@ class InputBatch:
         del self._req_ids[self.num_reqs:]
         del self.req_output_token_ids[self.num_reqs:]
 
-
     @property
     def max_num_logprobs(self) -> Optional[int]:
         """Returns the maximum logprobs value across all requests, or None."""
@@ -421,7 +422,8 @@ class InputBatch:
 
     def refresh_logitsprocs(self) -> None:
         """Update logits processors with batch state changes."""
-        batch_update = self.sampling.batch_update_builder.get_and_reset(self.num_reqs)
+        batch_update = self.sampling.batch_update_builder.get_and_reset(
+            self.num_reqs)
         if batch_update:
             for processor in self.sampling.logitsprocs.all:
                 processor.update_state(batch_update)

--- a/vllm/v1/worker/tt_input_batch.py
+++ b/vllm/v1/worker/tt_input_batch.py
@@ -178,18 +178,13 @@ class InputBatch:
                 and len(self.frequency_penalties_reqs) == 0
                 and len(self.repetition_penalties_reqs) == 0)
 
-    def _get_next_add_index(self) -> int:
-        # For TT, removed indices are managed by the model_runner, not here.
-        # Always append to end when req_index is not specified.
-        return self.num_reqs
-
     def add_request(
         self,
         request: "CachedRequestState",
         req_index: Optional[int] = None,
     ) -> None:
         if req_index is None:
-            req_index = self._get_next_add_index()
+            req_index = self.num_reqs
         assert req_index < self.max_num_reqs, (
             f"req_index={req_index} >= max_num_reqs={self.max_num_reqs}")
 
@@ -334,7 +329,7 @@ class InputBatch:
             self.random_reqs.clear()
             self.presence_penalties_reqs.clear()
             self.frequency_penalties_reqs.clear()
-            self.repetition_penalties_reqs.clear()
+            self.repetition_penalties_reqs.clear() #TODO I think these are taken care of by remove_request
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices
@@ -393,14 +388,10 @@ class InputBatch:
             if last_req_index in self.generators:
                 self.generators[empty_index] = self.generators.pop(
                     last_req_index)
-            else:
-                self.generators.pop(empty_index, None)
 
             if last_req_index in self.bad_words_token_ids:
                 self.bad_words_token_ids[
                     empty_index] = self.bad_words_token_ids.pop(last_req_index)
-            else:
-                self.bad_words_token_ids.pop(empty_index, None)
 
             # Move allowed_token_ids_mask row
             if self.allowed_token_ids_mask is not None:
@@ -414,9 +405,6 @@ class InputBatch:
         del self._req_ids[self.num_reqs:]
         del self.req_output_token_ids[self.num_reqs:]
 
-        # Clear removed indices since they've been compacted or are being
-        # managed by the caller (model_runner manages removed_req_indices)
-        self.batch_update_builder.removed.clear()
 
     @property
     def max_num_logprobs(self) -> Optional[int]:

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1361,6 +1361,9 @@ class TTModelRunner:
         if perform_device_sampling and model_input.max_num_logprobs > 0:
             assert isinstance(tt_out, tuple) and len(tt_out) == 2
             tt_out, tt_log_probs = tt_out
+        elif isinstance(tt_out, tuple):
+            # Model may return (logits, dummy_logprobs) even when not requested
+            tt_out, _ = tt_out
 
         return self._get_output_tokens(
             tt_out=tt_out,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -528,6 +528,8 @@ class TTModelRunner:
                 sample_params.pad_with_defaults(num_reqs)
 
         if is_prompt:
+            # Convert num_logprobs (int tensor) to enable_log_probs (bool tensor)
+            enable_log_probs = (sample_params.num_logprobs[:num_reqs] > 0)
             tt_sampling_params = TTSamplingParams(
                 temperature=sample_params.temperature[:num_reqs],
                 top_k=sample_params.top_k[:num_reqs],
@@ -536,9 +538,11 @@ class TTModelRunner:
                 frequency_penalty=sample_params.frequency_penalty[:num_reqs],
                 repetition_penalty=sample_params.repetition_penalty[:num_reqs],
                 seed=sample_params.seed[:num_reqs],
-                enable_log_probs=None,
+                enable_log_probs=enable_log_probs,
             )
         else:
+            # Convert num_logprobs (int tensor) to enable_log_probs (bool tensor)
+            enable_log_probs = (sample_params.num_logprobs > 0)
             tt_sampling_params = TTSamplingParams(
                 temperature=sample_params.temperature,
                 top_k=sample_params.top_k,
@@ -547,7 +551,7 @@ class TTModelRunner:
                 frequency_penalty=sample_params.frequency_penalty,
                 repetition_penalty=sample_params.repetition_penalty,
                 seed=sample_params.seed,
-                enable_log_probs=None,
+                enable_log_probs=enable_log_probs,
             )
         perform_device_sampling = self.check_perform_device_sampling(
             is_decode=not is_prompt)
@@ -706,6 +710,8 @@ class TTModelRunner:
             frequency_penalty = sampling_default_tensors["frequency_penalty"]
             repetition_penalty = sampling_default_tensors["repetition_penalty"]
             seed = sampling_default_tensors["seed"]
+            # enable_log_probs: convert num_logprobs > 0
+            enable_log_probs = (sampling_default_tensors["num_logprobs"] > 0)
         else:
             tokens = model_input.input_tokens
             positions = model_input.input_positions
@@ -730,6 +736,7 @@ class TTModelRunner:
             frequency_penalty = sampling_params.frequency_penalty
             repetition_penalty = sampling_params.repetition_penalty
             seed = sampling_params.seed
+            enable_log_probs = sampling_params.enable_log_probs
 
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
@@ -741,6 +748,7 @@ class TTModelRunner:
                 unpadded_batch_size.contiguous().view(-1),  # 1
                 top_k.contiguous().view(-1),  # B
                 seed.contiguous().view(-1),  # B
+                enable_log_probs.contiguous().view(-1).to(torch.int32),  # B (bool->int32)
             ],
             dim=0).contiguous()
 
@@ -895,6 +903,10 @@ class TTModelRunner:
             off += B
             seed = stacked_int[:, off:off + B].reshape(total_B)
             off += B
+            enable_log_probs_int = stacked_int[:, off:off + B].reshape(total_B)
+            off += B
+            # Convert back to bool tensor
+            enable_log_probs = (enable_log_probs_int > 0)
 
             # Optional structured inputs: keep as list[Optional[tensor]]
             # per DP rank to match prefill behavior.
@@ -976,6 +988,7 @@ class TTModelRunner:
             frequency_penalty_list: list[torch.Tensor] = []
             repetition_penalty_list: list[torch.Tensor] = []
             seed_list: list[torch.Tensor] = []
+            enable_log_probs_list: list[torch.Tensor] = []
             reset_batch = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
@@ -1022,6 +1035,7 @@ class TTModelRunner:
                     frequency_penalty_list.append(sp.frequency_penalty)
                     repetition_penalty_list.append(sp.repetition_penalty)
                     seed_list.append(sp.seed)
+                    enable_log_probs_list.append(sp.enable_log_probs)
 
                 # We know it's not a list here before concatenation
                 unpadded_batch_size: int = cast(
@@ -1063,6 +1077,7 @@ class TTModelRunner:
             frequency_penalty = torch.cat(frequency_penalty_list, dim=0)
             repetition_penalty = torch.cat(repetition_penalty_list, dim=0)
             seed = torch.cat(seed_list, dim=0)
+            enable_log_probs = torch.cat(enable_log_probs_list, dim=0)
 
         tt_sampling_params = TTSamplingParams(
             temperature=temperature,
@@ -1072,6 +1087,7 @@ class TTModelRunner:
             frequency_penalty=frequency_penalty,
             repetition_penalty=repetition_penalty,
             seed=seed,
+            enable_log_probs=enable_log_probs,
         )
 
         if self.model_config.is_multimodal_model and not is_decode:

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -597,11 +597,11 @@ class TTModelRunner:
 
         # Build host-only sampling params from input_batch
         allowed_token_ids_mask = None
-        if not input_batch.no_allowed_token_ids:
-            if input_batch.allowed_token_ids_mask is not None:
-                allowed_token_ids_mask = (
-                    input_batch.allowed_token_ids_mask[:input_batch.
-                                                       num_reqs].clone())
+        if not input_batch.no_allowed_token_ids and \
+            input_batch.allowed_token_ids_mask is not None:
+            allowed_token_ids_mask = (
+                input_batch.allowed_token_ids_mask[:input_batch.
+                                                    num_reqs].clone())
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1171,23 +1171,29 @@ class TTModelRunner:
         if not want_device_sampling:
             return False
 
-        # Host-only sampling params (logprobs, min_p, bad_words, logit_bias,
-        # allowed_token_ids, min_tokens) require host sampling.
-        # Check if any requests in the batch use these params.
+        # Calculate number of devices per DP rank
+        num_devices = (self.device_config.num_devices //
+                       self.parallel_config.data_parallel_size)
+
+        # Always host-only sampling params: min_p, bad_words, logit_bias,
+        # allowed_token_ids, min_tokens require host sampling.
         input_batch = self.input_batch
-        has_host_only_params = (
-            input_batch.num_logprobs  # logprobs requested
-            or not input_batch.no_allowed_token_ids  # allowed_token_ids set
+        has_always_host_only_params = (
+            not input_batch.no_allowed_token_ids  # allowed_token_ids set
             or input_batch.bad_words_token_ids  # bad_words set
             or input_batch.logitsprocs.has_active_processors()  # min_p, logit_bias, min_tokens
         )
-        if has_host_only_params:
+        if has_always_host_only_params:
             return False
-        # Device sampling currently doesn't support logprobs.
-        # TTPlatform.non_greedy_decoding_on_device must be True
-        # Also if logprobs is not None and devices_per_dp_cache == 1,
-        # logprobs on device is not supported
-        # (https://github.com/tenstorrent/tt-metal/issues/34077).
+
+        # Logprobs on device are only supported on multi-device setups (num_devices > 1).
+        # On single device, logprobs require host sampling.
+        # https://github.com/tenstorrent/tt-metal/issues/34077
+        if input_batch.num_logprobs and num_devices == 1:
+            return False
+
+        # TTPlatform.non_greedy_decoding_on_device must be True for random sampling,
+        # or all requests must be greedy without penalties.
         params_device_supported = TTPlatform.non_greedy_decoding_on_device or (
             self.input_batch.all_greedy and self.input_batch.no_penalties)
         return params_device_supported
@@ -1305,13 +1311,15 @@ class TTModelRunner:
                                                enable_trace=enable_trace,
                                                read_from_device=True)
 
-        # tt_out is a tuple of (logits, logprobs)
-        # v1 currently doesn't handle logprobs from TT models
+        # tt_out can be a tuple of (logits_or_tokens, logprobs) when device
+        # sampling is enabled with logprobs. Extract both components.
+        tt_log_probs = None
         if isinstance(tt_out, tuple):
-            tt_out = tt_out[0]
+            tt_out, tt_log_probs = tt_out
 
         return self._get_output_tokens(
             tt_out=tt_out,
+            tt_log_probs=tt_log_probs,
             sampling_params=sampling_params,
             model_input=model_input,
             batch_size_per_dp=batch_size_per_dp,
@@ -1322,6 +1330,7 @@ class TTModelRunner:
     def _get_output_tokens(
         self,
         tt_out: torch.Tensor,
+        tt_log_probs: Optional[torch.Tensor],
         sampling_params: TTSamplingParams,
         model_input: TTModelInput,
         batch_size_per_dp: list[int],
@@ -1330,10 +1339,14 @@ class TTModelRunner:
     ) -> tuple[list[torch.Tensor], list[Optional[LogprobsTensors]]]:
         """Return sampled tokens per DP rank using concatenated model
         outputs, plus optional logprobs per DP rank.
-        
+
         If perform_device_sampling is True, tokens are already sampled on
         device. Otherwise, sample on host using host_sampler.
-        
+
+        Args:
+            tt_out: Model output (logits or tokens depending on sampling mode)
+            tt_log_probs: Optional logprobs from device sampling (batch_size tensor)
+
         Returns:
             Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
             Each element in logprobs_per_dp is None if logprobs were not
@@ -1489,7 +1502,30 @@ class TTModelRunner:
             else:  # sample on device
                 # Grammar bitmask is applied on device
                 next_token_ids = tt_out[start:start + sz]
-                logprobs_per_dp.append(None)  # No logprobs with device sampling
+
+                # Extract logprobs if available from device sampling
+                if tt_log_probs is not None and model_input.max_num_logprobs:
+                    # TT device returns raw logprobs as [batch_size] tensor
+                    # containing log probability of the sampled token only.
+                    # Convert to LogprobsTensors format with minimal info.
+                    sampled_log_probs = tt_log_probs[start:start + sz]
+
+                    # Create LogprobsTensors with only sampled token info
+                    # Shape: [sz, 1] for token_ids and logprobs
+                    logprob_token_ids = next_token_ids.unsqueeze(-1).to(torch.int32)
+                    logprobs_values = sampled_log_probs.unsqueeze(-1).to(torch.float32)
+                    # Rank is unknown with device sampling, use -1 to indicate
+                    selected_token_ranks = torch.full((sz,), -1, dtype=torch.int32)
+
+                    logprobs_tensors = LogprobsTensors(
+                        logprob_token_ids=logprob_token_ids,
+                        logprobs=logprobs_values,
+                        selected_token_ranks=selected_token_ranks,
+                    )
+                    logprobs_per_dp.append(logprobs_tensors)
+                else:
+                    logprobs_per_dp.append(None)
+
             sampled_token_ids_per_dp.append(next_token_ids.view(sz, 1))
 
             if is_decode:

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -17,8 +17,8 @@ from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 from vllm.utils import LayerBlockType, cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
-from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsTensors,
-                             ModelRunnerOutput)
+from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsLists,
+                             LogprobsTensors, ModelRunnerOutput)
 from vllm.v1.sample.logits_processor import LogitsProcessorManager
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
@@ -77,6 +77,18 @@ class TTModelInput:
     # Decode-only: indicates the padded decode-batch layout changed since the
     # previous step (used by on-device sampling).
     reset_batch: bool = False
+
+    # Host-only sampling params - lists for DP (one per rank), single-element
+    # for non-DP. These are used for host sampling when device sampling is not
+    # supported.
+    # allowed_token_ids_mask: list of (num_reqs, vocab_size) bool tensors
+    allowed_token_ids_mask_list: Optional[list[Optional[torch.Tensor]]] = None
+    # bad_words_token_ids: list of dicts mapping req_index -> token_ids
+    bad_words_token_ids_list: Optional[list[dict[int, list[list[int]]]]] = None
+    # max_num_logprobs: max logprobs value across all requests
+    max_num_logprobs: Optional[int] = None
+    # logitsprocs: list of LogitsProcessorManager (one per rank)
+    logitsprocs_list: Optional[list["LogitsProcessorManager"]] = None
 
 
 class TTModelRunner:
@@ -583,6 +595,14 @@ class TTModelRunner:
                                dtype=torch.int32)
                 ])
 
+        # Build host-only sampling params from input_batch
+        allowed_token_ids_mask = None
+        if not input_batch.no_allowed_token_ids:
+            if input_batch.allowed_token_ids_mask is not None:
+                allowed_token_ids_mask = (
+                    input_batch.allowed_token_ids_mask[:input_batch.num_reqs]
+                    .clone())
+
         return TTModelInput(
             input_tokens=input_tokens,
             input_positions=input_positions,
@@ -596,6 +616,11 @@ class TTModelRunner:
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
             reset_batch=reset_batch,
+            # Host-only params - wrapped in lists for DP compatibility
+            allowed_token_ids_mask_list=[allowed_token_ids_mask],
+            bad_words_token_ids_list=[input_batch.bad_words_token_ids.copy()],
+            max_num_logprobs=input_batch.max_num_logprobs,
+            logitsprocs_list=[input_batch.logitsprocs],
         )
 
     def build_model_input(
@@ -614,6 +639,9 @@ class TTModelRunner:
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
             return None
+
+        # Refresh logits processors with batch state changes
+        self.input_batch.refresh_logitsprocs()
 
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output)
@@ -720,10 +748,27 @@ class TTModelRunner:
                 "output_tokens": model_input.output_tokens,
             }
 
+        # Host-only params for host sampling
+        host_only_params = None
+        if model_input is not None:
+            host_only_params = {
+                "allowed_token_ids_mask": (
+                    model_input.allowed_token_ids_mask_list[0]
+                    if model_input.allowed_token_ids_mask_list else None),
+                "bad_words_token_ids": (
+                    model_input.bad_words_token_ids_list[0]
+                    if model_input.bad_words_token_ids_list else {}),
+                "max_num_logprobs": model_input.max_num_logprobs,
+                "logitsprocs": (
+                    model_input.logitsprocs_list[0]
+                    if model_input.logitsprocs_list else None),
+            }
+
         result = {
             "int_inputs": int_inputs,
             "float_inputs": float_inputs,
             "sampling_tokens_inputs": sampling_tokens_inputs,
+            "host_only_params": host_only_params,
         }
 
         return result
@@ -837,6 +882,37 @@ class TTModelRunner:
             else:
                 grammar_bitmask_list = [None] * world
 
+            # Extract host-only params from gathered inputs (per-rank lists)
+            host_only_params_list = inputs.get("host_only_params")
+            allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
+            bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
+            logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
+            max_num_logprobs: Optional[int] = None
+            if host_only_params_list:
+                for rank_params in host_only_params_list:
+                    if rank_params is not None:
+                        allowed_token_ids_mask_list.append(
+                            rank_params.get("allowed_token_ids_mask"))
+                        bad_words_token_ids_list.append(
+                            rank_params.get("bad_words_token_ids", {}))
+                        logitsprocs_list.append(rank_params.get("logitsprocs"))
+                        rank_logprobs = rank_params.get("max_num_logprobs")
+                        if rank_logprobs is not None:
+                            if max_num_logprobs is None:
+                                max_num_logprobs = rank_logprobs
+                            else:
+                                max_num_logprobs = max(max_num_logprobs,
+                                                       rank_logprobs)
+                    else:
+                        allowed_token_ids_mask_list.append(None)
+                        bad_words_token_ids_list.append({})
+                        logitsprocs_list.append(None)
+            else:
+                # No host-only params - create empty lists
+                allowed_token_ids_mask_list = [None] * world
+                bad_words_token_ids_list = [{}] * world
+                logitsprocs_list = [None] * world
+
             off_f = 0
             temperature = stacked_float[:, off_f:off_f + B].reshape(total_B)
             off_f += B
@@ -869,6 +945,11 @@ class TTModelRunner:
             frequency_penalty_list: list[torch.Tensor] = []
             repetition_penalty_list: list[torch.Tensor] = []
             seed_list: list[torch.Tensor] = []
+            # Host-only params (per-rank lists)
+            allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
+            bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
+            logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
+            max_num_logprobs: Optional[int] = None
             reset_batch = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
@@ -922,6 +1003,28 @@ class TTModelRunner:
                 batch_size_per_dp.append(unpadded_batch_size)
                 grammar_bitmask_list.append(
                     mi.grammar_bitmask[0] if mi else None)
+
+                # Collect host-only params per rank
+                if mi is not None:
+                    allowed_token_ids_mask_list.append(
+                        mi.allowed_token_ids_mask_list[0]
+                        if mi.allowed_token_ids_mask_list else None)
+                    bad_words_token_ids_list.append(
+                        mi.bad_words_token_ids_list[0]
+                        if mi.bad_words_token_ids_list else {})
+                    logitsprocs_list.append(
+                        mi.logitsprocs_list[0]
+                        if mi.logitsprocs_list else None)
+                    if mi.max_num_logprobs is not None:
+                        if max_num_logprobs is None:
+                            max_num_logprobs = mi.max_num_logprobs
+                        else:
+                            max_num_logprobs = max(max_num_logprobs,
+                                                   mi.max_num_logprobs)
+                else:
+                    allowed_token_ids_mask_list.append(None)
+                    bad_words_token_ids_list.append({})
+                    logitsprocs_list.append(None)
 
             input_tokens = torch.cat(input_tokens_list, dim=0)
             input_positions = np.concatenate(input_positions_list, axis=0)
@@ -1028,6 +1131,11 @@ class TTModelRunner:
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
             reset_batch=reset_batch,
+            # Host-only params (per-rank lists)
+            allowed_token_ids_mask_list=allowed_token_ids_mask_list,
+            bad_words_token_ids_list=bad_words_token_ids_list,
+            max_num_logprobs=max_num_logprobs,
+            logitsprocs_list=logitsprocs_list,
         )
         return merged
 
@@ -1050,8 +1158,11 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         # Only 1 DP rank here
-        sampled_token_ids = self.execute_with_model_input(model_input)[0]
-        output = self.generate_runner_output(sampled_token_ids)
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(model_input)
+        sampled_token_ids = sampled_token_ids_per_dp[0]
+        logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
+        logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
+        output = self.generate_runner_output(sampled_token_ids, logprobs)
         return output
 
     def check_perform_device_sampling(self, is_decode: bool) -> bool:
@@ -1060,12 +1171,21 @@ class TTModelRunner:
         if not want_device_sampling:
             return False
 
-        # Currently requests with logprobs fail on request
-        # validation, but once supported, the TODOs below will be relevant.
-        # TODO: Also if logprobs are not None,
+        # Host-only sampling params (logprobs, min_p, bad_words, logit_bias,
+        # allowed_token_ids, min_tokens) require host sampling.
+        # Check if any requests in the batch use these params.
+        input_batch = self.input_batch
+        has_host_only_params = (
+            input_batch.num_logprobs  # logprobs requested
+            or not input_batch.no_allowed_token_ids  # allowed_token_ids set
+            or input_batch.bad_words_token_ids  # bad_words set
+            or input_batch.logitsprocs.has_active_processors()  # min_p, logit_bias, min_tokens
+        )
+        if has_host_only_params:
+            return False
+        # Device sampling currently doesn't support logprobs.
         # TTPlatform.non_greedy_decoding_on_device must be True
-        # (model limitations).
-        # TODO: Also if logprobs is not None and devices_per_dp_cache == 1,
+        # Also if logprobs is not None and devices_per_dp_cache == 1,
         # logprobs on device is not supported
         # (https://github.com/tenstorrent/tt-metal/issues/34077).
         params_device_supported = TTPlatform.non_greedy_decoding_on_device or (
@@ -1075,11 +1195,16 @@ class TTModelRunner:
     def execute_with_model_input(
         self,
         model_input: TTModelInput,
-    ) -> list[torch.Tensor]:
+    ) -> tuple[list[torch.Tensor], list[Optional[LogprobsTensors]]]:
         """
         Execute with a prebuilt input and return per-DP sampled ids without
         mutating internal state. In DP case, called by DP rank 0 to run merged
         batch. Note: currently does not support chunked prefill.
+        
+        Returns:
+            Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
+            Each element in logprobs_per_dp is None if logprobs were not
+            requested for that DP rank.
         """
         is_decode = model_input.prompt_lens is None
 
@@ -1087,8 +1212,9 @@ class TTModelRunner:
         if not isinstance(batch_size_per_dp, list):
             batch_size_per_dp = [batch_size_per_dp]
         if not any(bs > 0 for bs in batch_size_per_dp):
-            return [torch.tensor([], dtype=torch.int32)
-                    ] * len(batch_size_per_dp)
+            num_dp = len(batch_size_per_dp)
+            return ([torch.tensor([], dtype=torch.int32)] * num_dp,
+                    [None] * num_dp)
 
         kwargs = {
             "tokens": model_input.input_tokens,
@@ -1201,20 +1327,27 @@ class TTModelRunner:
         batch_size_per_dp: list[int],
         perform_device_sampling: bool,
         is_decode: bool,
-    ) -> list[torch.Tensor]:
+    ) -> tuple[list[torch.Tensor], list[Optional[LogprobsTensors]]]:
         """Return sampled tokens per DP rank using concatenated model
-        outputs.
+        outputs, plus optional logprobs per DP rank.
         
         If perform_device_sampling is True, tokens are already sampled on
         device. Otherwise, sample on host using host_sampler.
+        
+        Returns:
+            Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
+            Each element in logprobs_per_dp is None if logprobs were not
+            requested for that DP rank.
         """
         sampled_token_ids_per_dp: list[torch.Tensor] = []
+        logprobs_per_dp: list[Optional[LogprobsTensors]] = []
 
         start = 0
         for dp_rank, sz in enumerate(batch_size_per_dp):
             if sz <= 0:
                 sampled_token_ids_per_dp.append(
                     torch.tensor([], dtype=torch.int32))
+                logprobs_per_dp.append(None)
                 if is_decode:
                     # Fixed stride segments per DP rank for decode
                     start += self.scheduler_config.max_num_seqs
@@ -1304,8 +1437,29 @@ class TTModelRunner:
                         prompt_token_ids = prompt_token_ids.masked_fill(
                             pad_mask, self.vocab_size)
 
+                # Get host-only sampling params from model_input (per-rank lists).
+                # These are populated for both DP and non-DP cases.
+                rank_max_num_logprobs = model_input.max_num_logprobs
+                allowed_token_ids_mask = None
+                if (model_input.allowed_token_ids_mask_list
+                        and model_input.allowed_token_ids_mask_list[dp_rank]
+                        is not None):
+                    rank_mask = model_input.allowed_token_ids_mask_list[dp_rank]
+                    # Slice to actual batch size for this rank
+                    allowed_token_ids_mask = rank_mask[:sz]
+
+                bad_words_token_ids: dict[int, list[list[int]]] = {}
+                if (model_input.bad_words_token_ids_list
+                        and model_input.bad_words_token_ids_list[dp_rank]):
+                    bad_words_token_ids = model_input.bad_words_token_ids_list[
+                        dp_rank]
+
+                logitsprocs = (model_input.logitsprocs_list[dp_rank]
+                               if model_input.logitsprocs_list
+                               and model_input.logitsprocs_list[dp_rank] is not None
+                               else LogitsProcessorManager())
+
                 # Create SamplingMetadata for this DP rank
-                # TODO: support logprobs
                 sampling_metadata = SamplingMetadata(
                     temperature=temperature if not all_greedy else None,
                     all_greedy=all_greedy,
@@ -1313,16 +1467,16 @@ class TTModelRunner:
                     top_p=top_p,
                     top_k=top_k,
                     generators=generators,
-                    max_num_logprobs=None,
+                    max_num_logprobs=rank_max_num_logprobs,
                     no_penalties=no_penalties,
                     prompt_token_ids=prompt_token_ids,
                     frequency_penalties=frequency_penalty,
                     presence_penalties=presence_penalty,
                     repetition_penalties=repetition_penalty,
                     output_token_ids=output_token_ids,
-                    allowed_token_ids_mask=None,
-                    bad_words_token_ids={},
-                    logitsprocs=LogitsProcessorManager(),
+                    allowed_token_ids_mask=allowed_token_ids_mask,
+                    bad_words_token_ids=bad_words_token_ids,
+                    logitsprocs=logitsprocs,
                 )
 
                 sampler_output = self.host_sampler(
@@ -1330,9 +1484,12 @@ class TTModelRunner:
                     sampling_metadata=sampling_metadata,
                 )
                 next_token_ids = sampler_output.sampled_token_ids
+                # Capture logprobs for this DP rank
+                logprobs_per_dp.append(sampler_output.logprobs_tensors)
             else:  # sample on device
                 # Grammar bitmask is applied on device
                 next_token_ids = tt_out[start:start + sz]
+                logprobs_per_dp.append(None)  # No logprobs with device sampling
             sampled_token_ids_per_dp.append(next_token_ids.view(sz, 1))
 
             if is_decode:
@@ -1342,7 +1499,7 @@ class TTModelRunner:
                 # Prefill packed contiguously
                 start += sz
 
-        return sampled_token_ids_per_dp
+        return sampled_token_ids_per_dp, logprobs_per_dp
 
     def apply_grammar_bitmask(self, logits: torch.Tensor,
                               grammar_bitmask: torch.Tensor) -> None:
@@ -1363,7 +1520,17 @@ class TTModelRunner:
                                                     -1)[:, :logits.shape[-1]]
         logits.masked_fill_(unpacked_bitmask, -float("inf"))
 
-    def generate_runner_output(self, sampled_token_ids: torch.Tensor):
+    def generate_runner_output(
+        self,
+        sampled_token_ids: torch.Tensor,
+        logprobs: Optional[LogprobsLists] = None,
+    ):
+        """Generate ModelRunnerOutput from sampled tokens and optional logprobs.
+        
+        Args:
+            sampled_token_ids: Sampled token IDs tensor.
+            logprobs: LogprobsLists (already converted from tensors).
+        """
         # Cache the sampled tokens in the model runner, so that the scheduler
         # doesn't need to send them back.
         num_reqs = self.input_batch.num_reqs
@@ -1405,14 +1572,13 @@ class TTModelRunner:
                                        self.input_batch.req_ids[:num_reqs],
                                        None))
 
-        # Note: currently does not support speculative decoding, log probs,
-        # or pooling.
+        # Note: currently does not support speculative decoding or pooling.
         return ModelRunnerOutput(
             req_ids=self.input_batch.req_ids,
             req_id_to_index=self.input_batch.req_id_to_index,
             sampled_token_ids=[[t] for t in sampled_token_ids_list_1d],
             spec_token_ids=None,
-            logprobs=None,
+            logprobs=logprobs,
             prompt_logprobs_dict=prompt_logprobs_dict,
             pooler_output=[],
         )

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1190,7 +1190,7 @@ class TTModelRunner:
         # Also, only the sampled token's logprob is returned on device, not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if input_batch.num_logprobs and (num_devices == 1 or input_batch.num_logprobs > 1):
+        if input_batch.num_logprobs and (num_devices == 1 or any(x>1 for x in input_batch.num_logprobs.values())):
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True for random sampling,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -531,7 +531,8 @@ class TTModelRunner:
                 sample_params.pad_with_defaults(num_reqs)
 
         if is_prompt:
-            # Convert num_logprobs (int tensor) to enable_log_probs (bool tensor)
+            # Convert num_logprobs (int tensor)
+            # to enable_log_probs (bool tensor)
             enable_log_probs = (sample_params.num_logprobs[:num_reqs] > 0)
             tt_sampling_params = TTSamplingParams(
                 temperature=sample_params.temperature[:num_reqs],
@@ -544,7 +545,8 @@ class TTModelRunner:
                 enable_log_probs=enable_log_probs,
             )
         else:
-            # Convert num_logprobs (int tensor) to enable_log_probs (bool tensor)
+            # Convert num_logprobs (int tensor)
+            # to enable_log_probs (bool tensor)
             enable_log_probs = (sample_params.num_logprobs > 0)
             tt_sampling_params = TTSamplingParams(
                 temperature=sample_params.temperature,
@@ -928,7 +930,8 @@ class TTModelRunner:
             else:
                 grammar_bitmask_list = [None] * world
 
-            # Extract host-only sampling params from gathered inputs (per-rank lists)
+            # Extract host-only sampling params
+            # from gathered inputs (per-rank lists)
             host_only_sample_params_list = inputs.get(
                 "host_only_sample_params")
             if host_only_sample_params_list:
@@ -1449,7 +1452,6 @@ class TTModelRunner:
                     start:start + sz]
                 repetition_penalty = sampling_params.repetition_penalty[
                     start:start + sz]
-                seed = sampling_params.seed[start:start + sz]
 
                 # Determine if all greedy (temperature == 0.0) or all random
                 all_greedy = (temperature == 0.0).all().item()
@@ -1546,8 +1548,10 @@ class TTModelRunner:
 
                 # Extract logprobs if available from device sampling
                 if model_input.max_num_logprobs:
-                    # Sanity check for if we correctly detect when logprobs are supported.
-                    assert tt_log_probs is not None, "model should return logprobs when requested"
+                    # Sanity check for if we correctly detect
+                    # when logprobs are supported.
+                    assert tt_log_probs is not None,\
+                        "model should return logprobs when requested"
                     # TT device returns raw logprobs as [batch_size] tensor
                     # containing log probability of the sampled token only.
                     # Convert to LogprobsTensors format with minimal info.

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -13,6 +13,7 @@ from vllm.logger import init_logger
 from vllm.model_executor.model_loader.tt_loader import TTModelLoader
 from vllm.multimodal.inputs import MultiModalKwargs
 from vllm.platforms.tt import TTPlatform
+from vllm.sampling_params import SamplingType
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.config import uses_mrope
 from vllm.utils import LayerBlockType, cdiv
@@ -22,7 +23,6 @@ from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsLists,
 from vllm.v1.sample.logits_processor import LogitsProcessorManager
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
-from vllm.sampling_params import SamplingType
 from vllm.v1.worker.tt_input_batch import (SEED_NONE_SENTINEL,
                                            CachedRequestState, InputBatch)
 from vllm.worker.tt_model_runner import decode_warmup, prefill_warmup
@@ -650,11 +650,12 @@ class TTModelRunner:
             reset_batch=reset_batch,
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
-            bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids],
+            bad_words_token_ids_list=[
+                input_batch.sampling.bad_words_token_ids
+            ],
             max_num_logprobs=input_batch.max_num_logprobs,
             logitsprocs_list=[input_batch.sampling.logitsprocs],
-            generators_list=[generators]
-        )
+            generators_list=[generators])
 
     def build_model_input(
         self,
@@ -748,7 +749,8 @@ class TTModelRunner:
                 unpadded_batch_size.contiguous().view(-1),  # 1
                 top_k.contiguous().view(-1),  # B
                 seed.contiguous().view(-1),  # B
-                enable_log_probs.contiguous().view(-1).to(torch.int32),  # B (bool->int32)
+                enable_log_probs.contiguous().view(-1).to(
+                    torch.int32),  # B (bool->int32)
             ],
             dim=0).contiguous()
 
@@ -927,7 +929,8 @@ class TTModelRunner:
                 grammar_bitmask_list = [None] * world
 
             # Extract host-only sampling params from gathered inputs (per-rank lists)
-            host_only_sample_params_list = inputs.get("host_only_sample_params")
+            host_only_sample_params_list = inputs.get(
+                "host_only_sample_params")
             if host_only_sample_params_list:
                 for rank_params in host_only_sample_params_list:
                     if rank_params is not None:
@@ -943,7 +946,8 @@ class TTModelRunner:
                             else:
                                 max_num_logprobs = max(max_num_logprobs,
                                                        rank_logprobs)
-                        generators_list.append(rank_params.get("generators", {}))
+                        generators_list.append(
+                            rank_params.get("generators", {}))
                     else:
                         allowed_token_ids_mask_list.append(None)
                         bad_words_token_ids_list.append({})

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -67,8 +67,17 @@ class TTModelInput:
     perform_device_sampling: bool
 
     # always lists: single-element for non-DP, multi-element for DP
-    # If not using structured outputs, [None]
+    # If not used, [None]
     grammar_bitmask: list[Optional[torch.Tensor]]
+
+    # Host-only sampling params - lists for DP (one per rank), single-element
+    # for non-DP. These are used for host sampling when device sampling is not
+    # supported.
+    logitsprocs_list: list[Optional["LogitsProcessorManager"]]
+    # bad_words_token_ids: list of dicts mapping req_index -> token_ids
+    bad_words_token_ids_list: list[dict[int, list[list[int]]]]
+    # allowed_token_ids_mask: list of (num_reqs, vocab_size) bool tensors
+    allowed_token_ids_mask_list: list[Optional[torch.Tensor]]
 
     # Optional: tokens for sampling with penalties during decode
     prompt_tokens: Optional[torch.Tensor] = None
@@ -78,17 +87,8 @@ class TTModelInput:
     # previous step (used by on-device sampling).
     reset_batch: bool = False
 
-    # Host-only sampling params - lists for DP (one per rank), single-element
-    # for non-DP. These are used for host sampling when device sampling is not
-    # supported.
-    # allowed_token_ids_mask: list of (num_reqs, vocab_size) bool tensors
-    allowed_token_ids_mask_list: Optional[list[Optional[torch.Tensor]]] = None
-    # bad_words_token_ids: list of dicts mapping req_index -> token_ids
-    bad_words_token_ids_list: Optional[list[dict[int, list[list[int]]]]] = None
     # max_num_logprobs: max logprobs value across all requests
     max_num_logprobs: Optional[int] = None
-    # logitsprocs: list of LogitsProcessorManager (one per rank)
-    logitsprocs_list: Optional[list["LogitsProcessorManager"]] = None
 
 
 class TTModelRunner:
@@ -601,7 +601,7 @@ class TTModelRunner:
             input_batch.allowed_token_ids_mask is not None:
             allowed_token_ids_mask = (
                 input_batch.allowed_token_ids_mask[:input_batch.
-                                                    num_reqs].clone())
+                                                   num_reqs].clone())
 
         return TTModelInput(
             input_tokens=input_tokens,
@@ -753,15 +753,13 @@ class TTModelRunner:
         if model_input is not None:
             host_only_params = {
                 "allowed_token_ids_mask":
-                (model_input.allowed_token_ids_mask_list[0]
-                 if model_input.allowed_token_ids_mask_list else None),
+                model_input.allowed_token_ids_mask_list[0],
                 "bad_words_token_ids":
-                (model_input.bad_words_token_ids_list[0]
-                 if model_input.bad_words_token_ids_list else {}),
+                model_input.bad_words_token_ids_list[0],
                 "max_num_logprobs":
                 model_input.max_num_logprobs,
-                "logitsprocs": (model_input.logitsprocs_list[0]
-                                if model_input.logitsprocs_list else None),
+                "logitsprocs":
+                model_input.logitsprocs_list[0],
             }
 
         result = {
@@ -809,6 +807,7 @@ class TTModelRunner:
         allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
         bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
         logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
+        max_num_logprobs: Optional[int] = None
 
         if is_decode:
             # For decode, given gathered flattened tensors from all DP ranks.
@@ -888,7 +887,6 @@ class TTModelRunner:
 
             # Extract host-only params from gathered inputs (per-rank lists)
             host_only_params_list = inputs.get("host_only_params")
-            max_num_logprobs: Optional[int] = None
             if host_only_params_list:
                 for rank_params in host_only_params_list:
                     if rank_params is not None:
@@ -946,7 +944,6 @@ class TTModelRunner:
             frequency_penalty_list: list[torch.Tensor] = []
             repetition_penalty_list: list[torch.Tensor] = []
             seed_list: list[torch.Tensor] = []
-            max_num_logprobs: Optional[int] = None
             reset_batch = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
@@ -1004,13 +1001,10 @@ class TTModelRunner:
                 # Collect host-only params per rank
                 if mi is not None:
                     allowed_token_ids_mask_list.append(
-                        mi.allowed_token_ids_mask_list[0] if mi.
-                        allowed_token_ids_mask_list else None)
+                        mi.allowed_token_ids_mask_list[0])
                     bad_words_token_ids_list.append(
-                        mi.bad_words_token_ids_list[0] if mi.
-                        bad_words_token_ids_list else {})
-                    logitsprocs_list.append(mi.logitsprocs_list[0] if mi.
-                                            logitsprocs_list else None)
+                        mi.bad_words_token_ids_list[0])
+                    logitsprocs_list.append(mi.logitsprocs_list[0])
                     if mi.max_num_logprobs is not None:
                         if max_num_logprobs is None:
                             max_num_logprobs = mi.max_num_logprobs
@@ -1154,7 +1148,7 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         # Only 1 DP rank here
-        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input( # noqa: E501
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(  # noqa: E501
             model_input)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
@@ -1184,9 +1178,9 @@ class TTModelRunner:
         if has_always_host_only_params:
             return False
 
-        # Logprobs on device are only supported on multi-device setups 
+        # Logprobs on device are only supported on multi-device setups
         # (num_devices > 1)
-        # Also, only the sampled token's logprob is returned on device, 
+        # Also, only the sampled token's logprob is returned on device,
         # not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
@@ -1195,7 +1189,7 @@ class TTModelRunner:
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True
-        # for random sampling, 
+        # for random sampling,
         # or all requests must be greedy without penalties.
         params_device_supported = TTPlatform.non_greedy_decoding_on_device or (
             self.input_batch.all_greedy and self.input_batch.no_penalties)
@@ -1457,25 +1451,18 @@ class TTModelRunner:
                 # (per-rank lists).
                 # These are populated for both DP and non-DP cases.
                 rank_max_num_logprobs = model_input.max_num_logprobs
-                allowed_token_ids_mask = None
-                if (model_input.allowed_token_ids_mask_list
-                        and model_input.allowed_token_ids_mask_list[dp_rank]
-                        is not None):
-                    rank_mask = model_input.allowed_token_ids_mask_list[
-                        dp_rank]
+                allowed_token_ids_mask = model_input.allowed_token_ids_mask_list[  # noqa: E501
+                    dp_rank]
+                if allowed_token_ids_mask is not None:
                     # Slice to actual batch size for this rank
-                    allowed_token_ids_mask = rank_mask[:sz]
+                    allowed_token_ids_mask = allowed_token_ids_mask[:sz]
 
-                bad_words_token_ids: dict[int, list[list[int]]] = {}
-                if (model_input.bad_words_token_ids_list
-                        and model_input.bad_words_token_ids_list[dp_rank]):
-                    bad_words_token_ids = model_input.bad_words_token_ids_list[
-                        dp_rank]
+                bad_words_token_ids = model_input.bad_words_token_ids_list[
+                    dp_rank]
 
-                logitsprocs = (model_input.logitsprocs_list[dp_rank]
-                               if model_input.logitsprocs_list
-                               and model_input.logitsprocs_list[dp_rank]
-                               is not None else LogitsProcessorManager())
+                logitsprocs = model_input.logitsprocs_list[dp_rank]
+                if logitsprocs is None:
+                    logitsprocs = LogitsProcessorManager()
 
                 # Create SamplingMetadata for this DP rank
                 sampling_metadata = SamplingMetadata(

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -645,7 +645,7 @@ class TTModelRunner:
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
             reset_batch=reset_batch,
-            # Host-only params - wrapped in lists for DP compatibility
+            # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
             bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids.copy()],
             max_num_logprobs=input_batch.max_num_logprobs,
@@ -782,10 +782,10 @@ class TTModelRunner:
                 "output_tokens": model_input.output_tokens,
             }
 
-        # Host-only params for host sampling
-        host_only_params = None
+        # Host-only sampling params for host sampling
+        host_only_sample_params = None
         if model_input is not None:
-            host_only_params = {
+            host_only_sample_params = {
                 "allowed_token_ids_mask":
                 model_input.allowed_token_ids_mask_list[0],
                 "bad_words_token_ids":
@@ -802,7 +802,7 @@ class TTModelRunner:
             "int_inputs": int_inputs,
             "float_inputs": float_inputs,
             "sampling_tokens_inputs": sampling_tokens_inputs,
-            "host_only_params": host_only_params,
+            "host_only_sample_params": host_only_sample_params,
         }
 
         return result
@@ -926,10 +926,10 @@ class TTModelRunner:
             else:
                 grammar_bitmask_list = [None] * world
 
-            # Extract host-only params from gathered inputs (per-rank lists)
-            host_only_params_list = inputs.get("host_only_params")
-            if host_only_params_list:
-                for rank_params in host_only_params_list:
+            # Extract host-only sampling params from gathered inputs (per-rank lists)
+            host_only_sample_params_list = inputs.get("host_only_sample_params")
+            if host_only_sample_params_list:
+                for rank_params in host_only_sample_params_list:
                     if rank_params is not None:
                         allowed_token_ids_mask_list.append(
                             rank_params.get("allowed_token_ids_mask"))
@@ -950,7 +950,7 @@ class TTModelRunner:
                         logitsprocs_list.append(None)
                         generators_list.append({})
             else:
-                # No host-only params - create empty lists
+                # No host-only sampling params - create empty lists
                 allowed_token_ids_mask_list = [None] * world
                 bad_words_token_ids_list = [{}] * world
                 logitsprocs_list = [None] * world
@@ -1044,7 +1044,7 @@ class TTModelRunner:
                 grammar_bitmask_list.append(
                     mi.grammar_bitmask[0] if mi else None)
 
-                # Collect host-only params per rank
+                # Collect host-only sampling params per rank
                 if mi is not None:
                     allowed_token_ids_mask_list.append(
                         mi.allowed_token_ids_mask_list[0])
@@ -1171,7 +1171,7 @@ class TTModelRunner:
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
             reset_batch=reset_batch,
-            # Host-only params (per-rank lists)
+            # Host-only sampling params (per-rank lists)
             allowed_token_ids_mask_list=allowed_token_ids_mask_list,
             bad_words_token_ids_list=bad_words_token_ids_list,
             max_num_logprobs=max_num_logprobs,
@@ -1220,13 +1220,13 @@ class TTModelRunner:
         # Always host-only sampling params: min_p, bad_words, logit_bias,
         # allowed_token_ids, min_tokens require host sampling.
         input_batch = self.input_batch
-        has_always_host_only_params = (
+        has_always_host_only_sampling_params = (
             not input_batch.no_allowed_token_ids  # allowed_token_ids set
             or input_batch.sampling.bad_words_token_ids  # bad_words set
             or input_batch.sampling.logitsprocs.has_active_processors(
             )  # min_p, logit_bias, min_tokens
         )
-        if has_always_host_only_params:
+        if has_always_host_only_sampling_params:
             return False
 
         # Logprobs on device are only supported on multi-device setups

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1231,8 +1231,8 @@ class TTModelRunner:
         # not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if input_batch.sampling.num_logprobs and (num_devices == 1 or any(
-                x > 1 for x in input_batch.sampling.num_logprobs.values())):
+        max_lp = input_batch.max_num_logprobs
+        if max_lp > 1 or (max_lp > 0 and num_devices == 1):
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1362,7 +1362,8 @@ class TTModelRunner:
         # tt_out can be a tuple of (logits_or_tokens, logprobs) when device
         # sampling is enabled with logprobs. Extract both components.
         tt_log_probs = None
-        if isinstance(tt_out, tuple):
+        if perform_device_sampling and model_input.max_num_logprobs > 0:
+            assert isinstance(tt_out, tuple) and len(tt_out) == 2
             tt_out, tt_log_probs = tt_out
 
         return self._get_output_tokens(
@@ -1540,7 +1541,9 @@ class TTModelRunner:
                 next_token_ids = tt_out[start:start + sz]
 
                 # Extract logprobs if available from device sampling
-                if tt_log_probs is not None and model_input.max_num_logprobs:
+                if model_input.max_num_logprobs:
+                    # Sanity check for if we correctly detect when logprobs are supported.
+                    assert tt_log_probs is not None, "model should return logprobs when requested"
                     # TT device returns raw logprobs as [batch_size] tensor
                     # containing log probability of the sampled token only.
                     # Convert to LogprobsTensors format with minimal info.

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -383,6 +383,9 @@ class TTModelRunner:
         if persistent_batch_layout_changed:
             self._decode_layout_changed_since_last_decode = True
 
+        # Refresh logits processors with batch state changes
+        self.input_batch.refresh_logitsprocs()
+
     def _validate_mm_input(self, mm_input: MultiModalKwargs) -> None:
         """Validate multi-modal input supports only single images."""
         if list(mm_input.modalities) != ["image"]:
@@ -669,9 +672,6 @@ class TTModelRunner:
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
             return None
-
-        # Refresh logits processors with batch state changes
-        self.input_batch.refresh_logitsprocs()
 
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -647,7 +647,7 @@ class TTModelRunner:
             reset_batch=reset_batch,
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
-            bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids.copy()],
+            bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids],
             max_num_logprobs=input_batch.max_num_logprobs,
             logitsprocs_list=[input_batch.sampling.logitsprocs],
             generators_list=[generators]

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -79,7 +79,12 @@ class TTModelInput:
     bad_words_token_ids_list: list[dict[int, list[list[int]]]]
     # allowed_token_ids_mask: list of (num_reqs, vocab_size) bool tensors
     allowed_token_ids_mask_list: list[Optional[torch.Tensor]]
+    # list of dicts mapping req_index -> generator for each DP rank
+    # only set for host sampling
+    generators_list: list[dict[int, torch.Generator]]
 
+    # max_num_logprobs: max logprobs value across all requests
+    max_num_logprobs: int
     # Optional: tokens for sampling with penalties during decode
     prompt_tokens: Optional[torch.Tensor] = None
     output_tokens: Optional[torch.Tensor] = None
@@ -87,13 +92,6 @@ class TTModelInput:
     # Decode-only: indicates the padded decode-batch layout changed since the
     # previous step (used by on-device sampling).
     reset_batch: bool = False
-
-    # max_num_logprobs: max logprobs value across all requests
-    max_num_logprobs: Optional[int] = None
-
-    # list of dicts mapping req_index -> generator for each DP rank
-    # only set for host sampling
-    generators_list: list[dict[int, torch.Generator]]
 
 
 class TTModelRunner:
@@ -623,7 +621,7 @@ class TTModelRunner:
                 input_batch.sampling.allowed_token_ids_mask[:input_batch.
                                                             num_reqs].clone())
 
-        generators = None
+        generators = dict()
         if not perform_device_sampling:
             generators = input_batch.sampling.generators
             # Technically this advances the generator before it is copied,
@@ -847,8 +845,8 @@ class TTModelRunner:
         allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
         bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
         logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
-        max_num_logprobs: Optional[int] = None
-        generators_list: list[Optional[dict[int, torch.Generator]]] = []
+        max_num_logprobs: int = 0
+        generators_list: list[dict[int, torch.Generator]] = []
 
         if is_decode:
             # For decode, given gathered flattened tensors from all DP ranks.
@@ -943,12 +941,7 @@ class TTModelRunner:
                             rank_params.get("bad_words_token_ids", {}))
                         logitsprocs_list.append(rank_params.get("logitsprocs"))
                         rank_logprobs = rank_params.get("max_num_logprobs")
-                        if rank_logprobs is not None:
-                            if max_num_logprobs is None:
-                                max_num_logprobs = rank_logprobs
-                            else:
-                                max_num_logprobs = max(max_num_logprobs,
-                                                       rank_logprobs)
+                        max_num_logprobs = max(max_num_logprobs, rank_logprobs)
                         generators_list.append(
                             rank_params.get("generators", {}))
                     else:
@@ -1058,12 +1051,8 @@ class TTModelRunner:
                     bad_words_token_ids_list.append(
                         mi.bad_words_token_ids_list[0])
                     logitsprocs_list.append(mi.logitsprocs_list[0])
-                    if mi.max_num_logprobs is not None:
-                        if max_num_logprobs is None:
-                            max_num_logprobs = mi.max_num_logprobs
-                        else:
-                            max_num_logprobs = max(max_num_logprobs,
-                                                   mi.max_num_logprobs)
+                    max_num_logprobs = max(max_num_logprobs,
+                                           mi.max_num_logprobs)
                     generators_list.append(mi.generators_list[0])
                 else:
                     allowed_token_ids_mask_list.append(None)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -609,14 +609,14 @@ class TTModelRunner:
         # Build host-only sampling params from input_batch
         allowed_token_ids_mask = None
         if not input_batch.no_allowed_token_ids and \
-            input_batch.allowed_token_ids_mask is not None:
+            input_batch.sampling.allowed_token_ids_mask is not None:
             allowed_token_ids_mask = (
-                input_batch.allowed_token_ids_mask[:input_batch.
-                                                   num_reqs].clone())
+                input_batch.sampling.allowed_token_ids_mask[:input_batch.
+                                                            num_reqs].clone())
 
         generators = None
         if not perform_device_sampling:
-            generators = input_batch.generators
+            generators = input_batch.sampling.generators
             # Technically this advances the generator before it is copied,
             # but it's ok because this happens consistently.
             # We're assuming that _prepare_model_inputs is called
@@ -643,9 +643,9 @@ class TTModelRunner:
             reset_batch=reset_batch,
             # Host-only params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
-            bad_words_token_ids_list=[input_batch.bad_words_token_ids.copy()],
+            bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids.copy()],
             max_num_logprobs=input_batch.max_num_logprobs,
-            logitsprocs_list=[input_batch.logitsprocs],
+            logitsprocs_list=[input_batch.sampling.logitsprocs],
             generators_list=[generators]
         )
 
@@ -1206,8 +1206,8 @@ class TTModelRunner:
         input_batch = self.input_batch
         has_always_host_only_params = (
             not input_batch.no_allowed_token_ids  # allowed_token_ids set
-            or input_batch.bad_words_token_ids  # bad_words set
-            or input_batch.logitsprocs.has_active_processors(
+            or input_batch.sampling.bad_words_token_ids  # bad_words set
+            or input_batch.sampling.logitsprocs.has_active_processors(
             )  # min_p, logit_bias, min_tokens
         )
         if has_always_host_only_params:
@@ -1219,8 +1219,8 @@ class TTModelRunner:
         # not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if input_batch.num_logprobs and (num_devices == 1 or any(
-                x > 1 for x in input_batch.num_logprobs.values())):
+        if input_batch.sampling.num_logprobs and (num_devices == 1 or any(
+                x > 1 for x in input_batch.sampling.num_logprobs.values())):
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -600,8 +600,8 @@ class TTModelRunner:
         if not input_batch.no_allowed_token_ids:
             if input_batch.allowed_token_ids_mask is not None:
                 allowed_token_ids_mask = (
-                    input_batch.allowed_token_ids_mask[:input_batch.num_reqs]
-                    .clone())
+                    input_batch.allowed_token_ids_mask[:input_batch.
+                                                       num_reqs].clone())
 
         return TTModelInput(
             input_tokens=input_tokens,
@@ -752,16 +752,16 @@ class TTModelRunner:
         host_only_params = None
         if model_input is not None:
             host_only_params = {
-                "allowed_token_ids_mask": (
-                    model_input.allowed_token_ids_mask_list[0]
-                    if model_input.allowed_token_ids_mask_list else None),
-                "bad_words_token_ids": (
-                    model_input.bad_words_token_ids_list[0]
-                    if model_input.bad_words_token_ids_list else {}),
-                "max_num_logprobs": model_input.max_num_logprobs,
-                "logitsprocs": (
-                    model_input.logitsprocs_list[0]
-                    if model_input.logitsprocs_list else None),
+                "allowed_token_ids_mask":
+                (model_input.allowed_token_ids_mask_list[0]
+                 if model_input.allowed_token_ids_mask_list else None),
+                "bad_words_token_ids":
+                (model_input.bad_words_token_ids_list[0]
+                 if model_input.bad_words_token_ids_list else {}),
+                "max_num_logprobs":
+                model_input.max_num_logprobs,
+                "logitsprocs": (model_input.logitsprocs_list[0]
+                                if model_input.logitsprocs_list else None),
             }
 
         result = {
@@ -1007,14 +1007,13 @@ class TTModelRunner:
                 # Collect host-only params per rank
                 if mi is not None:
                     allowed_token_ids_mask_list.append(
-                        mi.allowed_token_ids_mask_list[0]
-                        if mi.allowed_token_ids_mask_list else None)
+                        mi.allowed_token_ids_mask_list[0] if mi.
+                        allowed_token_ids_mask_list else None)
                     bad_words_token_ids_list.append(
-                        mi.bad_words_token_ids_list[0]
-                        if mi.bad_words_token_ids_list else {})
-                    logitsprocs_list.append(
-                        mi.logitsprocs_list[0]
-                        if mi.logitsprocs_list else None)
+                        mi.bad_words_token_ids_list[0] if mi.
+                        bad_words_token_ids_list else {})
+                    logitsprocs_list.append(mi.logitsprocs_list[0] if mi.
+                                            logitsprocs_list else None)
                     if mi.max_num_logprobs is not None:
                         if max_num_logprobs is None:
                             max_num_logprobs = mi.max_num_logprobs
@@ -1158,7 +1157,8 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         # Only 1 DP rank here
-        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(model_input)
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(
+            model_input)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
@@ -1181,7 +1181,8 @@ class TTModelRunner:
         has_always_host_only_params = (
             not input_batch.no_allowed_token_ids  # allowed_token_ids set
             or input_batch.bad_words_token_ids  # bad_words set
-            or input_batch.logitsprocs.has_active_processors()  # min_p, logit_bias, min_tokens
+            or input_batch.logitsprocs.has_active_processors(
+            )  # min_p, logit_bias, min_tokens
         )
         if has_always_host_only_params:
             return False
@@ -1190,7 +1191,8 @@ class TTModelRunner:
         # Also, only the sampled token's logprob is returned on device, not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if input_batch.num_logprobs and (num_devices == 1 or any(x>1 for x in input_batch.num_logprobs.values())):
+        if input_batch.num_logprobs and (num_devices == 1 or any(
+                x > 1 for x in input_batch.num_logprobs.values())):
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True for random sampling,
@@ -1458,7 +1460,8 @@ class TTModelRunner:
                 if (model_input.allowed_token_ids_mask_list
                         and model_input.allowed_token_ids_mask_list[dp_rank]
                         is not None):
-                    rank_mask = model_input.allowed_token_ids_mask_list[dp_rank]
+                    rank_mask = model_input.allowed_token_ids_mask_list[
+                        dp_rank]
                     # Slice to actual batch size for this rank
                     allowed_token_ids_mask = rank_mask[:sz]
 
@@ -1470,8 +1473,8 @@ class TTModelRunner:
 
                 logitsprocs = (model_input.logitsprocs_list[dp_rank]
                                if model_input.logitsprocs_list
-                               and model_input.logitsprocs_list[dp_rank] is not None
-                               else LogitsProcessorManager())
+                               and model_input.logitsprocs_list[dp_rank]
+                               is not None else LogitsProcessorManager())
 
                 # Create SamplingMetadata for this DP rank
                 sampling_metadata = SamplingMetadata(
@@ -1513,10 +1516,14 @@ class TTModelRunner:
 
                     # Create LogprobsTensors with only sampled token info
                     # Shape: [sz, 1] for token_ids and logprobs
-                    logprob_token_ids = next_token_ids.unsqueeze(-1).to(torch.int32)
-                    logprobs_values = sampled_log_probs.unsqueeze(-1).to(torch.float32)
+                    logprob_token_ids = next_token_ids.unsqueeze(-1).to(
+                        torch.int32)
+                    logprobs_values = sampled_log_probs.unsqueeze(-1).to(
+                        torch.float32)
                     # Rank is unknown with device sampling, use -1 to indicate
-                    selected_token_ranks = torch.full((sz,), -1, dtype=torch.int32)
+                    selected_token_ranks = torch.full((sz, ),
+                                                      -1,
+                                                      dtype=torch.int32)
 
                     logprobs_tensors = LogprobsTensors(
                         logprob_token_ids=logprob_token_ids,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -22,6 +22,7 @@ from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, LogprobsLists,
 from vllm.v1.sample.logits_processor import LogitsProcessorManager
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import Sampler
+from vllm.sampling_params import SamplingType
 from vllm.v1.worker.tt_input_batch import (SEED_NONE_SENTINEL,
                                            CachedRequestState, InputBatch)
 from vllm.worker.tt_model_runner import decode_warmup, prefill_warmup
@@ -89,6 +90,10 @@ class TTModelInput:
 
     # max_num_logprobs: max logprobs value across all requests
     max_num_logprobs: Optional[int] = None
+
+    # list of dicts mapping req_index -> generator for each DP rank
+    # only set for host sampling
+    generators_list: list[dict[int, torch.Generator]]
 
 
 class TTModelRunner:
@@ -300,6 +305,12 @@ class TTModelRunner:
             req_id = new_req_data.req_id
             sampling_params = new_req_data.sampling_params
 
+            if sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+                generator = torch.Generator(device="cpu")
+                generator.manual_seed(sampling_params.seed)
+            else:
+                generator = None
+
             self.requests[req_id] = CachedRequestState(
                 req_id=req_id,
                 prompt_token_ids=new_req_data.prompt_token_ids,
@@ -307,7 +318,7 @@ class TTModelRunner:
                 mm_positions=new_req_data.mm_positions,
                 sampling_params=sampling_params,
                 pooling_params=None,
-                generator=None,
+                generator=generator,
                 block_ids=new_req_data.block_ids,
                 num_computed_tokens=new_req_data.num_computed_tokens,
                 output_token_ids=[],
@@ -603,6 +614,10 @@ class TTModelRunner:
                 input_batch.allowed_token_ids_mask[:input_batch.
                                                    num_reqs].clone())
 
+        generators = None
+        if not perform_device_sampling:
+            generators = input_batch.generators
+
         return TTModelInput(
             input_tokens=input_tokens,
             input_positions=input_positions,
@@ -621,6 +636,7 @@ class TTModelRunner:
             bad_words_token_ids_list=[input_batch.bad_words_token_ids.copy()],
             max_num_logprobs=input_batch.max_num_logprobs,
             logitsprocs_list=[input_batch.logitsprocs],
+            generators_list=[generators]
         )
 
     def build_model_input(
@@ -760,6 +776,8 @@ class TTModelRunner:
                 model_input.max_num_logprobs,
                 "logitsprocs":
                 model_input.logitsprocs_list[0],
+                "generators":
+                model_input.generators_list[0],
             }
 
         result = {
@@ -808,6 +826,7 @@ class TTModelRunner:
         bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
         logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
         max_num_logprobs: Optional[int] = None
+        generators_list: list[Optional[dict[int, torch.Generator]]] = []
 
         if is_decode:
             # For decode, given gathered flattened tensors from all DP ranks.
@@ -902,15 +921,18 @@ class TTModelRunner:
                             else:
                                 max_num_logprobs = max(max_num_logprobs,
                                                        rank_logprobs)
+                        generators_list.append(rank_params.get("generators", {}))
                     else:
                         allowed_token_ids_mask_list.append(None)
                         bad_words_token_ids_list.append({})
                         logitsprocs_list.append(None)
+                        generators_list.append({})
             else:
                 # No host-only params - create empty lists
                 allowed_token_ids_mask_list = [None] * world
                 bad_words_token_ids_list = [{}] * world
                 logitsprocs_list = [None] * world
+                generators_list = [{}] * world
 
             off_f = 0
             temperature = stacked_float[:, off_f:off_f + B].reshape(total_B)
@@ -1011,10 +1033,12 @@ class TTModelRunner:
                         else:
                             max_num_logprobs = max(max_num_logprobs,
                                                    mi.max_num_logprobs)
+                    generators_list.append(mi.generators_list[0])
                 else:
                     allowed_token_ids_mask_list.append(None)
                     bad_words_token_ids_list.append({})
                     logitsprocs_list.append(None)
+                    generators_list.append({})
 
             input_tokens = torch.cat(input_tokens_list, dim=0)
             input_positions = np.concatenate(input_positions_list, axis=0)
@@ -1126,6 +1150,7 @@ class TTModelRunner:
             bad_words_token_ids_list=bad_words_token_ids_list,
             max_num_logprobs=max_num_logprobs,
             logitsprocs_list=logitsprocs_list,
+            generators_list=generators_list,
         )
         return merged
 
@@ -1399,14 +1424,7 @@ class TTModelRunner:
                 all_greedy = (temperature == 0.0).all().item()
                 all_random = (temperature != 0.0).all().item()
 
-                # Create generators from seeds for this DP rank
-                # Generator keys are batch indices (0-based within current
-                # slice).
-                generators: dict[int, torch.Generator] = {}
-                for i, seed_val in enumerate(seed):
-                    if seed_val.item() != SEED_NONE_SENTINEL:
-                        generators[i] = torch.Generator(
-                            device="cpu").manual_seed(seed_val.item())
+                generators = model_input.generators_list[dp_rank]
 
                 # Determine if penalties are needed
                 no_penalties = ((presence_penalty == 0.0).all().item()

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -806,6 +806,10 @@ class TTModelRunner:
                                          dim=1)
             return block_tables
 
+        allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
+        bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
+        logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
+
         if is_decode:
             # For decode, given gathered flattened tensors from all DP ranks.
             # Ints: [toks(B), positions(B), block_tables(B*W),
@@ -884,9 +888,6 @@ class TTModelRunner:
 
             # Extract host-only params from gathered inputs (per-rank lists)
             host_only_params_list = inputs.get("host_only_params")
-            allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
-            bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
-            logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
             max_num_logprobs: Optional[int] = None
             if host_only_params_list:
                 for rank_params in host_only_params_list:
@@ -945,10 +946,6 @@ class TTModelRunner:
             frequency_penalty_list: list[torch.Tensor] = []
             repetition_penalty_list: list[torch.Tensor] = []
             seed_list: list[torch.Tensor] = []
-            # Host-only params (per-rank lists)
-            allowed_token_ids_mask_list: list[Optional[torch.Tensor]] = []
-            bad_words_token_ids_list: list[dict[int, list[list[int]]]] = []
-            logitsprocs_list: list[Optional[LogitsProcessorManager]] = []
             max_num_logprobs: Optional[int] = None
             reset_batch = False
 
@@ -1157,7 +1154,7 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         # Only 1 DP rank here
-        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input( # noqa: E501
             model_input)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
@@ -1187,15 +1184,18 @@ class TTModelRunner:
         if has_always_host_only_params:
             return False
 
-        # Logprobs on device are only supported on multi-device setups (num_devices > 1)
-        # Also, only the sampled token's logprob is returned on device, not the top-k alternatives.
+        # Logprobs on device are only supported on multi-device setups 
+        # (num_devices > 1)
+        # Also, only the sampled token's logprob is returned on device, 
+        # not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
         if input_batch.num_logprobs and (num_devices == 1 or any(
                 x > 1 for x in input_batch.num_logprobs.values())):
             return False
 
-        # TTPlatform.non_greedy_decoding_on_device must be True for random sampling,
+        # TTPlatform.non_greedy_decoding_on_device must be True
+        # for random sampling, 
         # or all requests must be greedy without penalties.
         params_device_supported = TTPlatform.non_greedy_decoding_on_device or (
             self.input_batch.all_greedy and self.input_batch.no_penalties)
@@ -1348,7 +1348,7 @@ class TTModelRunner:
 
         Args:
             tt_out: Model output (logits or tokens depending on sampling mode)
-            tt_log_probs: Optional logprobs from device sampling (batch_size tensor)
+            tt_log_probs: Optional logprobs from device sampling
 
         Returns:
             Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
@@ -1453,7 +1453,8 @@ class TTModelRunner:
                         prompt_token_ids = prompt_token_ids.masked_fill(
                             pad_mask, self.vocab_size)
 
-                # Get host-only sampling params from model_input (per-rank lists).
+                # Get host-only sampling params from model_input
+                # (per-rank lists).
                 # These are populated for both DP and non-DP cases.
                 rank_max_num_logprobs = model_input.max_num_logprobs
                 allowed_token_ids_mask = None

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1186,10 +1186,11 @@ class TTModelRunner:
         if has_always_host_only_params:
             return False
 
-        # Logprobs on device are only supported on multi-device setups (num_devices > 1).
+        # Logprobs on device are only supported on multi-device setups (num_devices > 1)
+        # Also, only the sampled token's logprob is returned on device, not the top-k alternatives.
         # On single device, logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if input_batch.num_logprobs and num_devices == 1:
+        if input_batch.num_logprobs and (num_devices == 1 or input_batch.num_logprobs > 1):
             return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True for random sampling,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -617,6 +617,16 @@ class TTModelRunner:
         generators = None
         if not perform_device_sampling:
             generators = input_batch.generators
+            # Technically this advances the generator before it is copied,
+            # but it's ok because this happens consistently.
+            # We're assuming that _prepare_model_inputs is called
+            # exactly once per step.
+            input_batch.advance_generators()
+            # NOTE: Our sampling paths are different between host and device.
+            # Whether a request is sampled on device or host
+            # depends also on other requests in the batch.
+            # This means sampling is not perfectly deterministic
+            # whenever device sampling is enabled.
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -20,6 +20,7 @@ from vllm.worker.tt_worker import (close_mesh_device, get_mesh_grid,
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm.v1.outputs import LogprobsLists
 
 logger = init_logger(__name__)
 
@@ -272,7 +273,7 @@ class TTWorker(WorkerBase):
     def apply_dp_execution_result(
             self,
             sampled_token_ids: torch.Tensor,
-            logprobs_lists: Optional[list] = None) -> ModelRunnerOutput:
+            logprobs_lists: Optional[LogprobsLists] = None) -> ModelRunnerOutput:
         """Called by each DP rank to apply sampled tokens to internal caches.
         
         Args:

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -273,7 +273,7 @@ class TTWorker(WorkerBase):
     def apply_dp_execution_result(
             self,
             sampled_token_ids: torch.Tensor,
-            logprobs_lists: Optional[LogprobsLists] = None) -> ModelRunnerOutput:
+            logprobs_lists: Optional["LogprobsLists"] = None) -> ModelRunnerOutput:
         """Called by each DP rank to apply sampled tokens to internal caches.
         
         Args:

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -273,7 +273,8 @@ class TTWorker(WorkerBase):
     def apply_dp_execution_result(
             self,
             sampled_token_ids: torch.Tensor,
-            logprobs_lists: Optional["LogprobsLists"] = None) -> ModelRunnerOutput:
+            logprobs_lists: Optional["LogprobsLists"] = None
+    ) -> ModelRunnerOutput:
         """Called by each DP rank to apply sampled tokens to internal caches.
         
         Args:

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -184,15 +184,16 @@ class TTWorker(WorkerBase):
 
     def build_dp_model_input(
         self, scheduler_output: Optional["SchedulerOutput"]
-    ) -> tuple[Optional[TTModelInput], int, int, int, int, int]:
+    ) -> tuple[Optional[TTModelInput], int, int, int, int, int, int]:
         """Called by each DP rank to build model input from scheduler output.
         Returns: (model_input, max_blocks, has_structured_input, has_penalties,
-        reset_batch, can_sample_device)
+        reset_batch, can_sample_device, needs_logprobs)
         """
         model_input = None
         has_penalties = 0
         reset_batch = 0
         can_sample_device = 1
+        needs_logprobs = 0
         if scheduler_output is not None:
             model_input = self.model_runner.build_model_input(scheduler_output)
             if model_input is not None:
@@ -200,6 +201,7 @@ class TTWorker(WorkerBase):
                     not self.model_runner.input_batch.no_penalties)
                 reset_batch = int(model_input.reset_batch)
                 can_sample_device = int(model_input.perform_device_sampling)
+                needs_logprobs = int(model_input.max_num_logprobs is not None)
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = int(
             model_input.grammar_bitmask[0] is not None) if model_input else 0
@@ -210,6 +212,7 @@ class TTWorker(WorkerBase):
             has_penalties,
             reset_batch,
             can_sample_device,
+            needs_logprobs,
         )
 
     def build_dp_decode_gather_input(
@@ -224,10 +227,11 @@ class TTWorker(WorkerBase):
                                                   dict[str,
                                                        Any]], is_decode: bool,
                               max_blocks_decode_batch: Optional[int],
-                              any_structured_inputs: bool) -> torch.Tensor:
+                              any_structured_inputs: bool) -> tuple[torch.Tensor, list]:
         """Called by TT device ranks (local DP rank 0) to concatenate DP-sized
-        inputs and execute. Returns a stacked tensor
-        [world, max_num_seqs, 1] of sampled ids.
+        inputs and execute. Returns a tuple of:
+        - stacked tensor [world, max_num_seqs, 1] of sampled ids
+        - list of logprobs per DP rank (as picklable lists, or None)
         Each DP slice is right-padded with zeros to max_num_seqs; empty entries
         are zeros. Same behavior for both prefill and decode."""
 
@@ -236,8 +240,13 @@ class TTWorker(WorkerBase):
         assert self.is_driver_worker, "concat_and_execute_dp must run on driver"
         merged = self.model_runner.concat_dp_model_inputs(
             inputs, is_decode, max_blocks_decode_batch, any_structured_inputs)
-        sampled_token_ids_per_dp: list[
-            torch.Tensor] = self.model_runner.execute_with_model_input(merged)
+        sampled_token_ids_per_dp, logprobs_per_dp = \
+            self.model_runner.execute_with_model_input(merged)
+
+        # Convert LogprobsTensors to picklable lists for scatter
+        logprobs_lists_per_dp = [
+            lp.tolists() if lp is not None else None for lp in logprobs_per_dp
+        ]
 
         # Pad each DP result to uniform shape for tensor all_gather.
         world = self.parallel_config.data_parallel_size
@@ -259,16 +268,24 @@ class TTWorker(WorkerBase):
                     ],
                                           dim=0)
             sampled_token_ids_per_dp[dp_rank] = token_ids
-        return torch.stack(sampled_token_ids_per_dp)  # [world, B, 1]
+        return torch.stack(sampled_token_ids_per_dp), logprobs_lists_per_dp
 
     def apply_dp_execution_result(
-            self, sampled_token_ids: torch.Tensor) -> ModelRunnerOutput:
+            self,
+            sampled_token_ids: torch.Tensor,
+            logprobs_lists: Optional[list] = None) -> ModelRunnerOutput:
         """Called by each DP rank to apply sampled tokens to internal caches.
+        
+        Args:
+            sampled_token_ids: Sampled token IDs for this DP rank.
+            logprobs_lists: Logprobs as lists (already converted from tensors)
+                for this DP rank, or None if not requested.
         """
         # Trim to active local batch size to drop padding rows.
         num_reqs = self.model_runner.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        return self.model_runner.generate_runner_output(sampled_token_ids)
+        return self.model_runner.generate_runner_output(
+            sampled_token_ids, logprobs_lists)
 
     # ---- Destructor (used to close devices) ----
 

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -223,11 +223,10 @@ class TTWorker(WorkerBase):
             model_input, max_blocks_decode_batch, any_structured_inputs,
             any_penalties_inputs)
 
-    def concat_and_execute_dp(self, inputs: Union[list[Optional[TTModelInput]],
-                                                  dict[str,
-                                                       Any]], is_decode: bool,
-                              max_blocks_decode_batch: Optional[int],
-                              any_structured_inputs: bool) -> tuple[torch.Tensor, list]:
+    def concat_and_execute_dp(
+            self, inputs: Union[list[Optional[TTModelInput]], dict[str, Any]],
+            is_decode: bool, max_blocks_decode_batch: Optional[int],
+            any_structured_inputs: bool) -> tuple[torch.Tensor, list]:
         """Called by TT device ranks (local DP rank 0) to concatenate DP-sized
         inputs and execute. Returns a tuple of:
         - stacked tensor [world, max_num_seqs, 1] of sampled ids

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -268,7 +268,7 @@ class TTWorker(WorkerBase):
                     ],
                                           dim=0)
             sampled_token_ids_per_dp[dp_rank] = token_ids
-        return torch.stack(sampled_token_ids_per_dp), logprobs_lists_per_dp
+        return torch.stack(sampled_token_ids_per_dp), logprobs_lists_per_dp # [world, B, 1], [world]
 
     def apply_dp_execution_result(
             self,

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -268,7 +268,8 @@ class TTWorker(WorkerBase):
                     ],
                                           dim=0)
             sampled_token_ids_per_dp[dp_rank] = token_ids
-        return torch.stack(sampled_token_ids_per_dp), logprobs_lists_per_dp # [world, B, 1], [world]
+        return torch.stack(sampled_token_ids_per_dp
+                           ), logprobs_lists_per_dp  # [world, B, 1], [world]
 
     def apply_dp_execution_result(
             self,


### PR DESCRIPTION
## Purpose
Implement the changes from https://github.com/tenstorrent/vllm/issues/301

Custom logits processors are not currently supported - this is a limitation of the v1 version we branched from. More changes possibly required once we rebase onto a version of v1 that supports them

## Test Plan

Added tests covering these sampling features, testing across DP/non DP correct so far.  CI pipeline to run them across all machine/model combos WIP.
