### PR TITLE
Fix grammar bitmask shape mismatch with padded vocab logits

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1727,9 +1727,17 @@ class TTModelRunner:
             )
             & 1
         ) == 0
-        unpacked_bitmask = unpacked_bitmask.reshape(grammar_bitmask.shape[0], -1)[
-            :, : logits.shape[-1]
-        ]
+        unpacked_bitmask = unpacked_bitmask.reshape(grammar_bitmask.shape[0], -1)
+        vocab_logits = logits.shape[-1]
+        vocab_bitmask = unpacked_bitmask.shape[-1]
+        if vocab_bitmask < vocab_logits:
+            # Logits may be wider than vocab (e.g. padded for on-device sampling).
+            # Pad bitmask with True (mask out) so padding positions are set to -inf.
+            unpacked_bitmask = torch.nn.functional.pad(
+                unpacked_bitmask, (0, vocab_logits - vocab_bitmask), value=True
+            )
+        elif vocab_bitmask > vocab_logits:
+            unpacked_bitmask = unpacked_bitmask[:, :vocab_logits]
         logits.masked_fill_(unpacked_bitmask, -float("inf"))
 
     def generate_runner_output(


### PR DESCRIPTION
## Summary
- When models pad lm_head to `padded_vocab_size` for on-device sampling (e.g. GPT-OSS-120B pads from 201088 to 262144 for pow2 topk), the logits tensor is wider than `vocab_size`
- The grammar bitmask unpacked from structured output is only `vocab_size` wide, causing `masked_fill_` to crash with shape mismatch: `The size of tensor a (262144) must match the size of tensor b (201088)`
- Fix: pad the bitmask with `True` (mask out) for positions beyond `vocab_size` so padding tokens are always set to `-inf`

vllm nightly for gpt-oss: https://github.com/tenstorrent/tt-metal/actions/runs/22435248307
