### PR TITLE
Fix tuple error for next tokens response in V1

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1178,10 +1178,11 @@ class TTModelRunner:
                                                **enc_dec_kwargs,
                                                enable_trace=enable_trace,
                                                read_from_device=True)
-            # tt_out is a tuple of (logits, logprobs)
-            # v1 currently doesn't handle logprobs from TT models
-            if isinstance(tt_out, tuple):
-                tt_out = tt_out[0]
+
+        # tt_out is a tuple of (logits, logprobs)
+        # v1 currently doesn't handle logprobs from TT models
+        if isinstance(tt_out, tuple):
+            tt_out = tt_out[0]
 
         return self._get_output_tokens(
             tt_out=tt_out,


### PR DESCRIPTION
Error https://github.com/tenstorrent/tt-metal/actions/runs/21983405660/job/63512204167#step:17:1176
Happens because now prefill returns logits as well