### PR TITLE
Add support for asynchronous decode scheduling

### DIFF
--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -259,9 +259,23 @@ class TTPlatform(Platform):
         register_tt_models(register_test_models)
 
         parallel_config = vllm_config.parallel_config
+        if (
+            vllm_config.scheduler_config.async_scheduling
+            and parallel_config.data_parallel_size > 1
+        ):
+            logger.warning(
+                "Async scheduling on TT is only supported with data_parallel_size=1. "
+                "Got data_parallel_size=%d, disabling async scheduling.",
+                parallel_config.data_parallel_size,
+            )
+            vllm_config.scheduler_config.async_scheduling = False
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
-            vllm_config.scheduler_config.scheduler_cls = TT_ASYNC_SCHEDULER_CLS
+            vllm_config.scheduler_config.scheduler_cls = (
+                TT_ASYNC_SCHEDULER_CLS
+                if vllm_config.scheduler_config.async_scheduling
+                else TT_STANDARD_SCHEDULER_CLS
+            )
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
@@ -368,6 +382,14 @@ class TTPlatform(Platform):
             # the standard TT scheduler. Keep user-provided custom scheduler.
             if vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS:
                 vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
+
+        # Guardrail: when async scheduling is disabled, do not leave the TT
+        # async scheduler selected.
+        if (
+            not vllm_config.scheduler_config.async_scheduling
+            and vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS
+        ):
+            vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -354,10 +354,7 @@ class TTPlatform(Platform):
             if model_capabilities
             else False
         )
