### PR TITLE
Respect server default stop_token_ids and Harmony stop tokens

### DIFF
--- a/vllm/entrypoints/harmony_utils.py
+++ b/vllm/entrypoints/harmony_utils.py
@@ -508,8 +508,11 @@ def get_streamable_parser_for_assistant() -> StreamableParser:
 
 def parse_output_into_messages(token_ids: Iterable[int]) -> StreamableParser:
     parser = get_streamable_parser_for_assistant()
+    stop_tokens = set(get_stop_tokens_for_assistant_actions())
     for token_id in token_ids:
         parser.process(token_id)
+        if token_id in stop_tokens:
+            break
     return parser
 
 

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -838,6 +838,16 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
 
+        # Merge server-default stop_token_ids (e.g., model-specific tokens
+        # like </call> for gpt-oss) with any request-specified ones
+        stop_token_ids = self.stop_token_ids or None
+        default_stop_ids = default_sampling_params.get("stop_token_ids")
+        if default_stop_ids:
+            if stop_token_ids is None:
+                stop_token_ids = list(default_stop_ids)
+            else:
+                stop_token_ids = list(set(stop_token_ids) | set(default_stop_ids))
+
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.top_logprobs
@@ -899,7 +909,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p=min_p,
             seed=self.seed,
             stop=self.stop,
-            stop_token_ids=self.stop_token_ids,
+            stop_token_ids=stop_token_ids,
             logprobs=self.top_logprobs if self.logprobs else None,
             prompt_logprobs=prompt_logprobs,
             ignore_eos=self.ignore_eos,
@@ -1333,6 +1343,16 @@ class CompletionRequest(OpenAIBaseModel):
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
 
+        # Merge server-default stop_token_ids (e.g., model-specific tokens
+        # like </call> for gpt-oss) with any request-specified ones
+        stop_token_ids = self.stop_token_ids or None
+        default_stop_ids = default_sampling_params.get("stop_token_ids")
+        if default_stop_ids:
+            if stop_token_ids is None:
+                stop_token_ids = list(default_stop_ids)
+            else:
+                stop_token_ids = list(set(stop_token_ids) | set(default_stop_ids))
+
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.logprobs
@@ -1385,7 +1405,7 @@ class CompletionRequest(OpenAIBaseModel):
             min_p=min_p,
             seed=self.seed,
             stop=self.stop,
-            stop_token_ids=self.stop_token_ids,
+            stop_token_ids=stop_token_ids,
             logprobs=self.logprobs,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens if not echo_without_generation else 1,


### PR DESCRIPTION
- Issue: https://github.com/tenstorrent/vllm/issues/334
- Apply the fix from https://github.com/vllm-project/vllm/pull/35076 manually (could not cherry-pick in a clean manor due to too many conflicts after upstream changes) to propagate default stop_token_ids to per-request SamplingParams, so that models like gpt-oss with openai harmony parsing correctly stop at stop tokens.
- vLLM nightly: https://github.com/tenstorrent/tt-metal/actions/runs/23015153197