### PR TITLE
Fix grammar bitmask shape mismatch with padded vocab logits

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1735,9 +1735,18 @@ class TTModelRunner:
             )
             & 1
         ) == 0
-        unpacked_bitmask = unpacked_bitmask.reshape(grammar_bitmask.shape[0], -1)[
-            :, : logits.shape[-1]
-        ]
+        unpacked_bitmask = unpacked_bitmask.reshape(grammar_bitmask.shape[0], -1)
+        vocab_logits = logits.shape[-1]
+        vocab_bitmask = unpacked_bitmask.shape[-1]
+        if vocab_bitmask < vocab_logits:
+            # Logits may be wider than vocab (e.g. padded for on-device
+            # sampling).  Pad bitmask with True so padding positions are
+            # masked to -inf.
+            unpacked_bitmask = torch.nn.functional.pad(
+                unpacked_bitmask, (0, vocab_logits - vocab_bitmask), value=True
+            )
+        elif vocab_bitmask > vocab_logits:
+            unpacked_bitmask = unpacked_bitmask[:, :vocab_logits]
         logits.masked_fill_(unpacked_bitmask, -float("inf"))
 
     def generate_runner_output(


### PR DESCRIPTION
## Summary

- Fix `apply_grammar_bitmask` in `tt_model_runner.py` to handle padded vocab sizes
- When on-device sampling pads logits to a power-of-2 per-device vocab (e.g., 262144 for GPT-OSS-120B with vocab 201088), the grammar bitmask only covers the real vocab, causing a shape mismatch
- The fix pads the unpacked bitmask with `True` (mask out) when it's narrower than the logits, or slices when wider

## Root Cause

The structured output grammar bitmask is packed as int32 values covering `ceil(vocab_size / 32)` entries. When unpacked, it produces `vocab_size` bits (201088 for GPT-OSS-120B). However, logits from the TT model have a padded vocab size of 262144 (8 devices × 32768 per device, next power-of-2 of tile-aligned per-device vocab).

The old code `unpacked_bitmask[:, :logits.shape[-1]]` tried to slice 262144 elements from a 201088-element tensor, causing:
```
RuntimeError: The size of tensor a (262144) must match the size of tensor b (201088) at non-singleton dimension 1
```

## Impact

This fixes the GPT-OSS-120B **high-throughput** vLLM nightly structured output benchmark, which was failing with all 32 requests returning "Internal Server Error":
- https://github.com/tenstorrent/tt-metal/actions/runs/22509035650/job/65214604008

The **low-latency** nightly also fails at the structured output step, but that's a secondary failure caused by a pre-existing device hang during the regular decode benchmark (5/32 succeed, then device times out on the 6th request). The structured output benchmark runs on an already-dead device. The low-latency decode hang needs separate investigation.

## Test plan

- [ ] Verify GPT-OSS-120B high-throughput nightly structured output benchmark passes
- [ ] Verify no regression in regular (non-structured) benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)