-        if (
-            vllm_config.scheduler_config.async_scheduling
-            and not supports_async_decode
-        ):
+        if vllm_config.scheduler_config.async_scheduling and not supports_async_decode:
             logger.warning(
                 "Async scheduling was requested, but TT model %s (%s) does not "
                 "declare support (`model_capabilities['supports_async_decode']`). "
@@ -369,13 +366,8 @@ class TTPlatform(Platform):
             vllm_config.scheduler_config.async_scheduling = False
             # If TT selected the async scheduler by default, switch back to
             # the standard TT scheduler. Keep user-provided custom scheduler.
-            if (
-                vllm_config.scheduler_config.scheduler_cls
-                == TT_ASYNC_SCHEDULER_CLS
-            ):
-                vllm_config.scheduler_config.scheduler_cls = (
-                    TT_STANDARD_SCHEDULER_CLS
-                )
+            if vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS:
+                vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -23,6 +23,9 @@ else:
 
 logger = init_logger(__name__)
 
+TT_ASYNC_SCHEDULER_CLS = "vllm.v1.core.sched.tt_scheduler.TTScheduler"
+TT_STANDARD_SCHEDULER_CLS = "vllm.v1.core.sched.ascend_scheduler.AscendScheduler"
+
 
 def _register_model_if_missing(ModelRegistry, model_arch: str, model_path: str) -> None:
     """Register `model_arch` only if not already registered.
@@ -258,9 +261,7 @@ class TTPlatform(Platform):
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
-            vllm_config.scheduler_config.scheduler_cls = (
-                "vllm.v1.core.sched.ascend_scheduler.AscendScheduler"
-            )
+            vllm_config.scheduler_config.scheduler_cls = TT_ASYNC_SCHEDULER_CLS
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
@@ -346,6 +347,35 @@ class TTPlatform(Platform):
         model_capabilities: dict | None = getattr(
             model_class, "model_capabilities", None
         )
+
+        # Model-gated async scheduling.
+        supports_async_decode = (
+            model_capabilities.get("supports_async_decode", False)
+            if model_capabilities
+            else False
+        )
+        if (
+            vllm_config.scheduler_config.async_scheduling
+            and not supports_async_decode
+        ):
+            logger.warning(
+                "Async scheduling was requested, but TT model %s (%s) does not "
+                "declare support (`model_capabilities['supports_async_decode']`). "
+                "Disabling async scheduling and falling back to standard TT "
+                "scheduler.",
+                model_class.__name__,
+                model_class.__module__,
+            )
+            vllm_config.scheduler_config.async_scheduling = False
+            # If TT selected the async scheduler by default, switch back to
+            # the standard TT scheduler. Keep user-provided custom scheduler.
+            if (
+                vllm_config.scheduler_config.scheduler_cls
+                == TT_ASYNC_SCHEDULER_CLS
+            ):
+                vllm_config.scheduler_config.scheduler_cls = (
+                    TT_STANDARD_SCHEDULER_CLS
+                )
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/v1/core/sched/tt_scheduler.py
+++ b/vllm/v1/core/sched/tt_scheduler.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import cast
+
+from vllm.logger import init_logger
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class TTScheduler(AsyncScheduler):
+    """Scheduler for the TT (Tenstorrent) platform.
+
+    TT constraints:
+    - No mixed prefill+decode batches: each batch is either all-prefill
+      or all-decode.
+    - No chunked prefill: each prefill must be scheduled in full.
+
+    Inherits from AsyncScheduler to get num_output_placeholders support,
+    which allows decode requests to be re-scheduled before
+    update_from_output processes the previous step's results.  This is
+    essential for overlapping CPU scheduling with device execution.
+
+    Supports ``set_forced_mode`` for DP-gather coordination:
+    - ``0`` forces decode-only (even if waiting queue is non-empty).
+    - ``1`` forces prefill-only (even if waiting queue is empty).
+    - ``None`` uses the default policy: prefill-first, then decode.
+    """
+
+    waiting: RequestQueue
+    running: list[Request]
+    max_num_running_reqs: int
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._forced_mode: int | None = None
+
+    def set_forced_mode(self, mode: int | None) -> None:
+        assert mode in (None, 0, 1)
+        self._forced_mode = mode
+
+    def schedule(self) -> SchedulerOutput:
+        want_prefill = bool(self.waiting) and self._forced_mode != 0
+        want_decode = not want_prefill and self._forced_mode != 1
+
+        if want_decode:
+            if self.waiting:
+                # forced_mode=0 but waiting has requests.  Suppress the
+                # waiting loop so the base scheduler only runs decode.
+                return self._schedule_decode_only()
+            # No waiting requests — base scheduler naturally does
+            # decode-only (the waiting loop is a no-op).
+            return super().schedule()
+
+        if want_prefill:
+            return self._schedule_prefill_only()
+
+        # forced_mode=1 but nothing in waiting — return an empty batch.
+        # Call super with hidden running so nothing gets scheduled.
+        return self._schedule_prefill_only()
+
+    def _schedule_prefill_only(self) -> SchedulerOutput:
+        """Schedule only waiting (prefill) requests.
+
+        Temporarily hides the running (decode) requests so the base
+        scheduler's running loop iterates zero times and only the
+        waiting loop executes.  Adjusts max_num_running_reqs so the
+        waiting loop respects the true capacity.
+        """
+        saved_running = self.running
+        saved_max = self.max_num_running_reqs
+        self.running = cast(list[Request], [])
+        self.max_num_running_reqs = max(0, saved_max - len(saved_running))
+        try:
+            result = super().schedule()
+        finally:
+            self.running = saved_running + self.running
+            self.max_num_running_reqs = saved_max
+        return result
+
+    def _schedule_decode_only(self) -> SchedulerOutput:
+        """Schedule only running (decode) requests.
+
+        Temporarily hides the waiting queue so the base scheduler's
+        waiting loop is a no-op.  Any requests that get preempted
+        during decode scheduling are merged back into the original
+        waiting queue afterwards.
+        """
+        saved_waiting = self.waiting
+        self.waiting = create_request_queue(self.policy)
+        try:
+            result = super().schedule()
+        finally:
+            if self.waiting:
+                saved_waiting.prepend_requests(self.waiting)
+            self.waiting = saved_waiting
+        return result

--- a/vllm/v1/core/sched/tt_scheduler.py
+++ b/vllm/v1/core/sched/tt_scheduler.py
@@ -27,8 +27,11 @@ class TTScheduler(AsyncScheduler):
 
     Supports ``set_forced_mode`` for DP-gather coordination:
     - ``0`` forces decode-only (even if waiting queue is non-empty).
-    - ``1`` forces prefill-only (even if waiting queue is empty).
-    - ``None`` uses the default policy: prefill-first, then decode.
+    - ``1`` forces prefill-only (and may return an empty batch when waiting
+      is empty).
+    - ``None`` uses the default policy: prefer prefill when waiting is
+      non-empty, but fall back to decode-only if prefill cannot admit any
+      request and running decode requests exist.
     """
 
     waiting: RequestQueue
@@ -44,24 +47,50 @@ class TTScheduler(AsyncScheduler):
         self._forced_mode = mode
 
     def schedule(self) -> SchedulerOutput:
-        want_prefill = bool(self.waiting) and self._forced_mode != 0
-        want_decode = not want_prefill and self._forced_mode != 1
+        has_waiting = bool(self.waiting)
+        has_running = bool(self.running)
+        mode = self._forced_mode
 
-        if want_decode:
-            if self.waiting:
-                # forced_mode=0 but waiting has requests.  Suppress the
-                # waiting loop so the base scheduler only runs decode.
+        # Forced mode from DP-gather coordination:
+        #   mode == 1 -> prefill-only
+        #   mode == 0 -> decode-only
+        if mode == 1:
+            # If waiting is empty, this intentionally returns an empty batch.
+            return self._schedule_prefill_only()
+        if mode == 0:
+            if has_waiting:
+                # Hide waiting so base scheduler cannot admit prefill.
                 return self._schedule_decode_only()
-            # No waiting requests — base scheduler naturally does
-            # decode-only (the waiting loop is a no-op).
+            # No waiting requests: base scheduler naturally runs decode-only.
             return super().schedule()
 
-        if want_prefill:
-            return self._schedule_prefill_only()
+        # Default mode (mode is None):
+        # Prefer prefill whenever waiting is non-empty to admit new requests.
+        if has_waiting:
+            prefill_result = self._schedule_prefill_only()
+            has_prefill_running = any(
+                req.num_computed_tokens < req.num_prompt_tokens for req in self.running
+            )
+            # If waiting is non-empty but prefill cannot be admitted (e.g. KV
+            # pressure and no chunked prefill), do not stall decode progress.
+            # Fall back to decode-only so running requests can advance and free
+            # capacity for later full-prefill admission.
+            #
+            # Guard: only apply this when running requests are already in
+            # decode phase. If any running request is still in prefill phase,
+            # forcing decode-only here can create scheduler/model-output
+            # mismatches in async TT flow.
+            if (
+                prefill_result.total_num_scheduled_tokens == 0
+                and has_running
+                and bool(self.waiting)
+                and not has_prefill_running
+            ):
+                return self._schedule_decode_only()
+            return prefill_result
 
-        # forced_mode=1 but nothing in waiting — return an empty batch.
-        # Call super with hidden running so nothing gets scheduled.
-        return self._schedule_prefill_only()
+        # No waiting requests in default mode: run decode-only naturally.
+        return super().schedule()
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
         """Schedule only waiting (prefill) requests.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -427,6 +427,18 @@ class EngineCore:
         if hasattr(self, "requires_gather") and self.requires_gather:
             # Different execution path for gathered batch DP.
             assert hasattr(self, "_execute_model_dp_gather")
+            grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+            # DP gather path for TT still consumes structured constraints from
+            # scheduler_output in worker-side model input building.
+            if current_platform.is_tt():
+                if grammar_output is not None:
+                    scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
+                else:
+                    scheduler_output.structured_output_request_ids = None
+                    scheduler_output.grammar_bitmask = None
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
             grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -24,10 +24,10 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
-from vllm.platforms import current_platform
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import engine_receiver_cache_from_config
+from vllm.platforms import current_platform
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
 from vllm.utils.gc_utils import (
@@ -492,9 +492,7 @@ class EngineCore:
             else:
                 if not scheduler_output.pending_structured_output_tokens:
                     if current_platform.is_tt():
-                        future = cast(
-                            Future[ModelRunnerOutput], exec_future
-                        )
+                        future = cast(Future[ModelRunnerOutput], exec_future)
                     else:
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -429,8 +429,21 @@ class EngineCore:
             assert hasattr(self, "_execute_model_dp_gather")
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
-            future = self.model_executor.execute_model(scheduler_output, non_block=True)
             grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+            if current_platform.is_tt():
+                # TT consumes grammar constraints inside execute_model
+                # (worker-side), so materialize them on scheduler_output before
+                # submission.
+                if grammar_output is not None:
+                    scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
+                else:
+                    scheduler_output.structured_output_request_ids = None
+                    scheduler_output.grammar_bitmask = None
+
+            future = self.model_executor.execute_model(scheduler_output, non_block=True)
             with self.log_error_detail(scheduler_output):
                 model_output = future.result()
                 if model_output is None:
@@ -478,22 +491,52 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
+        exec_future: Future[ModelRunnerOutput] | None = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule()
-            exec_future = self.model_executor.execute_model(
-                scheduler_output, non_block=True
-            )
             if not self.is_ec_producer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
             if self.is_pooling_model or not model_executed:
                 # No sampling required (no requests scheduled).
+                exec_future = cast(
+                    Future[ModelRunnerOutput],
+                    self.model_executor.execute_model(scheduler_output, non_block=True),
+                )
                 future = cast(Future[ModelRunnerOutput], exec_future)
             else:
                 if not scheduler_output.pending_structured_output_tokens:
                     if current_platform.is_tt():
+                        # TT consumes grammar constraints inside execute_model
+                        # (worker-side), so materialize grammar fields on
+                        # scheduler_output before execute_model submission.
+                        grammar_output = self.scheduler.get_grammar_bitmask(
+                            scheduler_output
+                        )
+                        if grammar_output is not None:
+                            scheduler_output.structured_output_request_ids = (
+                                grammar_output.structured_output_request_ids
+                            )
+                            scheduler_output.grammar_bitmask = (
+                                grammar_output.grammar_bitmask
+                            )
+                        else:
+                            scheduler_output.structured_output_request_ids = None
+                            scheduler_output.grammar_bitmask = None
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         future = cast(Future[ModelRunnerOutput], exec_future)
                     else:
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)
                         )
@@ -504,13 +547,24 @@ class EngineCore:
                             grammar_output, non_block=True
                         )
                 else:
-                    if not current_platform.is_tt():
+                    # Structured-output grammar needs previous-step tokens.
+                    # For TT, grammar is consumed in execute_model path, so we
+                    # must defer execute_model submission itself.
+                    if current_platform.is_tt():
+                        deferred_scheduler_output = scheduler_output
+                    else:
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)
                         )
-                    # We need to defer sampling until we have processed the model output
-                    # from the prior step.
-                    deferred_scheduler_output = scheduler_output
+                        # We need to defer sampling until we have processed the
+                        # model output from the prior step.
+                        deferred_scheduler_output = scheduler_output
 
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
@@ -546,6 +600,28 @@ class EngineCore:
             # We now have the tokens needed to compute the bitmask for the
             # deferred request. Get the bitmask and call sample tokens.
             if current_platform.is_tt():
+                # For TT async path, grammar must be computed after prior output
+                # has updated request states, and before execute_model consumes
+                # scheduler_output in build_model_input.
+                grammar_output = self.scheduler.get_grammar_bitmask(
+                    deferred_scheduler_output
+                )
+                if grammar_output is not None:
+                    deferred_scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    deferred_scheduler_output.grammar_bitmask = (
+                        grammar_output.grammar_bitmask
+                    )
+                else:
+                    deferred_scheduler_output.structured_output_request_ids = None
+                    deferred_scheduler_output.grammar_bitmask = None
+                exec_future = cast(
+                    Future[ModelRunnerOutput],
+                    self.model_executor.execute_model(
+                        deferred_scheduler_output, non_block=True
+                    ),
+                )
                 batch_queue.appendleft(
                     (
                         cast(Future[ModelRunnerOutput], exec_future),

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -24,6 +24,7 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
+from vllm.platforms import current_platform
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import engine_receiver_cache_from_config
@@ -121,6 +122,11 @@ class EngineCore:
 
         # Setup scheduler.
         Scheduler = vllm_config.scheduler_config.get_scheduler_cls()
+        logger.info(
+            "Scheduler class: %s, async_scheduling=%s",
+            Scheduler.__name__,
+            vllm_config.scheduler_config.async_scheduling,
+        )
 
         if len(kv_cache_config.kv_cache_groups) == 0:
             # Encoder models without KV cache don't support
@@ -484,18 +490,26 @@ class EngineCore:
                 # No sampling required (no requests scheduled).
                 future = cast(Future[ModelRunnerOutput], exec_future)
             else:
-                exec_future.add_done_callback(self._log_err_callback(scheduler_output))
-
                 if not scheduler_output.pending_structured_output_tokens:
-                    # We aren't waiting for any tokens, get any grammar output
-                    # and sample immediately.
-                    grammar_output = self.scheduler.get_grammar_bitmask(
-                        scheduler_output
-                    )
-                    future = self.model_executor.sample_tokens(
-                        grammar_output, non_block=True
-                    )
+                    if current_platform.is_tt():
+                        future = cast(
+                            Future[ModelRunnerOutput], exec_future
+                        )
+                    else:
+                        exec_future.add_done_callback(
+                            self._log_err_callback(scheduler_output)
+                        )
+                        grammar_output = self.scheduler.get_grammar_bitmask(
+                            scheduler_output
+                        )
+                        future = self.model_executor.sample_tokens(
+                            grammar_output, non_block=True
+                        )
                 else:
+                    if not current_platform.is_tt():
+                        exec_future.add_done_callback(
+                            self._log_err_callback(scheduler_output)
+                        )
                     # We need to defer sampling until we have processed the model output
                     # from the prior step.
                     deferred_scheduler_output = scheduler_output
@@ -533,11 +547,21 @@ class EngineCore:
         if deferred_scheduler_output:
             # We now have the tokens needed to compute the bitmask for the
             # deferred request. Get the bitmask and call sample tokens.
-            grammar_output = self.scheduler.get_grammar_bitmask(
-                deferred_scheduler_output
-            )
-            future = self.model_executor.sample_tokens(grammar_output, non_block=True)
-            batch_queue.appendleft((future, deferred_scheduler_output))
+            if current_platform.is_tt():
+                batch_queue.appendleft(
+                    (
+                        cast(Future[ModelRunnerOutput], exec_future),
+                        deferred_scheduler_output,
+                    )
+                )
+            else:
+                grammar_output = self.scheduler.get_grammar_bitmask(
+                    deferred_scheduler_output
+                )
+                future = self.model_executor.sample_tokens(
+                    grammar_output, non_block=True
+                )
+                batch_queue.appendleft((future, deferred_scheduler_output))
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -120,7 +120,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
 
     def __init__(
         self,
-        runner: "TTModelRunner",
+        runner: TTModelRunner,
         tt_out: Any | None,
         model_input: TTModelInput,
         batch_size_per_dp: list[int],
@@ -159,9 +159,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         )
 
         tt_log_probs = None
-        assert isinstance(
-            self._sampling_params.enable_log_probs, torch.Tensor
-        )
+        assert isinstance(self._sampling_params.enable_log_probs, torch.Tensor)
         if (
             self._perform_device_sampling
             and self._sampling_params.enable_log_probs.any()
@@ -2047,9 +2045,7 @@ class TTModelRunner:
         num_reqs = len(req_ids)
         sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
         if sampled_token_ids_np.dtype != np.int32:
-            sampled_token_ids_np = sampled_token_ids_np.astype(
-                np.int32, copy=False
-            )
+            sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
 
         # Write the sampled token into persistent batch token storage so
         # that _prepare_model_inputs reads it as the next decode input.
@@ -2064,8 +2060,8 @@ class TTModelRunner:
             output_token_ids = self.requests[req_id].output_token_ids
             output_token_ids.append(int(sampled_token_ids_np[req_idx]))
 
-        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = (
-            dict.fromkeys(req_ids, None)
+        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
+            req_ids, None
         )
 
         return ModelRunnerOutput(

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, cast
 
@@ -22,6 +23,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
+    AsyncModelRunnerOutput,
     LogprobsLists,
     LogprobsTensors,
     ModelRunnerOutput,
@@ -104,6 +106,93 @@ class TTModelInput:
     reset_batch: bool = False
 
 
+class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
+    """Wraps a non-blocking TT decode submission.
+
+    Returned by ``_execute_model_async_decode`` so that the executor can
+    defer the blocking device-sync / readback to a worker thread while the
+    main thread continues scheduling the next batch.
+
+    ``req_ids`` and ``req_id_to_index`` are captured at submit time because
+    ``input_batch`` may be overwritten by the next step before
+    ``get_output()`` runs.
+    """
+
+    def __init__(
+        self,
+        runner: "TTModelRunner",
+        tt_out: Any | None,
+        model_input: TTModelInput,
+        batch_size_per_dp: list[int],
+        sampling_params: TTSamplingParams,
+        perform_device_sampling: bool,
+        completion_event: threading.Event,
+        req_ids: list[str],
+        req_id_to_index: dict[str, int],
+    ):
+        self._runner = runner
+        self._tt_out = tt_out
+        self._model_input = model_input
+        self._batch_size_per_dp = batch_size_per_dp
+        self._sampling_params = sampling_params
+        self._perform_device_sampling = perform_device_sampling
+        self._completion_event = completion_event
+        self._req_ids = req_ids
+        self._req_id_to_index = req_id_to_index
+
+    def get_output(self) -> ModelRunnerOutput:
+        try:
+            return self._get_output_impl()
+        finally:
+            self._completion_event.set()
+
+    def _get_output_impl(self) -> ModelRunnerOutput:
+        runner = self._runner
+        tt_out_raw = self._tt_out
+
+        if tt_out_raw is None:
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        tt_out = runner.model.sync_and_read_decode_output(
+            tt_out_raw,
+            is_tokens=self._perform_device_sampling,
+        )
+
+        tt_log_probs = None
+        assert isinstance(
+            self._sampling_params.enable_log_probs, torch.Tensor
+        )
+        if (
+            self._perform_device_sampling
+            and self._sampling_params.enable_log_probs.any()
+        ):
+            assert isinstance(tt_out, tuple) and len(tt_out) == 2
+            tt_out, tt_log_probs = tt_out
+        elif isinstance(tt_out, tuple):
+            tt_out, _ = tt_out
+
+        sampled_token_ids_per_dp, logprobs_per_dp = runner._get_output_tokens(
+            tt_out=tt_out,
+            tt_log_probs=tt_log_probs,
+            sampling_params=self._sampling_params,
+            model_input=self._model_input,
+            batch_size_per_dp=self._batch_size_per_dp,
+            perform_device_sampling=self._perform_device_sampling,
+            is_decode=True,
+        )
+
+        sampled_token_ids = sampled_token_ids_per_dp[0]
+        logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
+        logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
+
+        return runner.generate_runner_output_from_async(
+            req_ids=self._req_ids,
+            req_id_to_index=self._req_id_to_index,
+            sampled_token_ids=sampled_token_ids,
+            logprobs=logprobs,
+        )
+
+
 class TTModelRunner:
     def __init__(
         self,
@@ -168,6 +257,16 @@ class TTModelRunner:
         # change during prefill steps (e.g. new requests added), so we keep a
         # sticky flag and clear it only after a decode input consumes it.
         self._decode_layout_changed_since_last_decode: bool = True
+
+        # Async scheduling: overlap CPU scheduling with device execution.
+        # Only supported for DP=1 (DP>1 uses a different execution path).
+        self.async_scheduling = (
+            self.scheduler_config.async_scheduling
+            and self.parallel_config.data_parallel_size == 1
+        )
+        # Guards single in-flight async decode. Set when an async decode is
+        # submitted; cleared when get_output() completes on the async thread.
+        self._pending_async_event: threading.Event | None = None
 
         # Sampler for sampling on host when device sampling is not supported.
         # Only used by device ranks (local dp rank 0).
@@ -1293,20 +1392,35 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
         intermediate_tensors: IntermediateTensors | None = None,
-    ) -> ModelRunnerOutput:
+    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
         """Execution path for non-DP case.
-        Execute the model with the given scheduler output."""
+        Execute the model with the given scheduler output.
+
+        When ``async_scheduling`` is enabled and the step is a decode,
+        returns ``AsyncTTModelRunnerOutput`` (the trace is submitted but
+        the device has not been synced yet).  The executor puts
+        ``get_output()`` on its async thread and returns a Future.
+        """
         # In the DP case, this function is skipped!
         # tt_worker.py directly calls execute_with_model_input
         # With DP, the actual model pass happens on a batch
         # produced by concatenating the inputs from all DP ranks.
+
+        # Wait for any in-flight async decode from the previous step.
+        if self._pending_async_event is not None:
+            self._pending_async_event.wait()
+            self._pending_async_event = None
 
         # Update cached state and prepare model inputs
         model_input = self.build_model_input(scheduler_output)
         if model_input is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
-        # Only 1 DP rank here
+        is_decode = model_input.prompt_lens is None
+        if self.async_scheduling and is_decode:
+            return self._execute_model_async_decode(model_input)
+
+        # Synchronous path (prefill, or decode without async scheduling)
         sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(  # noqa: E501
             model_input
         )
@@ -1315,6 +1429,111 @@ class TTModelRunner:
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
         output = self.generate_runner_output(sampled_token_ids, logprobs)
         return output
+
+    def _execute_model_async_decode(
+        self,
+        model_input: TTModelInput,
+    ) -> AsyncTTModelRunnerOutput:
+        """Submit a decode trace without blocking for device completion.
+
+        Mirrors the decode path of ``execute_with_model_input`` but passes
+        ``read_from_device=False`` so that ``decode_forward`` returns device
+        tensors immediately.  The actual sync + readback + sampling happens
+        later inside ``AsyncTTModelRunnerOutput.get_output()``.
+        """
+        event = threading.Event()
+
+        batch_size_per_dp = model_input.unpadded_batch_size
+        if not isinstance(batch_size_per_dp, list):
+            batch_size_per_dp = [batch_size_per_dp]
+
+        if not any(bs > 0 for bs in batch_size_per_dp):
+            event.set()
+            self._pending_async_event = event
+            num_reqs = self.input_batch.num_reqs
+            return AsyncTTModelRunnerOutput(
+                runner=self,
+                tt_out=None,
+                model_input=model_input,
+                batch_size_per_dp=batch_size_per_dp,
+                sampling_params=model_input.tt_sampling_params,
+                perform_device_sampling=model_input.perform_device_sampling,
+                completion_event=event,
+                req_ids=list(self.input_batch.req_ids[:num_reqs]),
+                req_id_to_index=dict(self.input_batch.req_id_to_index),
+            )
+
+        kwargs: dict[str, Any] = {
+            "tokens": model_input.input_tokens,
+            "page_table": model_input.block_tables,
+            "kv_cache": self.kv_caches,
+            "start_pos": model_input.input_positions,
+        }
+
+        sampling_params = model_input.tt_sampling_params
+        perform_device_sampling = model_input.perform_device_sampling
+        if perform_device_sampling:
+            sampling_param_dict = {
+                field.name: (
+                    getattr(sampling_params, field.name).tolist()
+                    if getattr(sampling_params, field.name) is not None
+                    else None
+                )
+                for field in fields(sampling_params)
+            }
+            sampling_param_dict["seed"] = [
+                None if s == SEED_NONE_SENTINEL else s
+                for s in sampling_param_dict["seed"]
+            ]
+            kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
+
+            if model_input.prompt_tokens is not None:
+                assert model_input.output_tokens is not None
+                kwargs["prompt_tokens"] = model_input.prompt_tokens
+                kwargs["output_tokens"] = model_input.output_tokens
+
+            kwargs["reset_batch"] = model_input.reset_batch
+
+        enc_dec_kwargs: dict[str, Any] = {}
+        if self.request_specific_rope:
+            if any(
+                req_id not in self.previous_req_ids
+                for req_id in self.input_batch.req_ids
+            ):
+                enc_dec_kwargs = {
+                    "rope_deltas_all_users": [
+                        self.requests[req_id].mrope_position_delta
+                        for req_id in self.input_batch.req_ids
+                    ]
+                }
+            else:
+                enc_dec_kwargs = {"rope_deltas_all_users": None}
+            self.previous_req_ids = set(self.input_batch.req_ids)
+
+        enable_trace = self.trace_mode in ["all", "decode_only"]
+        tt_out = self.model.decode_forward(
+            **kwargs,
+            **enc_dec_kwargs,
+            enable_trace=enable_trace,
+            read_from_device=False,
+        )
+
+        # Capture req_ids/req_id_to_index now - input_batch will be
+        # overwritten by the next step's build_model_input before
+        # get_output() runs on the async thread.
+        self._pending_async_event = event
+        num_reqs = self.input_batch.num_reqs
+        return AsyncTTModelRunnerOutput(
+            runner=self,
+            tt_out=tt_out,
+            model_input=model_input,
+            batch_size_per_dp=batch_size_per_dp,
+            sampling_params=sampling_params,
+            perform_device_sampling=perform_device_sampling,
+            completion_event=event,
+            req_ids=list(self.input_batch.req_ids[:num_reqs]),
+            req_id_to_index=dict(self.input_batch.req_id_to_index),
+        )
 
     def check_perform_device_sampling(
         self, is_decode: bool, has_structured_outputs: bool
@@ -1798,6 +2017,60 @@ class TTModelRunner:
         return ModelRunnerOutput(
             req_ids=self.input_batch.req_ids,
             req_id_to_index=self.input_batch.req_id_to_index,
+            sampled_token_ids=[
+                sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
+            ],
+            logprobs=logprobs,
+            prompt_logprobs_dict=prompt_logprobs_dict,
+            pooler_output=[],
+        )
+
+    def generate_runner_output_from_async(
+        self,
+        req_ids: list[str],
+        req_id_to_index: dict[str, int],
+        sampled_token_ids: torch.Tensor,
+        logprobs: LogprobsLists | None = None,
+    ) -> ModelRunnerOutput:
+        """Build ``ModelRunnerOutput`` for an async decode step.
+
+        Runs on the async output thread after device sync + sampling.
+        Updates ``self.input_batch`` (token_ids_cpu and num_tokens) so
+        that the next step's ``_prepare_model_inputs`` reads the correct
+        decode input token.  Thread-safe: ``_pending_async_event.wait()``
+        on the main thread guarantees this method completes before
+        ``build_model_input`` accesses ``input_batch``.
+
+        Uses *captured* ``req_ids`` / ``req_id_to_index`` for the
+        ``ModelRunnerOutput`` since those reflect the batch at submit time.
+        """
+        num_reqs = len(req_ids)
+        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        if sampled_token_ids_np.dtype != np.int32:
+            sampled_token_ids_np = sampled_token_ids_np.astype(
+                np.int32, copy=False
+            )
+
+        # Write the sampled token into persistent batch token storage so
+        # that _prepare_model_inputs reads it as the next decode input.
+        start_idxs = self.input_batch.num_tokens[:num_reqs]
+        end_idxs = start_idxs + 1
+        rows = np.arange(num_reqs)
+        self.input_batch.token_ids_cpu[rows, start_idxs] = sampled_token_ids_np
+        self.input_batch.num_tokens[:num_reqs] = end_idxs
+
+        for req_idx in range(num_reqs):
+            req_id = req_ids[req_idx]
+            output_token_ids = self.requests[req_id].output_token_ids
+            output_token_ids.append(int(sampled_token_ids_np[req_idx]))
+
+        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = (
+            dict.fromkeys(req_ids, None)
+        )
+
+        return ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
             sampled_token_ids=[
                 sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
             ],

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1971,6 +1971,11 @@ class TTModelRunner:
         # Cache the sampled tokens in the model runner, so that the scheduler
         # doesn't need to send them back.
         num_reqs = self.input_batch.num_reqs
+        # Snapshot request mapping for this step. The batch queue may allow a
+        # later step to run and mutate input_batch before EngineCore consumes
+        # this ModelRunnerOutput.
+        req_ids = list(self.input_batch.req_ids[:num_reqs])
+        req_id_to_index = dict(self.input_batch.req_id_to_index)
         assert sampled_token_ids.shape[0] == num_reqs, (
             f"Number of request outputs {sampled_token_ids.shape[0]} != "
             f"number of requests in input batch {num_reqs}"
@@ -2008,13 +2013,13 @@ class TTModelRunner:
 
         # Empty prompt log probs
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
-            self.input_batch.req_ids[:num_reqs], None
+            req_ids, None
         )
 
         # Note: currently does not support speculative decoding or pooling.
         return ModelRunnerOutput(
-            req_ids=self.input_batch.req_ids,
-            req_id_to_index=self.input_batch.req_id_to_index,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
             sampled_token_ids=[
                 sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
             ],


### PR DESCRIPTION
## Purpose

Reduce ITL by overlapping CPU and device work. Specifically, VLLM's AsyncScheduler is able to run on step N+1 even before step N has finished. And while N+1 is running on device, AsyncScheduler is able to accept the results from step N.

Issue: https://github.com/tenstorrent/vllm/issues/339

## Test Plan

* Performance: TBD tests to run
* Conformance: VLLM CI https://github.com/tenstorrent/tt-metal/actions/runs/22892942311

## Test Setup

Server cmd:
```
vllm bench serve --endpoint /v1/chat/completions --backend openai-chat --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --random-input-len 2 --random-output-len 1024 --ignore-eos --percentile-metrics ttft,tpot,itl,e2el --tokenizer meta-llama/Llama-3.1-8B-Instruct --max-concurrency 32 --num-prompts 320 --async-scheduling
```
Bench cmd:
```
vllm bench serve --endpoint /v1/chat/completions --backend openai-chat --model meta-llama/Llama-3.1-8B-Instruct --dataset-name random --random-input-len 2 --random-output-len 1024 --ignore-eos --percentile-metrics ttft,tpot,itl,e2el --tokenizer meta-llama/Llama-3.1-8B-Instruct --max-concurrency 32 --num-prompts 320
```
## Test results

<img width="736" height="108" alt="image" src="https://github.com/user-attachments/assets/445b6a08-100f-4558-b370-b0256caa3d84" />


When KV has headroom (1B case), prefill-first admission dominates and TTFT remains good.
When KV is near/full (8B case), prefills are often temporarily inadmissible, so decode progress is prioritized. In async mode, two effects amplify this for TTFT: (1) queue-fill/submission is prioritized before output consumption, while KV release is only applied on output consumption (update_from_output), and (2) one-step-ahead decode scheduling can transiently reserve an extra KV page.
As a result, newly waiting requests observe delayed prefill admission (higher TTFT/P99), even though steady-state decode cadence improves (better ITL).


## How this works

<img width="1717" height="875" alt="Ondev_sampling_async_detail" src="https://github.com/user-attachments/assets/17190b12-831c-4135-b310-96e581ca77d3" />


This trace from on-device sampling show the async overlay nicely. Starting at the bottom, we finish with getting tensors from the device (<listcomp> - red circle). Then process_decode_output_host. Once we have that for step N, the upper thread can continue to build_model_input and decode_forward for N+1, including trace submit - black circle. Only then we do Scheduler.update_from_output() for N and Scheduler.schedule for N+2. At that point we start waiting for step N+1 device outputs in the lower thread (<listcomp> - green circle).

In summary, the CPU work between red circle (trace finish) and black circle (trace submit) is serial to the device, device is idle. The CPU work between trace submit (black circle) and  tensor readout (next red circle) runs parallel to the device. That is the Scheduler work. This is zoomed in to the transition between two steps - there are big gaps when we're just waiting for the device and nothing visible is happening.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

