### PR TITLE
Fix flaky penalty test

### DIFF
--- a/tests/tt/test_tt_penalties.py
+++ b/tests/tt/test_tt_penalties.py
@@ -165,7 +165,7 @@ class TestFrequencyPenalty:
                 RequestConfig(
                     prompt=prompt,
                     max_tokens=15,
-                    temperature=0.5,
+                    temperature=1.5,
                     frequency_penalty=0.0 if i % 2 == 0 else 2.0,
                     seed=42,
                 ))


### PR DESCRIPTION
Temperature is too low to create variability in response and show the effect of penalty

- [x] [vllm nightly](https://github.com/tenstorrent/tt-metal/actions/runs/21989359158/job/63532669250)