### PR TITLE
Fix grammar bitmask crash with padded vocab logits

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1535,7 +1535,7 @@ class TTModelRunner:
                     start += self.scheduler_config.max_num_seqs
                 continue
             if not perform_device_sampling:
-                logits = tt_out[start : start + sz, -1, :]
+                logits = tt_out[start : start + sz, -1, :self.vocab_size]
 
                 grammar_bitmask = model_input.grammar_bitmask[dp_rank]
 


### PR DESCRIPTION
## Summary
- Trim logits to `vocab_size` when extracting for host sampling, fixing shape mismatch with grammar bitmask

TT models pad the lm_head vocab dimension for tile alignment (multiple of 32), so logits have width > `vocab_size` (e.g. 201216 vs 201088 for GPT-OSS). The grammar bitmask is sized to actual `vocab_size`, causing `masked_fill_` to fail with:

```
RuntimeError: The size of tensor a (201216) must match the size of tensor b (201088) at non-singleton dimension 1
```

The one-line fix slices logits to `[:self.vocab_size]` at extraction time, before any host-side operations.

## Test plan
- [ ] Verify structured output / grammar-guided generation works with GPT-OSS models
- [ ] Verify non-grammar requests still work correctly