### PR TITLE
[v0] Don't send logprobs>1 requests to device

### DIFF
--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -342,9 +342,15 @@ class TTPlatform(Platform):
 
     @staticmethod
     def compat_sampling_required(sampling_params, num_devices) -> bool:
-        # device logprobs currently only supported on multi-device setups
+        # Device logprobs only supported on multi-device setups and only
+        # the sampled token's logprob is returned (not top-k alternatives).
+        # Single device: any logprobs require host sampling.
+        # Multi-device: logprobs > 1 requires host sampling because device
+        # can only return the sampled token's logprob.
         # https://github.com/tenstorrent/tt-metal/issues/34077
-        if sampling_params.logprobs is not None and num_devices == 1:
+        if sampling_params.logprobs is not None \
+        and sampling_params.logprobs > 0 \
+        and (num_devices == 1 or sampling_params.logprobs > 1):
             return True
 
         # all of the following sampling params require compat sampling


### PR DESCRIPTION
## Purpose
Device sampling asserts requested logprobs are <=1, but we didn't gate device sampling in v0 on that, leading to crashes like https://github.com/tenstorrent/tt-metal/actions/runs/22081596375/job/63808180087 .
V1 already has correct gating.
## Test Plan

## Test Result

