### PR TITLE
Fix text config

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -104,7 +104,7 @@ class TTModelRunner:
         # mrope requires keeping "rope_deltas" between prefill/decode phases.
         self.request_specific_rope = bool(
             self.model_config.uses_mrope) or bool(
-                uses_mrope(self.model_config.hf_config.text_config))
+                uses_mrope(self.model_config.hf_config.get_text_config()))
         if self.request_specific_rope:
             self.previous_req_ids: set[str] = set()
 


### PR DESCRIPTION
`text_config` has to be accessed through getter https://github.com/tenstorrent/tt-metal/actions/runs/21940360780/job/63365308673#step:17:149

successful v1 run https://github.com/tenstorrent/tt-metal/actions/runs/21944617611/job/63379558453