### PR TITLE
Add extra_ttrun_args option to override_tt_config to pass additional tt-run args for multi-host

### DIFF
--- a/tt_metal/README.md
+++ b/tt_metal/README.md
@@ -292,7 +292,7 @@ pytest tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=meta-ll
 To run offline inference or a server on a multi-host system, vLLM needs to be launched from the host that has MPI rank 0 (determined from the rankfile). Underneath the hood, the `tt-run` utility from tt-metal will be used to spawn MPI processes on each host. For example, for offline inference on 2 Wormhole Galaxy hosts with DP=2 (distributed across hosts):
 
 ```sh
-MESH_DEVICE=(8,8) python -u examples/offline_inference_tt.py --model <MODEL_NAME> --data_parallel_size 2 --async_engine --override_tt_config '{"rank_binding": "<PATH_TO_TT_METAL>/tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml", "mpi_args": "--host <HOST1>,<HOST2> --map-by rankfile:file=/etc/mpirun/rankfile --mca btl self,tcp --mca btl_tcp_if_include cnx1 --bind-to none --tag-output", "config_pkl_dir": "<PATH_TO_SHARED_TMP_DIR>", "fabric_config": "FABRIC_1D", "fabric_reliability_mode": "RELAXED_INIT", "env_passthrough":["VLLM_*", "MESH_DEVICE"]}'
+MESH_DEVICE=(8,8) python -u examples/offline_inference_tt.py --model <MODEL_NAME> --data_parallel_size 2 --async_engine --override_tt_config '{"rank_binding": "<PATH_TO_TT_METAL>/tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml", "extra_ttrun_args": "--tcp-interface cnx1", "mpi_args": "--host <HOST1>,<HOST2> --map-by rankfile:file=/etc/mpirun/rankfile", "config_pkl_dir": "<PATH_TO_SHARED_TMP_DIR>", "fabric_config": "FABRIC_1D", "fabric_reliability_mode": "RELAXED_INIT", "env_passthrough":["VLLM_*", "MESH_DEVICE"]}'
 ```
 
 > **Notes:**
@@ -301,3 +301,4 @@ MESH_DEVICE=(8,8) python -u examples/offline_inference_tt.py --model <MODEL_NAME
 > - To check which host has MPI rank 0, examine the rankfile (commonly /etc/mpirun/rankfile). If you launch from another host, vLLM will raise an error and indicate which host to run from.
 > - `config_pkl_dir` needs to be set to a directory that is shared by all hosts (used during initialization to write a temporary config file that is read by other hosts).
 > - If you need to set environment variables that should be propagated to all hosts, you can either 1) specify them as part of `env_passthrough` in `--override_tt_config` or 2) add them as a `global_env` in the rank_binding file.
+> - `extra_ttrun_args` can be used to pass additional flags directly to `tt-run` as a raw string (e.g. `"--tcp-interface cnx1"`, `"--bare"`, `"--debug-gdbserver"`).

--- a/vllm/v1/engine/tt_core_launcher.py
+++ b/vllm/v1/engine/tt_core_launcher.py
@@ -156,6 +156,7 @@ def tt_run_launch(
     Uses args from override_tt_config:
       - rank_binding: str (required, already parsed)
       - mpi_args: str (optional, parsed here)
+      - extra_ttrun_args: str (optional, parsed here)
       - config_pkl_dir: str (required, parsed here)
     Args:
         handshake_address: ZMQ address for engine handshake communication.
@@ -173,6 +174,7 @@ def tt_run_launch(
     # Parse override_tt_config for optional fields.
     override_tt_config = vllm_config.model_config.override_tt_config or {}
     mpi_args = override_tt_config.get("mpi_args", "")
+    extra_ttrun_args = override_tt_config.get("extra_ttrun_args")
     cfg_dir = override_tt_config.get("config_pkl_dir")
 
     if not cfg_dir:
@@ -223,7 +225,30 @@ def tt_run_launch(
     with open(tmp_rb_path, "w") as tf:
         yaml.safe_dump(rb, tf)
 
-    cmd = ["tt-run", "--rank-binding", tmp_rb_path]
+    normalized_extra_ttrun_args: list[str] = []
+    if extra_ttrun_args:
+        if not isinstance(extra_ttrun_args, str):
+            raise RuntimeError(
+                "override_tt_config['extra_ttrun_args'] must be a string"
+            )
+        normalized_extra_ttrun_args = shlex.split(extra_ttrun_args)
+
+        # Prevent ambiguous/duplicated flags that vLLM is responsible for.
+        reserved_flags = {"--rank-binding", "--mpi-args"}
+        if any(
+            (tok in reserved_flags)
+            or any(tok.startswith(f"{flag}=") for flag in reserved_flags)
+            for tok in normalized_extra_ttrun_args
+        ):
+            raise RuntimeError(
+                "override_tt_config['extra_ttrun_args'] must not include "
+                "--rank-binding or --mpi-args (vLLM sets these)"
+            )
+
+    cmd = ["tt-run"]
+    if normalized_extra_ttrun_args:
+        cmd.extend(normalized_extra_ttrun_args)
+    cmd.extend(["--rank-binding", tmp_rb_path])
     if mpi_args:
         # Pass raw string; tt-run will shlex.split it
         cmd.extend(["--mpi-args", mpi_args])
@@ -243,7 +268,8 @@ def tt_run_launch(
     )
 
     child_env = os.environ.copy()
-    logger.info("Launching engines with tt-run: %s", " ".join(cmd))
+    pretty_cmd = shlex.join(cmd)
+    logger.info("Launching engines with tt-run: %s", pretty_cmd)
     mpi_proc = subprocess.Popen(cmd, env=child_env)
 
     # Set up finalizer for MPI subprocess cleanup


### PR DESCRIPTION
- Following https://github.com/tenstorrent/tt-metal/pull/36282, we required a way to pass in extra tt-run args such as `--tcp-interface`. Added `extra_ttrun_args` as a key option to the `--override_tt_config` dict for that purpose.
- vLLM nightly (only t3000 multi-proc test): https://github.com/tenstorrent/tt-metal/actions/runs/22333960210