### PR TITLE
Register dummy test model for multi-host inference on dual galaxy

### DIFF
--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -184,6 +184,13 @@ def register_tt_test_models():
         "models.vllm_test_utils.no_op_test.test_model:DummyNoOpModel",
     )
 
+    # Fake model for testing multi-host inference on dual Galaxy
+    _register_model_if_missing(
+        ModelRegistry,
+        "TTDummyDualGlxModel",
+        "models.vllm_test_utils.dual_glx_ccl_test.test_model:DummyDualGlxModel",
+    )
+
 
 class TTPlatform(Platform):
     _enum = PlatformEnum.TT


### PR DESCRIPTION
- Test model registration for the dummy dual galaxy model added in https://github.com/tenstorrent/tt-metal/pull/38493
- vLLM nightly (only testing that existing t3k multi-process test model still works, new job will be added at a later time due to non-trivial pipeline changes for multi-host): https://github.com/tenstorrent/tt-metal/actions/runs/22375467074