### PR TITLE
Add support for async scheduling for DP and non-DP cases

### DIFF
--- a/tools/pre_commit/check_pickle_imports.py
+++ b/tools/pre_commit/check_pickle_imports.py
@@ -36,6 +36,7 @@ ALLOWED_FILES = {
     "benchmarks/cutlass_benchmarks/w8a8_benchmarks.py",
     "benchmarks/cutlass_benchmarks/sparse_benchmarks.py",
     "vllm/v1/engine/core.py",  # for serializing inputs in DP gather path
+    "vllm/v1/engine/tt_dp_gather.py",  # extracted DP gather serialization path
     # cloudpickle
     "vllm/v1/executor/multiproc_executor.py",
     "vllm/v1/executor/ray_executor.py",

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -23,8 +23,7 @@ else:
 
 logger = init_logger(__name__)
 
-TT_ASYNC_SCHEDULER_CLS = "vllm.v1.core.sched.tt_scheduler.TTScheduler"
-TT_STANDARD_SCHEDULER_CLS = "vllm.v1.core.sched.ascend_scheduler.AscendScheduler"
+TT_SCHEDULER_CLS = "vllm.v1.core.sched.tt_scheduler.TTScheduler"
 
 
 def _register_model_if_missing(ModelRegistry, model_arch: str, model_path: str) -> None:
@@ -259,23 +258,9 @@ class TTPlatform(Platform):
         register_tt_models(register_test_models)
 
         parallel_config = vllm_config.parallel_config
-        if (
-            vllm_config.scheduler_config.async_scheduling
-            and parallel_config.data_parallel_size > 1
-        ):
-            logger.warning(
-                "Async scheduling on TT is only supported with data_parallel_size=1. "
-                "Got data_parallel_size=%d, disabling async scheduling.",
-                parallel_config.data_parallel_size,
-            )
-            vllm_config.scheduler_config.async_scheduling = False
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
-            vllm_config.scheduler_config.scheduler_cls = (
-                TT_ASYNC_SCHEDULER_CLS
-                if vllm_config.scheduler_config.async_scheduling
-                else TT_STANDARD_SCHEDULER_CLS
-            )
+            vllm_config.scheduler_config.scheduler_cls = TT_SCHEDULER_CLS
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
@@ -362,7 +347,10 @@ class TTPlatform(Platform):
             model_class, "model_capabilities", None
         )
 
-        # Model-gated async scheduling.
+        # Model-gated async scheduling. Async overlap requires generators that
+        # support split decode submission via `decode_forward(...,
+        # read_from_device=False)` followed by `read_decode_output(...,
+        # async_read=True)`.
         supports_async_decode = (
             model_capabilities.get("supports_async_decode", False)
             if model_capabilities
@@ -372,24 +360,20 @@ class TTPlatform(Platform):
             logger.warning(
                 "Async scheduling was requested, but TT model %s (%s) does not "
                 "declare support (`model_capabilities['supports_async_decode']`). "
-                "Disabling async scheduling and falling back to standard TT "
+                "Disabling async execution overlap while keeping the TT "
                 "scheduler.",
                 model_class.__name__,
                 model_class.__module__,
             )
             vllm_config.scheduler_config.async_scheduling = False
-            # If TT selected the async scheduler by default, switch back to
-            # the standard TT scheduler. Keep user-provided custom scheduler.
-            if vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS:
-                vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
 
-        # Guardrail: when async scheduling is disabled, do not leave the TT
-        # async scheduler selected.
-        if (
-            not vllm_config.scheduler_config.async_scheduling
-            and vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS
+        # TT uses a single scheduler implementation for both sync and async
+        # execution modes; async_scheduling only controls execution overlap.
+        if vllm_config.scheduler_config.scheduler_cls in (
+            TT_SCHEDULER_CLS,
+            "vllm.v1.core.sched.ascend_scheduler.AscendScheduler",
         ):
-            vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
+            vllm_config.scheduler_config.scheduler_cls = TT_SCHEDULER_CLS
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -259,9 +259,23 @@ class TTPlatform(Platform):
         register_tt_models(register_test_models)
 
         parallel_config = vllm_config.parallel_config
+        if (
+            vllm_config.scheduler_config.async_scheduling
+            and parallel_config.data_parallel_size > 1
+        ):
+            logger.warning(
+                "Async scheduling on TT is only supported with data_parallel_size=1. "
+                "Got data_parallel_size=%d, disabling async scheduling.",
+                parallel_config.data_parallel_size,
+            )
+            vllm_config.scheduler_config.async_scheduling = False
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
-            vllm_config.scheduler_config.scheduler_cls = TT_ASYNC_SCHEDULER_CLS
+            vllm_config.scheduler_config.scheduler_cls = (
+                TT_ASYNC_SCHEDULER_CLS
+                if vllm_config.scheduler_config.async_scheduling
+                else TT_STANDARD_SCHEDULER_CLS
+            )
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
@@ -368,6 +382,14 @@ class TTPlatform(Platform):
             # the standard TT scheduler. Keep user-provided custom scheduler.
             if vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS:
                 vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
+
+        # Guardrail: when async scheduling is disabled, do not leave the TT
+        # async scheduler selected.
+        if (
+            not vllm_config.scheduler_config.async_scheduling
+            and vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS
+        ):
+            vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -354,10 +354,7 @@ class TTPlatform(Platform):
             if model_capabilities
             else False
         )
-        if (
-            vllm_config.scheduler_config.async_scheduling
-            and not supports_async_decode
-        ):
+        if vllm_config.scheduler_config.async_scheduling and not supports_async_decode:
             logger.warning(
                 "Async scheduling was requested, but TT model %s (%s) does not "
                 "declare support (`model_capabilities['supports_async_decode']`). "
@@ -369,13 +366,8 @@ class TTPlatform(Platform):
             vllm_config.scheduler_config.async_scheduling = False
             # If TT selected the async scheduler by default, switch back to
             # the standard TT scheduler. Keep user-provided custom scheduler.
-            if (
-                vllm_config.scheduler_config.scheduler_cls
-                == TT_ASYNC_SCHEDULER_CLS
-            ):
-                vllm_config.scheduler_config.scheduler_cls = (
-                    TT_STANDARD_SCHEDULER_CLS
-                )
+            if vllm_config.scheduler_config.scheduler_cls == TT_ASYNC_SCHEDULER_CLS:
+                vllm_config.scheduler_config.scheduler_cls = TT_STANDARD_SCHEDULER_CLS
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -23,6 +23,9 @@ else:
 
 logger = init_logger(__name__)
 
+TT_ASYNC_SCHEDULER_CLS = "vllm.v1.core.sched.tt_scheduler.TTScheduler"
+TT_STANDARD_SCHEDULER_CLS = "vllm.v1.core.sched.ascend_scheduler.AscendScheduler"
+
 
 def _register_model_if_missing(ModelRegistry, model_arch: str, model_path: str) -> None:
     """Register `model_arch` only if not already registered.
@@ -258,9 +261,7 @@ class TTPlatform(Platform):
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm.v1.worker.tt_worker.TTWorker"
-            vllm_config.scheduler_config.scheduler_cls = (
-                "vllm.v1.core.sched.ascend_scheduler.AscendScheduler"
-            )
+            vllm_config.scheduler_config.scheduler_cls = TT_ASYNC_SCHEDULER_CLS
 
         # For TT models, prepend "TT" to the architecture name,
         # e.g. "TTLlamaForCausalLM"
@@ -346,6 +347,35 @@ class TTPlatform(Platform):
         model_capabilities: dict | None = getattr(
             model_class, "model_capabilities", None
         )
+
+        # Model-gated async scheduling.
+        supports_async_decode = (
+            model_capabilities.get("supports_async_decode", False)
+            if model_capabilities
+            else False
+        )
+        if (
+            vllm_config.scheduler_config.async_scheduling
+            and not supports_async_decode
+        ):
+            logger.warning(
+                "Async scheduling was requested, but TT model %s (%s) does not "
+                "declare support (`model_capabilities['supports_async_decode']`). "
+                "Disabling async scheduling and falling back to standard TT "
+                "scheduler.",
+                model_class.__name__,
+                model_class.__module__,
+            )
+            vllm_config.scheduler_config.async_scheduling = False
+            # If TT selected the async scheduler by default, switch back to
+            # the standard TT scheduler. Keep user-provided custom scheduler.
+            if (
+                vllm_config.scheduler_config.scheduler_cls
+                == TT_ASYNC_SCHEDULER_CLS
+            ):
+                vllm_config.scheduler_config.scheduler_cls = (
+                    TT_STANDARD_SCHEDULER_CLS
+                )
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/vllm/v1/core/sched/tt_scheduler.py
+++ b/vllm/v1/core/sched/tt_scheduler.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import cast
+
+from vllm.logger import init_logger
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
+from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+class TTScheduler(AsyncScheduler):
+    """Scheduler for the TT (Tenstorrent) platform.
+
+    TT constraints:
+    - No mixed prefill+decode batches: each batch is either all-prefill
+      or all-decode.
+    - No chunked prefill: each prefill must be scheduled in full.
+
+    Inherits from AsyncScheduler to get num_output_placeholders support,
+    which allows decode requests to be re-scheduled before
+    update_from_output processes the previous step's results.  This is
+    essential for overlapping CPU scheduling with device execution.
+
+    Supports ``set_forced_mode`` for DP-gather coordination:
+    - ``0`` forces decode-only (even if waiting queue is non-empty).
+    - ``1`` forces prefill-only (even if waiting queue is empty).
+    - ``None`` uses the default policy: prefill-first, then decode.
+    """
+
+    waiting: RequestQueue
+    running: list[Request]
+    max_num_running_reqs: int
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._forced_mode: int | None = None
+
+    def set_forced_mode(self, mode: int | None) -> None:
+        assert mode in (None, 0, 1)
+        self._forced_mode = mode
+
+    def schedule(self) -> SchedulerOutput:
+        want_prefill = bool(self.waiting) and self._forced_mode != 0
+        want_decode = not want_prefill and self._forced_mode != 1
+
+        if want_decode:
+            if self.waiting:
+                # forced_mode=0 but waiting has requests.  Suppress the
+                # waiting loop so the base scheduler only runs decode.
+                return self._schedule_decode_only()
+            # No waiting requests — base scheduler naturally does
+            # decode-only (the waiting loop is a no-op).
+            return super().schedule()
+
+        if want_prefill:
+            return self._schedule_prefill_only()
+
+        # forced_mode=1 but nothing in waiting — return an empty batch.
+        # Call super with hidden running so nothing gets scheduled.
+        return self._schedule_prefill_only()
+
+    def _schedule_prefill_only(self) -> SchedulerOutput:
+        """Schedule only waiting (prefill) requests.
+
+        Temporarily hides the running (decode) requests so the base
+        scheduler's running loop iterates zero times and only the
+        waiting loop executes.  Adjusts max_num_running_reqs so the
+        waiting loop respects the true capacity.
+        """
+        saved_running = self.running
+        saved_max = self.max_num_running_reqs
+        self.running = cast(list[Request], [])
+        self.max_num_running_reqs = max(0, saved_max - len(saved_running))
+        try:
+            result = super().schedule()
+        finally:
+            self.running = saved_running + self.running
+            self.max_num_running_reqs = saved_max
+        return result
+
+    def _schedule_decode_only(self) -> SchedulerOutput:
+        """Schedule only running (decode) requests.
+
+        Temporarily hides the waiting queue so the base scheduler's
+        waiting loop is a no-op.  Any requests that get preempted
+        during decode scheduling are merged back into the original
+        waiting queue afterwards.
+        """
+        saved_waiting = self.waiting
+        self.waiting = create_request_queue(self.policy)
+        try:
+            result = super().schedule()
+        finally:
+            if self.waiting:
+                saved_waiting.prepend_requests(self.waiting)
+            self.waiting = saved_waiting
+        return result

--- a/vllm/v1/core/sched/tt_scheduler.py
+++ b/vllm/v1/core/sched/tt_scheduler.py
@@ -5,7 +5,7 @@ from typing import cast
 
 from vllm.logger import init_logger
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
-from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
 from vllm.v1.request import Request
 
@@ -20,10 +20,13 @@ class TTScheduler(AsyncScheduler):
       or all-decode.
     - No chunked prefill: each prefill must be scheduled in full.
 
-    Inherits from AsyncScheduler to get num_output_placeholders support,
-    which allows decode requests to be re-scheduled before
-    update_from_output processes the previous step's results.  This is
-    essential for overlapping CPU scheduling with device execution.
+    Inherits from AsyncScheduler to get num_output_placeholders support.
+    TT uses this scheduler in both sync and async execution modes:
+    - with async_scheduling=False, it behaves as the single TT scheduler
+      without execution overlap
+    - with async_scheduling=True, placeholders allow decode requests to be
+      re-scheduled before update_from_output processes the previous step's
+      results, enabling host/device overlap
 
     Supports ``set_forced_mode`` for DP-gather coordination:
     - ``0`` forces decode-only (even if waiting queue is non-empty).
@@ -56,13 +59,16 @@ class TTScheduler(AsyncScheduler):
         #   mode == 0 -> decode-only
         if mode == 1:
             # If waiting is empty, this intentionally returns an empty batch.
-            return self._schedule_prefill_only()
+            result = self._schedule_prefill_only()
+            return self._finalize_scheduler_output(result)
         if mode == 0:
             if has_waiting:
                 # Hide waiting so base scheduler cannot admit prefill.
-                return self._schedule_decode_only()
+                result = self._schedule_decode_only()
+                return self._finalize_scheduler_output(result)
             # No waiting requests: base scheduler naturally runs decode-only.
-            return super().schedule()
+            result = super().schedule()
+            return self._finalize_scheduler_output(result)
 
         # Default mode (mode is None):
         # Prefer prefill whenever waiting is non-empty to admit new requests.
@@ -86,11 +92,34 @@ class TTScheduler(AsyncScheduler):
                 and bool(self.waiting)
                 and not has_prefill_running
             ):
-                return self._schedule_decode_only()
-            return prefill_result
+                result = self._schedule_decode_only()
+                return self._finalize_scheduler_output(result)
+            return self._finalize_scheduler_output(prefill_result)
 
         # No waiting requests in default mode: run decode-only naturally.
-        return super().schedule()
+        result = super().schedule()
+        return self._finalize_scheduler_output(result)
+
+    def _finalize_scheduler_output(
+        self, scheduler_output: SchedulerOutput
+    ) -> SchedulerOutput:
+        if not scheduler_output.pending_structured_output_tokens:
+            self.get_grammar_bitmask(scheduler_output)
+        return scheduler_output
+
+    def get_grammar_bitmask(
+        self, scheduler_output: SchedulerOutput
+    ) -> GrammarOutput | None:
+        grammar_output = super().get_grammar_bitmask(scheduler_output)
+        if grammar_output is not None:
+            scheduler_output.structured_output_request_ids = (
+                grammar_output.structured_output_request_ids
+            )
+            scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
+        else:
+            scheduler_output.structured_output_request_ids = None
+            scheduler_output.grammar_bitmask = None
+        return grammar_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
         """Schedule only waiting (prefill) requests.

--- a/vllm/v1/core/sched/tt_scheduler.py
+++ b/vllm/v1/core/sched/tt_scheduler.py
@@ -27,8 +27,11 @@ class TTScheduler(AsyncScheduler):
 
     Supports ``set_forced_mode`` for DP-gather coordination:
     - ``0`` forces decode-only (even if waiting queue is non-empty).
-    - ``1`` forces prefill-only (even if waiting queue is empty).
-    - ``None`` uses the default policy: prefill-first, then decode.
+    - ``1`` forces prefill-only (and may return an empty batch when waiting
+      is empty).
+    - ``None`` uses the default policy: prefer prefill when waiting is
+      non-empty, but fall back to decode-only if prefill cannot admit any
+      request and running decode requests exist.
     """
 
     waiting: RequestQueue
@@ -44,24 +47,50 @@ class TTScheduler(AsyncScheduler):
         self._forced_mode = mode
 
     def schedule(self) -> SchedulerOutput:
-        want_prefill = bool(self.waiting) and self._forced_mode != 0
-        want_decode = not want_prefill and self._forced_mode != 1
+        has_waiting = bool(self.waiting)
+        has_running = bool(self.running)
+        mode = self._forced_mode
 
-        if want_decode:
-            if self.waiting:
-                # forced_mode=0 but waiting has requests.  Suppress the
-                # waiting loop so the base scheduler only runs decode.
+        # Forced mode from DP-gather coordination:
+        #   mode == 1 -> prefill-only
+        #   mode == 0 -> decode-only
+        if mode == 1:
+            # If waiting is empty, this intentionally returns an empty batch.
+            return self._schedule_prefill_only()
+        if mode == 0:
+            if has_waiting:
+                # Hide waiting so base scheduler cannot admit prefill.
                 return self._schedule_decode_only()
-            # No waiting requests — base scheduler naturally does
-            # decode-only (the waiting loop is a no-op).
+            # No waiting requests: base scheduler naturally runs decode-only.
             return super().schedule()
 
-        if want_prefill:
-            return self._schedule_prefill_only()
+        # Default mode (mode is None):
+        # Prefer prefill whenever waiting is non-empty to admit new requests.
+        if has_waiting:
+            prefill_result = self._schedule_prefill_only()
+            has_prefill_running = any(
+                req.num_computed_tokens < req.num_prompt_tokens for req in self.running
+            )
+            # If waiting is non-empty but prefill cannot be admitted (e.g. KV
+            # pressure and no chunked prefill), do not stall decode progress.
+            # Fall back to decode-only so running requests can advance and free
+            # capacity for later full-prefill admission.
+            #
+            # Guard: only apply this when running requests are already in
+            # decode phase. If any running request is still in prefill phase,
+            # forcing decode-only here can create scheduler/model-output
+            # mismatches in async TT flow.
+            if (
+                prefill_result.total_num_scheduled_tokens == 0
+                and has_running
+                and bool(self.waiting)
+                and not has_prefill_running
+            ):
+                return self._schedule_decode_only()
+            return prefill_result
 
-        # forced_mode=1 but nothing in waiting — return an empty batch.
-        # Call super with hidden running so nothing gets scheduled.
-        return self._schedule_prefill_only()
+        # No waiting requests in default mode: run decode-only naturally.
+        return super().schedule()
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
         """Schedule only waiting (prefill) requests.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -373,7 +373,9 @@ class EngineCore:
                 # During shutdown, peers may close connections mid-collective.
                 # Exit gracefully to allow coordinated shutdown.
                 if "Connection closed by peer" in str(e):
-                    logger.debug("Collective failed during shutdown, exiting gracefully")
+                    logger.debug(
+                        "Collective failed during shutdown, exiting gracefully"
+                    )
                     raise SystemExit() from e
                 raise
             if int(has_requests_t.item()) == 0:
@@ -388,7 +390,9 @@ class EngineCore:
             # is prefill but it doesn't get scheduled.
             has_running = bool(getattr(self.scheduler, "running", []))
             has_waiting = bool(getattr(self.scheduler, "waiting", False))
-            must_prefill = has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
+            dp_decode_streak = cast(int, self.dp_decode_streak)
+            dp_max_consec_decodes = cast(int, self.dp_max_consec_decodes)
+            must_prefill = has_waiting and dp_decode_streak >= dp_max_consec_decodes
             local_prefill_intent = (
                 1 if (has_waiting and (must_prefill or not has_running)) else 0
             )
@@ -426,7 +430,7 @@ class EngineCore:
             # Update decode streak: increment only when decode scheduled tokens;
             # reset to 0 when prefill runs OR when nothing was scheduled.
             if scheduler_output.total_num_scheduled_tokens > 0 and forced_mode == 0:
-                self.dp_decode_streak += 1  # type: ignore[has-type]
+                self.dp_decode_streak = dp_decode_streak + 1
             else:
                 self.dp_decode_streak = 0
 
@@ -1541,9 +1545,7 @@ class DPEngineCoreProc(EngineCoreProc):
             # During shutdown, peers may close connections mid-collective.
             # Exit gracefully to allow coordinated shutdown.
             if "Connection closed by peer" in str(e):
-                logger.debug(
-                    "Collective failed during shutdown, exiting gracefully"
-                )
+                logger.debug("Collective failed during shutdown, exiting gracefully")
                 raise SystemExit() from e
             raise
         return int(has_requests_t.item()) > 0
@@ -1557,7 +1559,9 @@ class DPEngineCoreProc(EngineCoreProc):
         # is prefill but it doesn't get scheduled.
         has_running = bool(getattr(self.scheduler, "running", []))
         has_waiting = bool(getattr(self.scheduler, "waiting", False))
-        must_prefill = has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
+        must_prefill = (
+            has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
+        )
         local_prefill_intent = (
             1 if (has_waiting and (must_prefill or not has_running)) else 0
         )
@@ -1608,9 +1612,7 @@ class DPEngineCoreProc(EngineCoreProc):
                 self._dp_apply_forced_mode(None)
                 self._dp_update_decode_streak(scheduler_output, forced_mode)
                 if not self.is_ec_producer:
-                    model_executed = (
-                        scheduler_output.total_num_scheduled_tokens > 0
-                    )
+                    model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
         prev_model_output: ModelRunnerOutput | None = None
         prev_scheduler_output: SchedulerOutput | None = None
@@ -1669,7 +1671,7 @@ class DPEngineCoreProc(EngineCoreProc):
         world = parallel_config.data_parallel_size
 
         local_has_requests = scheduler_output is not None
-        if local_has_requests:
+        if scheduler_output is not None:
             self.dlog(
                 "enter_gather tokens=%d", scheduler_output.total_num_scheduled_tokens
             )

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -427,6 +427,18 @@ class EngineCore:
         if hasattr(self, "requires_gather") and self.requires_gather:
             # Different execution path for gathered batch DP.
             assert hasattr(self, "_execute_model_dp_gather")
+            grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+            # DP gather path for TT still consumes structured constraints from
+            # scheduler_output in worker-side model input building.
+            if current_platform.is_tt():
+                if grammar_output is not None:
+                    scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
+                else:
+                    scheduler_output.structured_output_request_ids = None
+                    scheduler_output.grammar_bitmask = None
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
             grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -24,10 +24,10 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
-from vllm.platforms import current_platform
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import engine_receiver_cache_from_config
+from vllm.platforms import current_platform
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.transformers_utils.config import maybe_register_config_serialize_by_value
 from vllm.utils.gc_utils import (
@@ -492,9 +492,7 @@ class EngineCore:
             else:
                 if not scheduler_output.pending_structured_output_tokens:
                     if current_platform.is_tt():
-                        future = cast(
-                            Future[ModelRunnerOutput], exec_future
-                        )
+                        future = cast(Future[ModelRunnerOutput], exec_future)
                     else:
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -13,7 +13,6 @@ from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from inspect import isclass, signature
 from logging import DEBUG
-from pathlib import Path
 from typing import Any, TypeVar, cast
 
 import msgspec
@@ -114,8 +113,6 @@ class EngineCore:
             )
 
         self.log_stats = log_stats
-        self._tt_step_debug = os.environ.get("VLLM_TT_STEP_DEBUG") == "1"
-        self._init_debug_viztracer()
 
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
@@ -230,10 +227,6 @@ class EngineCore:
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
         freeze_gc_heap()
-
-    def _tt_debug(self, msg: str, *args: object) -> None:
-        if self._tt_step_debug:
-            logger.info("[TT_STEP_DEBUG][core] " + msg, *args)
 
     def _initialize_kv_caches(
         self, vllm_config: VllmConfig
@@ -496,18 +489,6 @@ class EngineCore:
         batch_queue = self.batch_queue
         assert batch_queue is not None
 
-        is_tt = current_platform.is_tt()
-
-        if is_tt:
-            self._tt_debug(
-                "enter queue_len=%d "
-                "has_requests=%s running=%d waiting=%d",
-                len(batch_queue),
-                self.scheduler.has_requests(),
-                len(getattr(self.scheduler, "running", [])),
-                len(getattr(self.scheduler, "waiting", [])),
-            )
-
         # Try to schedule a new batch if the batch queue is not full, but
         # the scheduler may return an empty batch if all requests are scheduled.
         # Note that this is not blocking.
@@ -520,17 +501,6 @@ class EngineCore:
             scheduler_output = self.scheduler.schedule()
             if not self.is_ec_producer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
-            if is_tt:
-                self._tt_debug(
-                    "scheduled total_tokens=%d reqs=%s new=%s cached=%s "
-                    "pending_struct=%s",
-                    scheduler_output.total_num_scheduled_tokens,
-                    list(scheduler_output.num_scheduled_tokens.keys()),
-                    [r.req_id for r in scheduler_output.scheduled_new_reqs],
-                    list(scheduler_output.scheduled_cached_reqs.req_ids),
-                    scheduler_output.pending_structured_output_tokens,
-                )
-
             if self.is_pooling_model or not model_executed:
                 # No sampling required (no requests scheduled).
                 exec_future = cast(
@@ -587,13 +557,6 @@ class EngineCore:
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
                 batch_queue.appendleft((future, scheduler_output))
-                if is_tt:
-                    self._tt_debug(
-                        "queued queue_len=%d newest_reqs=%s oldest_done=%s",
-                        len(batch_queue),
-                        list(scheduler_output.num_scheduled_tokens.keys()),
-                        bool(batch_queue[-1][0].done()),
-                    )
                 if (
                     model_executed
                     and len(batch_queue) < self.batch_queue_size
@@ -611,25 +574,12 @@ class EngineCore:
 
         # Block until the next result is available.
         future, scheduler_output = batch_queue.pop()
-        if is_tt:
-            self._tt_debug(
-                "drain queue_len_after_pop=%d reqs=%s future_done=%s",
-                len(batch_queue),
-                list(scheduler_output.num_scheduled_tokens.keys()),
-                future.done(),
-            )
         with self.log_error_detail(scheduler_output):
             model_output = future.result()
 
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output
         )
-        if is_tt:
-            self._tt_debug(
-                "updated reqs=%s output_reqs=%s",
-                list(scheduler_output.num_scheduled_tokens.keys()),
-                list(model_output.req_ids),
-            )
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is
@@ -665,262 +615,7 @@ class EngineCore:
 
         return engine_core_outputs, model_executed
 
-    def _init_debug_viztracer(self) -> None:
-        self._debug_viztracer = None
-        self._debug_viztracer_started = False
-        self._debug_viztracer_capture_active = False
-        self._debug_viztracer_clear_on_activate = False
-        self._debug_viztracer_finished = False
-        # VizTracer env vars:
-        # - `VLLM_VIZTRACE_MODE`: enables tracing and selects when capture starts.
-        #   Supported values are `engine_init`, `first_request`, and
-        #   `first_dp_decode_submit`. Unset or empty disables VizTracer.
-        # - `VLLM_VIZTRACE_STEPS`: number of engine steps to capture after
-        #   tracing becomes active. Default `200`, minimum `1`.
-        # - `VLLM_VIZTRACE_ENTRIES`: VizTracer buffer size (`tracer_entries`).
-        #   Default `2000000`, minimum `1000`.
-        # - `VLLM_VIZTRACE_MIN_DURATION_US`: minimum event duration passed to
-        #   VizTracer as `min_duration`. Default `0`.
-        # - `VLLM_VIZTRACE_USE_INCLUDE_FILTER`: when set to `1`, restricts the
-        #   trace to the curated `include_files` list built below. Default `0`.
-        # - `VLLM_VIZTRACE_ALL_RANKS`: when set to `1` with
-        #   `VLLM_VIZTRACE_MODE=first_dp_decode_submit`, start armed tracers on
-        #   all local DP ranks instead of only local rank 0. Default `0`.
-        # - `VLLM_VIZTRACE_OUTPUT_DIR`: directory where the trace JSON is
-        #   written. Default is the current working directory.
-        # Example: set all VizTracer env vars.
-        #   export VLLM_VIZTRACE_MODE=engine_init
-        #   export VLLM_VIZTRACE_STEPS=8000
-        #   export VLLM_VIZTRACE_ENTRIES=4000000
-        #   export VLLM_VIZTRACE_MIN_DURATION_US=0
-        #   export VLLM_VIZTRACE_USE_INCLUDE_FILTER=1
-        #   export VLLM_VIZTRACE_ALL_RANKS=1
-        #   export VLLM_VIZTRACE_OUTPUT_DIR=/tmp/vllm-viztraces
-        # Example: unset all VizTracer env vars.
-        #   unset VLLM_VIZTRACE_MODE
-        #   unset VLLM_VIZTRACE_STEPS
-        #   unset VLLM_VIZTRACE_ENTRIES
-        #   unset VLLM_VIZTRACE_MIN_DURATION_US
-        #   unset VLLM_VIZTRACE_USE_INCLUDE_FILTER
-        #   unset VLLM_VIZTRACE_ALL_RANKS
-        #   unset VLLM_VIZTRACE_OUTPUT_DIR
-        self._debug_viztracer_mode = os.environ.get("VLLM_VIZTRACE_MODE", "")
-        self._debug_viztracer_enabled = bool(self._debug_viztracer_mode)
-        self._debug_viztracer_step_budget = max(
-            int(os.environ.get("VLLM_VIZTRACE_STEPS", "200")),
-            1,
-        )
-        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
-        self._debug_viztracer_entries = max(
-            int(os.environ.get("VLLM_VIZTRACE_ENTRIES", "2000000")),
-            1000,
-        )
-        self._debug_viztracer_min_duration_us = max(
-            float(os.environ.get("VLLM_VIZTRACE_MIN_DURATION_US", "0")),
-            0.0,
-        )
-        self._debug_viztracer_use_include_filter = (
-            os.environ.get("VLLM_VIZTRACE_USE_INCLUDE_FILTER") == "1"
-        )
-        self._debug_viztracer_all_ranks = (
-            os.environ.get("VLLM_VIZTRACE_ALL_RANKS") == "1"
-        )
-        self._debug_viztracer_output_dir = os.environ.get(
-            "VLLM_VIZTRACE_OUTPUT_DIR",
-            os.getcwd(),
-        )
-
-        repo_root = Path(__file__).resolve().parents[3]
-        include_files = [
-            repo_root / "vllm/v1/engine/core.py",
-            repo_root / "vllm/v1/executor/uniproc_executor.py",
-            repo_root / "vllm/v1/worker/tt_worker.py",
-            repo_root / "vllm/v1/worker/tt_model_runner.py",
-            repo_root.parent / "tt-metal/models/demos/llama3_70b_galaxy/tt/generator.py",
-            repo_root.parent / "tt-metal/models/tt_transformers/tt/generator.py",
-        ]
-        self._debug_viztracer_include_files = [
-            str(path) for path in include_files if path.exists()
-        ]
-
-        if self._debug_viztracer_mode == "engine_init":
-            self._start_debug_viztracer(armed_only=False)
-        elif self._debug_viztracer_mode in {
-            "first_request",
-            "first_dp_decode_submit",
-        }:
-            # Start tracing before the executor constructs worker threads, then
-            # clear bootstrap data when the requested trigger fires so the saved
-            # report focuses on the interesting window.
-            self._start_debug_viztracer(armed_only=True, clear_on_activate=True)
-
-    def _start_debug_viztracer(
-        self, armed_only: bool, clear_on_activate: bool = False
-    ) -> None:
-        if (
-            not self._debug_viztracer_enabled
-            or self._debug_viztracer_started
-            or self._debug_viztracer_finished
-        ):
-            return
-
-        try:
-            from viztracer import VizTracer
-        except ImportError:
-            logger.warning(
-                "VizTracer debugging was requested but viztracer is not installed."
-            )
-            self._debug_viztracer_enabled = False
-            return
-
-        dp_rank = self.vllm_config.parallel_config.data_parallel_rank
-        local_dp_rank = self.vllm_config.parallel_config.data_parallel_rank_local
-        if (
-            self._debug_viztracer_mode == "first_dp_decode_submit"
-            and not self._debug_viztracer_all_ranks
-            and local_dp_rank != 0
-        ):
-            return
-
-        filename_stem = (
-            "viztrace-first-dp-decode-submit"
-            if self._debug_viztracer_mode == "first_dp_decode_submit"
-            else (
-                "viztrace-engine-init"
-                if self._debug_viztracer_mode == "engine_init"
-                else "viztrace-first-request"
-            )
-        )
-        output_path = os.path.join(
-            self._debug_viztracer_output_dir,
-            f"{filename_stem}-pid{os.getpid()}-dp{dp_rank}-ldp{local_dp_rank}.json",
-        )
-        tracer_kwargs: dict[str, Any] = {
-            "output_file": output_path,
-            "tracer_entries": self._debug_viztracer_entries,
-            "pid_suffix": False,
-            "min_duration": self._debug_viztracer_min_duration_us,
-        }
-        if self._debug_viztracer_use_include_filter:
-            tracer_kwargs["include_files"] = self._debug_viztracer_include_files
-        tracer_kwargs["process_name"] = (
-            f"EngineCore_DP{dp_rank}_LDP{local_dp_rank}"
-        )
-        tracer = VizTracer(**tracer_kwargs)
-        tracer.start()
-        self._debug_viztracer = tracer
-        self._debug_viztracer_started = True
-        self._debug_viztracer_capture_active = not armed_only
-        self._debug_viztracer_clear_on_activate = clear_on_activate
-        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
-        logger.info(
-            "Started VizTracer: mode=%s output=%s steps=%d entries=%d include_filter=%s armed_only=%s",
-            self._debug_viztracer_mode,
-            output_path,
-            self._debug_viztracer_steps_remaining,
-            self._debug_viztracer_entries,
-            self._debug_viztracer_use_include_filter,
-            armed_only,
-        )
-
-    def _activate_debug_viztracer(self, trigger: str) -> None:
-        if (
-            not self._debug_viztracer_started
-            or self._debug_viztracer is None
-            or self._debug_viztracer_capture_active
-        ):
-            return
-
-        if self._debug_viztracer_clear_on_activate:
-            self._debug_viztracer.clear()
-            logger.info(
-                "Cleared VizTracer bootstrap data on activation: mode=%s trigger=%s",
-                self._debug_viztracer_mode,
-                trigger,
-            )
-
-        self._debug_viztracer_capture_active = True
-        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
-        logger.info(
-            "Activated VizTracer capture: mode=%s trigger=%s steps=%d",
-            self._debug_viztracer_mode,
-            trigger,
-            self._debug_viztracer_steps_remaining,
-        )
-
-    def _maybe_start_debug_viztracer(
-        self, request_type: EngineCoreRequestType
-    ) -> None:
-        if (
-            self._debug_viztracer_mode != "first_request"
-            or self._debug_viztracer_finished
-            or request_type != EngineCoreRequestType.ADD
-        ):
-            return
-        if not self._debug_viztracer_started:
-            self._start_debug_viztracer(armed_only=False)
-            return
-        self._activate_debug_viztracer("first_request")
-
-    def _maybe_trigger_debug_viztracer_on_dp_decode_submit(
-        self, is_decode: bool, local_dp_rank: int
-    ) -> None:
-        if (
-            self._debug_viztracer_mode != "first_dp_decode_submit"
-            or self._debug_viztracer_finished
-            or not self._debug_viztracer_started
-            or self._debug_viztracer_capture_active
-            or not is_decode
-            or local_dp_rank != 0
-        ):
-            return
-        assert self._debug_viztracer is not None
-        self._activate_debug_viztracer("first_dp_decode_submit")
-        self._debug_viztracer.log_instant(
-            "VLLM_VIZTRACE_TRIGGER:first_dp_decode_submit",
-            args={
-                "pid": os.getpid(),
-                "dp_rank": self.vllm_config.parallel_config.data_parallel_rank,
-                "local_dp_rank": local_dp_rank,
-            },
-            scope="p",
-        )
-        logger.info(
-            "Activated VizTracer capture on first DP decode submit: pid=%d dp_rank=%s local_dp_rank=%s",
-            os.getpid(),
-            self.vllm_config.parallel_config.data_parallel_rank,
-            local_dp_rank,
-        )
-
-    def _maybe_advance_debug_viztracer(self) -> None:
-        if (
-            not self._debug_viztracer_started
-            or not self._debug_viztracer_capture_active
-        ):
-            return
-        self._debug_viztracer_steps_remaining -= 1
-        if self._debug_viztracer_steps_remaining <= 0:
-            self._stop_debug_viztracer("captured configured number of engine steps")
-
-    def _stop_debug_viztracer(self, reason: str) -> None:
-        if not self._debug_viztracer_started or self._debug_viztracer is None:
-            return
-
-        tracer = self._debug_viztracer
-        self._debug_viztracer = None
-        self._debug_viztracer_started = False
-        self._debug_viztracer_capture_active = False
-        self._debug_viztracer_clear_on_activate = False
-        self._debug_viztracer_finished = True
-        try:
-            tracer.stop()
-            tracer.save()
-            logger.info("Saved VizTracer trace: %s", reason)
-        except Exception:
-            logger.exception("Failed to stop/save VizTracer trace")
-
     def shutdown(self):
-        self._stop_debug_viztracer("engine shutdown")
         self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()
@@ -1394,7 +1089,6 @@ class EngineCoreProc(EngineCore):
             self.output_queue.put_nowait(output)
         # Post-step hook.
         self.post_step(model_executed)
-        self._maybe_advance_debug_viztracer()
 
         return model_executed
 
@@ -1402,8 +1096,6 @@ class EngineCoreProc(EngineCore):
         self, request_type: EngineCoreRequestType, request: Any
     ) -> None:
         """Dispatch request from client."""
-        self._maybe_start_debug_viztracer(request_type)
-
         if request_type == EngineCoreRequestType.ADD:
             req, request_wave = request
             self.add_request(req, request_wave)
@@ -2040,10 +1732,6 @@ class DPEngineCoreProc(EngineCoreProc):
         # 0=decode, 1=prefill.
         assert hasattr(self, "_dp_gather_forced_mode"), "forced_mode not set"
         is_decode = self._dp_gather_forced_mode == 0
-        self._maybe_trigger_debug_viztracer_on_dp_decode_submit(
-            is_decode=is_decode,
-            local_dp_rank=local_rank,
-        )
 
         # Build local dp model input (or None).
         all_local_inputs = self.model_executor.collective_rpc(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -503,53 +503,18 @@ class EngineCore:
                 )
                 future = cast(Future[ModelRunnerOutput], exec_future)
             else:
-                if not scheduler_output.pending_structured_output_tokens:
-                    if current_platform.is_tt():
-                        exec_future = cast(
-                            Future[ModelRunnerOutput],
-                            self.model_executor.execute_model(
-                                scheduler_output, non_block=True
-                            ),
-                        )
-                        future = cast(Future[ModelRunnerOutput], exec_future)
-                    else:
-                        exec_future = cast(
-                            Future[ModelRunnerOutput],
-                            self.model_executor.execute_model(
-                                scheduler_output, non_block=True
-                            ),
-                        )
-                        exec_future.add_done_callback(
-                            self._log_err_callback(scheduler_output)
-                        )
-                        grammar_output = self.scheduler.get_grammar_bitmask(
-                            scheduler_output
-                        )
-                        future = self.model_executor.sample_tokens(
-                            grammar_output, non_block=True
-                        )
-                else:
-                    # Structured-output grammar needs previous-step tokens.
-                    # For TT, grammar is consumed in execute_model path, so we
-                    # must defer execute_model submission itself.
-                    if current_platform.is_tt():
-                        deferred_scheduler_output = scheduler_output
-                    else:
-                        exec_future = cast(
-                            Future[ModelRunnerOutput],
-                            self.model_executor.execute_model(
-                                scheduler_output, non_block=True
-                            ),
-                        )
-                        exec_future.add_done_callback(
-                            self._log_err_callback(scheduler_output)
-                        )
-                        # We need to defer sampling until we have processed the
-                        # model output from the prior step.
-                        deferred_scheduler_output = scheduler_output
+                future, deferred_scheduler_output = (
+                    self.model_executor.submit_scheduled_batch(
+                        scheduler_output,
+                        self.scheduler.get_grammar_bitmask,
+                        non_block=True,
+                        failure_callback=self._log_err_callback(scheduler_output),
+                    )
+                )
 
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
+                assert future is not None
                 batch_queue.appendleft((future, scheduler_output))
                 if (
                     model_executed
@@ -579,37 +544,15 @@ class EngineCore:
         # in a field and do it immediately once step_with_batch_queue is
         # re-called. The latter slightly favors TTFT over TPOT/throughput.
         if deferred_scheduler_output:
-            # We now have the tokens needed to compute the bitmask for the
-            # deferred request. Get the bitmask and call sample tokens.
-            if current_platform.is_tt():
-                # For TT async path, grammar must be computed after prior output
-                # has updated request states, and before execute_model consumes
-                # scheduler_output in build_model_input.
-                # NOTE: get_grammar_bitmask writes the bitmask directly into
-                # deferred_scheduler_output.grammar_bitmask in-place; there is
-                # no return value to capture here (contrast with the non-TT path
-                # below, which passes the bitmask explicitly to sample_tokens).
-                self.scheduler.get_grammar_bitmask(deferred_scheduler_output)
-                exec_future = cast(
-                    Future[ModelRunnerOutput],
-                    self.model_executor.execute_model(
-                        deferred_scheduler_output, non_block=True
-                    ),
-                )
-                batch_queue.appendleft(
-                    (
-                        cast(Future[ModelRunnerOutput], exec_future),
-                        deferred_scheduler_output,
-                    )
-                )
-            else:
-                grammar_output = self.scheduler.get_grammar_bitmask(
-                    deferred_scheduler_output
-                )
-                future = self.model_executor.sample_tokens(
-                    grammar_output, non_block=True
-                )
-                batch_queue.appendleft((future, deferred_scheduler_output))
+            future = cast(
+                Future[ModelRunnerOutput],
+                self.model_executor.submit_deferred_scheduled_batch(
+                    deferred_scheduler_output,
+                    self.scheduler.get_grammar_bitmask,
+                    non_block=True,
+                ),
+            )
+            batch_queue.appendleft((future, deferred_scheduler_output))
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -432,6 +432,7 @@ class EngineCore:
                     # Most backends sample after execute_model(); TT keeps that
                     # work inside execute_model(), so this branch is skipped there.
                     model_output = self.model_executor.sample_tokens(grammar_output)
+                assert model_output is not None
 
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -678,10 +678,12 @@ class EngineCore:
         self._debug_viztracer = None
         self._debug_viztracer_started = False
         self._debug_viztracer_capture_active = False
+        self._debug_viztracer_clear_on_activate = False
+        self._debug_viztracer_finished = False
         # VizTracer env vars:
         # - `VLLM_VIZTRACE_MODE`: enables tracing and selects when capture starts.
-        #   Supported values are `first_request` and `first_dp_decode_submit`.
-        #   Unset or empty disables VizTracer.
+        #   Supported values are `engine_init`, `first_request`, and
+        #   `first_dp_decode_submit`. Unset or empty disables VizTracer.
         # - `VLLM_VIZTRACE_STEPS`: number of engine steps to capture after
         #   tracing becomes active. Default `200`, minimum `1`.
         # - `VLLM_VIZTRACE_ENTRIES`: VizTracer buffer size (`tracer_entries`).
@@ -696,7 +698,7 @@ class EngineCore:
         # - `VLLM_VIZTRACE_OUTPUT_DIR`: directory where the trace JSON is
         #   written. Default is the current working directory.
         # Example: set all VizTracer env vars.
-        #   export VLLM_VIZTRACE_MODE=first_dp_decode_submit
+        #   export VLLM_VIZTRACE_MODE=engine_init
         #   export VLLM_VIZTRACE_STEPS=8000
         #   export VLLM_VIZTRACE_ENTRIES=4000000
         #   export VLLM_VIZTRACE_MIN_DURATION_US=0
@@ -713,10 +715,11 @@ class EngineCore:
         #   unset VLLM_VIZTRACE_OUTPUT_DIR
         self._debug_viztracer_mode = os.environ.get("VLLM_VIZTRACE_MODE", "")
         self._debug_viztracer_enabled = bool(self._debug_viztracer_mode)
-        self._debug_viztracer_steps_remaining = max(
+        self._debug_viztracer_step_budget = max(
             int(os.environ.get("VLLM_VIZTRACE_STEPS", "200")),
             1,
         )
+        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
         self._debug_viztracer_entries = max(
             int(os.environ.get("VLLM_VIZTRACE_ENTRIES", "2000000")),
             1000,
@@ -749,11 +752,25 @@ class EngineCore:
             str(path) for path in include_files if path.exists()
         ]
 
-        if self._debug_viztracer_mode == "first_dp_decode_submit":
-            self._start_debug_viztracer(armed_only=True)
+        if self._debug_viztracer_mode == "engine_init":
+            self._start_debug_viztracer(armed_only=False)
+        elif self._debug_viztracer_mode in {
+            "first_request",
+            "first_dp_decode_submit",
+        }:
+            # Start tracing before the executor constructs worker threads, then
+            # clear bootstrap data when the requested trigger fires so the saved
+            # report focuses on the interesting window.
+            self._start_debug_viztracer(armed_only=True, clear_on_activate=True)
 
-    def _start_debug_viztracer(self, armed_only: bool) -> None:
-        if not self._debug_viztracer_enabled or self._debug_viztracer_started:
+    def _start_debug_viztracer(
+        self, armed_only: bool, clear_on_activate: bool = False
+    ) -> None:
+        if (
+            not self._debug_viztracer_enabled
+            or self._debug_viztracer_started
+            or self._debug_viztracer_finished
+        ):
             return
 
         try:
@@ -777,7 +794,11 @@ class EngineCore:
         filename_stem = (
             "viztrace-first-dp-decode-submit"
             if self._debug_viztracer_mode == "first_dp_decode_submit"
-            else "viztrace-first-request"
+            else (
+                "viztrace-engine-init"
+                if self._debug_viztracer_mode == "engine_init"
+                else "viztrace-first-request"
+            )
         )
         output_path = os.path.join(
             self._debug_viztracer_output_dir,
@@ -799,6 +820,8 @@ class EngineCore:
         self._debug_viztracer = tracer
         self._debug_viztracer_started = True
         self._debug_viztracer_capture_active = not armed_only
+        self._debug_viztracer_clear_on_activate = clear_on_activate
+        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
         logger.info(
             "Started VizTracer: mode=%s output=%s steps=%d entries=%d include_filter=%s armed_only=%s",
             self._debug_viztracer_mode,
@@ -809,21 +832,51 @@ class EngineCore:
             armed_only,
         )
 
+    def _activate_debug_viztracer(self, trigger: str) -> None:
+        if (
+            not self._debug_viztracer_started
+            or self._debug_viztracer is None
+            or self._debug_viztracer_capture_active
+        ):
+            return
+
+        if self._debug_viztracer_clear_on_activate:
+            self._debug_viztracer.clear()
+            logger.info(
+                "Cleared VizTracer bootstrap data on activation: mode=%s trigger=%s",
+                self._debug_viztracer_mode,
+                trigger,
+            )
+
+        self._debug_viztracer_capture_active = True
+        self._debug_viztracer_steps_remaining = self._debug_viztracer_step_budget
+        logger.info(
+            "Activated VizTracer capture: mode=%s trigger=%s steps=%d",
+            self._debug_viztracer_mode,
+            trigger,
+            self._debug_viztracer_steps_remaining,
+        )
+
     def _maybe_start_debug_viztracer(
         self, request_type: EngineCoreRequestType
     ) -> None:
         if (
             self._debug_viztracer_mode != "first_request"
+            or self._debug_viztracer_finished
             or request_type != EngineCoreRequestType.ADD
         ):
             return
-        self._start_debug_viztracer(armed_only=False)
+        if not self._debug_viztracer_started:
+            self._start_debug_viztracer(armed_only=False)
+            return
+        self._activate_debug_viztracer("first_request")
 
     def _maybe_trigger_debug_viztracer_on_dp_decode_submit(
         self, is_decode: bool, local_dp_rank: int
     ) -> None:
         if (
             self._debug_viztracer_mode != "first_dp_decode_submit"
+            or self._debug_viztracer_finished
             or not self._debug_viztracer_started
             or self._debug_viztracer_capture_active
             or not is_decode
@@ -831,7 +884,7 @@ class EngineCore:
         ):
             return
         assert self._debug_viztracer is not None
-        self._debug_viztracer_capture_active = True
+        self._activate_debug_viztracer("first_dp_decode_submit")
         self._debug_viztracer.log_instant(
             "VLLM_VIZTRACE_TRIGGER:first_dp_decode_submit",
             args={
@@ -865,6 +918,9 @@ class EngineCore:
         tracer = self._debug_viztracer
         self._debug_viztracer = None
         self._debug_viztracer_started = False
+        self._debug_viztracer_capture_active = False
+        self._debug_viztracer_clear_on_activate = False
+        self._debug_viztracer_finished = True
         try:
             tracer.stop()
             tracer.save()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-import pickle
 import queue
 import signal
 import threading
@@ -20,6 +19,7 @@ import torch
 import torch.distributed as dist
 import zmq
 
+import vllm.v1.engine.tt_dp_gather as tt_dp_gather
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
@@ -64,7 +64,7 @@ from vllm.v1.engine.utils import (
 from vllm.v1.executor import Executor
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import SchedulerStats
-from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
 from vllm.v1.structured_output import StructuredOutputManager
@@ -97,6 +97,26 @@ class EngineCore:
     requires_gather: bool
     dp_decode_streak: int
     dp_max_consec_decodes: int
+    _dp_gather_forced_mode: int
+
+    def _dp_any_rank_has_scheduler_requests(self) -> bool:
+        raise NotImplementedError
+
+    def _dp_negotiate_forced_mode(self) -> int:
+        raise NotImplementedError
+
+    def _dp_apply_forced_mode(self, forced_mode: int | None) -> None:
+        raise NotImplementedError
+
+    def _dp_update_decode_streak(
+        self, scheduler_output: SchedulerOutput | None, forced_mode: int | None
+    ) -> None:
+        raise NotImplementedError
+
+    def _execute_model_dp_gather(
+        self, scheduler_output: SchedulerOutput | None
+    ) -> ModelRunnerOutput:
+        raise NotImplementedError
 
     def __init__(
         self,
@@ -359,56 +379,14 @@ class EngineCore:
         was executed.
         """
 
-        # For gathered DP execution, agree on mode BEFORE any early returns,
-        # and only apply it if we will schedule locally.
         forced_mode: int | None = None
         requires_gather = hasattr(self, "requires_gather") and self.requires_gather
         if requires_gather:
-            assert hasattr(self, "dp_max_consec_decodes")
-            assert hasattr(self, "dp_decode_streak")
-            assert hasattr(self, "dlog")
-            assert hasattr(self, "dp_group")
-            # Check if any rank has work before doing intent all_reduce.
-            local_has_requests = 1 if self.scheduler.has_requests() else 0
-            has_requests_t = torch.tensor([local_has_requests], dtype=torch.int32)
-            try:
-                dist.all_reduce(
-                    has_requests_t, op=dist.ReduceOp.SUM, group=self.dp_group
-                )
-            except RuntimeError as e:
-                # During shutdown, peers may close connections mid-collective.
-                # Exit gracefully to allow coordinated shutdown.
-                if "Connection closed by peer" in str(e):
-                    logger.debug(
-                        "Collective failed during shutdown, exiting gracefully"
-                    )
-                    raise SystemExit() from e
-                raise
-            if int(has_requests_t.item()) == 0:
+            # For gathered DP execution, agree on mode before any early returns.
+            if not self._dp_any_rank_has_scheduler_requests():
                 # No rank has work, return early without scheduling.
                 return {}, False
-
-            # Max-consecutive-decoding guard: if there are waiting prefills
-            # and we decoded for dp_max_consec_decodes steps consecutively,
-            # force one prefill step. Otherwise, prefer decode while running.
-            # Can't automatically set intent to be prefill if there are any
-            # waiting requests since we could get stuck in a loop where intent
-            # is prefill but it doesn't get scheduled.
-            has_running = bool(getattr(self.scheduler, "running", []))
-            has_waiting = bool(getattr(self.scheduler, "waiting", False))
-            dp_decode_streak = cast(int, self.dp_decode_streak)
-            dp_max_consec_decodes = cast(int, self.dp_max_consec_decodes)
-            must_prefill = has_waiting and dp_decode_streak >= dp_max_consec_decodes
-            local_prefill_intent = (
-                1 if (has_waiting and (must_prefill or not has_running)) else 0
-            )
-            intent_tensor = torch.tensor([local_prefill_intent], dtype=torch.int32)
-            self.dlog("before_intent_allreduce intent_tensor=%s", intent_tensor)
-            dist.all_reduce(intent_tensor, op=dist.ReduceOp.MAX, group=self.dp_group)
-            forced_mode = int(intent_tensor.item())  # 1=prefill, 0=decode
-            self.dlog("after_intent_allreduce forced_mode=%d", forced_mode)
-            # Record forced_mode so it can be used by _execute_model_dp_gather.
-            self._dp_gather_forced_mode = forced_mode
+            forced_mode = self._dp_negotiate_forced_mode()
 
         # Check for any requests remaining in the scheduler - unfinished,
         # or finished and not yet removed from the batch.
@@ -419,43 +397,40 @@ class EngineCore:
                 _ = self._execute_model_dp_gather(None)
             return {}, False
 
-        # Apply the forced mode only for ranks that will call schedule().
         if requires_gather and forced_mode is not None:
-            set_mode = getattr(self.scheduler, "set_forced_mode", None)
-            if callable(set_mode):
-                set_mode(forced_mode)
+            self._dp_apply_forced_mode(forced_mode)
 
         scheduler_output = self.scheduler.schedule()
 
         if requires_gather and forced_mode is not None:
-            # Reset forced mode after scheduling to leave no residual state.
-            set_mode = getattr(self.scheduler, "set_forced_mode", None)
-            if callable(set_mode):
-                set_mode(None)
-
-            # Update decode streak: increment only when decode scheduled tokens;
-            # reset to 0 when prefill runs OR when nothing was scheduled.
-            if scheduler_output.total_num_scheduled_tokens > 0 and forced_mode == 0:
-                self.dp_decode_streak = dp_decode_streak + 1
-            else:
-                self.dp_decode_streak = 0
+            self._dp_apply_forced_mode(None)
+            self._dp_update_decode_streak(scheduler_output, forced_mode)
 
         is_tt = current_platform.is_tt()
         grammar_output = None
 
         if requires_gather:
-            # Different execution path for gathered batch DP.
+            # Gathered-DP routes through the TT helper, which coordinates the
+            # cross-rank gather/execute/scatter sequence before local results
+            # can be applied.
             if not is_tt:
+                # Non-TT backends keep the standard vLLM split: grammar bitmask
+                # first, then model execution/sampling.
+                # Currently unreachable outside TT, kept for future.
                 grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
             assert hasattr(self, "_execute_model_dp_gather")
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
+            # Regular execution can launch the model first and overlap grammar
+            # work while the executor is running.
             future = self.model_executor.execute_model(scheduler_output, non_block=True)
             if not is_tt:
                 grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
             with self.log_error_detail(scheduler_output):
                 model_output = future.result()
                 if model_output is None:
+                    # Most backends sample after execute_model(); TT keeps that
+                    # work inside execute_model(), so this branch is skipped there.
                     model_output = self.model_executor.sample_tokens(grammar_output)
 
         engine_core_outputs = self.scheduler.update_from_output(
@@ -1534,460 +1509,37 @@ class DPEngineCoreProc(EngineCoreProc):
             )
 
     def _completed_dp_gather_future(self) -> Future[tuple[torch.Tensor, list]]:
-        parallel_config = self.vllm_config.parallel_config
-        world = parallel_config.data_parallel_size
-        batch_size = self.vllm_config.scheduler_config.max_num_seqs
-        future: Future[tuple[torch.Tensor, list]] = Future()
-        future.set_result(
-            (torch.zeros((world, batch_size, 1), dtype=torch.int32), [None] * world)
-        )
-        return future
+        return tt_dp_gather._completed_dp_gather_future(self)
 
     def _dp_any_rank_has_scheduler_requests(self) -> bool:
-        local_has_requests = 1 if self.scheduler.has_requests() else 0
-        has_requests_t = torch.tensor([local_has_requests], dtype=torch.int32)
-        try:
-            dist.all_reduce(has_requests_t, op=dist.ReduceOp.SUM, group=self.dp_group)
-        except RuntimeError as e:
-            # During shutdown, peers may close connections mid-collective.
-            # Exit gracefully to allow coordinated shutdown.
-            if "Connection closed by peer" in str(e):
-                logger.debug("Collective failed during shutdown, exiting gracefully")
-                raise SystemExit() from e
-            raise
-        return int(has_requests_t.item()) > 0
+        return tt_dp_gather._dp_any_rank_has_scheduler_requests(self)
 
     def _dp_negotiate_forced_mode(self) -> int:
-        # Max-consecutive-decoding guard: if there are waiting prefills
-        # and we decoded for dp_max_consec_decodes steps consecutively,
-        # force one prefill step. Otherwise, prefer decode while running.
-        # Can't automatically set intent to be prefill if there are any
-        # waiting requests since we could get stuck in a loop where intent
-        # is prefill but it doesn't get scheduled.
-        has_running = bool(getattr(self.scheduler, "running", []))
-        has_waiting = bool(getattr(self.scheduler, "waiting", False))
-        must_prefill = (
-            has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
-        )
-        local_prefill_intent = (
-            1 if (has_waiting and (must_prefill or not has_running)) else 0
-        )
-        intent_tensor = torch.tensor([local_prefill_intent], dtype=torch.int32)
-        self.dlog("before_intent_allreduce intent_tensor=%s", intent_tensor)
-        dist.all_reduce(intent_tensor, op=dist.ReduceOp.MAX, group=self.dp_group)
-        forced_mode = int(intent_tensor.item())  # 1=prefill, 0=decode
-        self.dlog("after_intent_allreduce forced_mode=%d", forced_mode)
-        # Record forced_mode so it can be used by DP gather submission.
-        self._dp_gather_forced_mode = forced_mode
-        return forced_mode
+        return tt_dp_gather._dp_negotiate_forced_mode(self)
 
     def _dp_apply_forced_mode(self, forced_mode: int | None) -> None:
-        set_mode = getattr(self.scheduler, "set_forced_mode", None)
-        if callable(set_mode):
-            set_mode(forced_mode)
+        tt_dp_gather._dp_apply_forced_mode(self, forced_mode)
 
     def _dp_update_decode_streak(
         self, scheduler_output: SchedulerOutput | None, forced_mode: int | None
     ) -> None:
-        if scheduler_output is None or forced_mode is None:
-            return
-        # This is intentionally stale by at most one step in async DP mode:
-        # forced-mode negotiation for step N+1 runs before update_from_output(N).
-        if scheduler_output.total_num_scheduled_tokens > 0 and forced_mode == 0:
-            self.dp_decode_streak += 1
-        else:
-            self.dp_decode_streak = 0
+        tt_dp_gather._dp_update_decode_streak(self, scheduler_output, forced_mode)
 
     def step_dp_with_batch_queue(
         self,
     ) -> tuple[dict[int, EngineCoreOutputs] | None, bool]:
-        assert self.batch_queue is not None
-
-        global_has_requests = self._dp_any_rank_has_scheduler_requests()
-        in_flight = self._dp_in_flight
-        if not global_has_requests and in_flight is None:
-            return {}, False
-
-        forced_mode: int | None = None
-        scheduler_output: SchedulerOutput | None = None
-        model_executed = False
-        if global_has_requests:
-            forced_mode = self._dp_negotiate_forced_mode()
-            if self.scheduler.has_requests():
-                self._dp_apply_forced_mode(forced_mode)
-                scheduler_output = self.scheduler.schedule()
-                self._dp_apply_forced_mode(None)
-                self._dp_update_decode_streak(scheduler_output, forced_mode)
-                if not self.is_ec_producer:
-                    model_executed = scheduler_output.total_num_scheduled_tokens > 0
-
-        prev_model_output: ModelRunnerOutput | None = None
-        prev_scheduler_output: SchedulerOutput | None = None
-        engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
-        if in_flight is not None:
-            prev_model_output = self.dp_gather_finalize(in_flight)
-            prev_scheduler_output = in_flight.scheduler_output
-            self._dp_in_flight = None
-
-        if (
-            scheduler_output is not None
-            and scheduler_output.pending_structured_output_tokens
-        ):
-            if prev_model_output is not None and prev_scheduler_output is not None:
-                engine_core_outputs = self.scheduler.update_from_output(
-                    prev_scheduler_output, prev_model_output
-                )
-                prev_model_output = None
-                prev_scheduler_output = None
-            self.scheduler.get_grammar_bitmask(scheduler_output)
-
-        if global_has_requests:
-            self._dp_in_flight = self.dp_gather_submit(scheduler_output)
-
-        if prev_model_output is not None and prev_scheduler_output is not None:
-            engine_core_outputs = self.scheduler.update_from_output(
-                prev_scheduler_output, prev_model_output
-            )
-            return engine_core_outputs, model_executed
-
-        if not global_has_requests:
-            return engine_core_outputs, False
-
-        return engine_core_outputs, model_executed
+        return tt_dp_gather.step_dp_with_batch_queue(self)
 
     def dp_gather_submit(
         self, scheduler_output: SchedulerOutput | None
     ) -> DPGatherHandle:
-        """Prepare and submit one gathered-DP execution step.
-
-        Collects per-rank DP inputs, negotiates the merged execution shape, and
-        returns a `DPGatherHandle` consumed by `dp_gather_finalize()` on the
-        next step.
-
-        This path is mixed-mode rather than purely sync or async:
-        - it is always synchronous for the host-side gather/orchestration work
-        - for prefill, the worker executes synchronously even though we pass
-          `non_block=True` through the executor boundary
-        - for decode, the worker uses the async decode submit path and returns
-          a future-like handle that is completed later in `dp_gather_finalize()`
-        """
-        parallel_config = self.vllm_config.parallel_config
-        group = self.dp_group
-        rank = self.dp_rank
-        local_rank = parallel_config.data_parallel_rank_local
-        world = parallel_config.data_parallel_size
-
-        local_has_requests = scheduler_output is not None
-        if scheduler_output is not None:
-            self.dlog(
-                "enter_gather tokens=%d", scheduler_output.total_num_scheduled_tokens
-            )
-
-        # Detect decode vs prefill using forced_mode negotiated earlier.
-        # 0=decode, 1=prefill.
-        assert hasattr(self, "_dp_gather_forced_mode"), "forced_mode not set"
-        is_decode = self._dp_gather_forced_mode == 0
-
-        # Build local dp model input (or None).
-        all_local_inputs = self.model_executor.collective_rpc(
-            "build_dp_model_input", args=(scheduler_output,)
-        )[0]  # type: ignore[var-annotated]
-        (
-            local_input,
-            local_max_blocks,
-            local_has_structured,
-            local_has_penalties,
-            local_reset_batch,
-            local_can_sample_device,
-            local_needs_logprobs,
-            req_ids,
-            req_id_to_index,
-        ) = all_local_inputs
-        max_blocks_decode = None  # Only used for decode.
-        any_structured_inputs = False  # Only used for decode.
-        any_needs_logprobs = False
-
-        gathered_inputs: Any = None
-        if is_decode:
-            # Gather max_blocks, has_structured, has_penalties, reset_batch,
-            # cannot_sample_on_device, and needs_logprobs from all ranks.
-            input_info_t = torch.tensor(
-                [
-                    local_max_blocks,
-                    local_has_structured,
-                    local_has_penalties,
-                    local_reset_batch,
-                    # Invert so we can use MAX reduction and still compute
-                    # "all ranks can sample on device".
-                    1 - local_can_sample_device,
-                    local_needs_logprobs,
-                ],
-                dtype=torch.int32,
-            )
-            dist.all_reduce(input_info_t, op=dist.ReduceOp.MAX, group=group)
-            max_blocks_decode = int(input_info_t[0].item())
-            any_structured_inputs = input_info_t[1].item() > 0
-            any_penalties_inputs = input_info_t[2].item() > 0
-            any_reset_batch = input_info_t[3].item() > 0
-            all_sample_device = input_info_t[4].item() == 0
-            any_needs_logprobs = input_info_t[5].item() > 0
-
-            # Build tensorized gather input for decode.
-            decode_inputs: dict[str, Any] = self.model_executor.collective_rpc(
-                "build_dp_decode_gather_input",
-                args=(
-                    local_input,
-                    max_blocks_decode,
-                    any_structured_inputs,
-                    any_penalties_inputs,
-                ),
-            )[0]
-
-            # Decode: use gather with fixed-shape inputs.
-            int_local = decode_inputs["int_inputs"]  # 1D int32
-            float_local = decode_inputs["float_inputs"]  # 1D float32
-
-            # Only rank 0 needs buffers for the gather operation.
-            # Pre-allocate stacked tensors and create list views for gather.
-            stacked_int = None
-            stacked_float = None
-            gather_list_int = None
-            gather_list_float = None
-            if rank == 0:
-                stacked_int = torch.empty(
-                    (world, *int_local.shape), dtype=int_local.dtype
-                )
-                stacked_float = torch.empty(
-                    (world, *float_local.shape), dtype=float_local.dtype
-                )
-                gather_list_int = [stacked_int[i] for i in range(world)]
-                gather_list_float = [stacked_float[i] for i in range(world)]
-
-            # Gather to rank 0, then send to other device ranks (local rank 0).
-            # Note: if num device ranks == num world ranks, then this could be
-            # all_gather but we usually have device ranks << world.
-            dist.gather(int_local, gather_list_int, dst=0, group=group)
-            dist.gather(float_local, gather_list_float, dst=0, group=group)
-            if len(self.dp_device_ranks) > 1:
-                if rank == 0:
-                    # Rank 0 sends stacked tensors to other device ranks.
-                    for dst in self.dp_device_ranks[1:]:
-                        dist.send(stacked_int, dst=dst, group=group)
-                        dist.send(stacked_float, dst=dst, group=group)
-                elif local_rank == 0:  # other device ranks
-                    # Other device ranks receive from rank 0.
-                    stacked_int = torch.empty(
-                        (world, *int_local.shape), dtype=int_local.dtype
-                    )
-                    stacked_float = torch.empty(
-                        (world, *float_local.shape), dtype=float_local.dtype
-                    )
-                    dist.recv(stacked_int, src=0, group=group)
-                    dist.recv(stacked_float, src=0, group=group)
-
-            # Gather prompt/output tokens only when they are needed (penalties)
-            # and (if sampling on host or the decode batch layout changed).
-            gathered_tokens_inputs = None
-            if any_penalties_inputs and (not all_sample_device or any_reset_batch):
-                # Gather token dicts (containing tensors) to rank 0
-                if rank == 0:
-                    gathered_tokens_inputs = [None for _ in range(world)]
-                local_tokens_inputs = decode_inputs["sampling_tokens_inputs"]
-                dist.gather_object(
-                    local_tokens_inputs, gathered_tokens_inputs, dst=0, group=group
-                )
-
-                if len(self.dp_device_ranks) > 1:
-                    if rank == 0:
-                        # Rank 0 sends gathered tokens to other device ranks
-                        pickled_tokens = pickle.dumps(gathered_tokens_inputs)
-                        tokens_tensor = torch.frombuffer(
-                            pickled_tokens, dtype=torch.uint8
-                        )
-                        tokens_size = torch.tensor(
-                            [tokens_tensor.numel()], dtype=torch.long
-                        )
-                        for dst in self.dp_device_ranks[1:]:
-                            dist.send(tokens_size, dst=dst, group=group)
-                            dist.send(tokens_tensor, dst=dst, group=group)
-                    elif local_rank == 0:  # other device ranks
-                        # Other device ranks receive from rank 0
-                        tokens_size = torch.zeros(1, dtype=torch.long)
-                        dist.recv(tokens_size, src=0, group=group)
-                        tokens_tensor = torch.empty(
-                            tokens_size.item(), dtype=torch.uint8
-                        )
-                        dist.recv(tokens_tensor, src=0, group=group)
-                        gathered_tokens_inputs = pickle.loads(
-                            tokens_tensor.numpy().tobytes()
-                        )
-
-            # Gather host-only sampling params (logprobs, allowed_token_ids,
-            # bad_words, logit_bias, min_p, min_tokens) when sampling on host.
-            gathered_host_only_sample_params = None
-            if not all_sample_device:
-                if rank == 0:
-                    gathered_host_only_sample_params = [None for _ in range(world)]
-                local_host_only_sample_params = decode_inputs.get(
-                    "host_only_sample_params"
-                )
-                dist.gather_object(
-                    local_host_only_sample_params,
-                    gathered_host_only_sample_params,
-                    dst=0,
-                    group=group,
-                )
-
-                if len(self.dp_device_ranks) > 1:
-                    if rank == 0:
-                        # Rank 0 sends gathered host_only params to device ranks
-                        pickled_host_only = pickle.dumps(
-                            gathered_host_only_sample_params
-                        )
-                        host_only_tensor = torch.frombuffer(
-                            pickled_host_only, dtype=torch.uint8
-                        )
-                        host_only_size = torch.tensor(
-                            [host_only_tensor.numel()], dtype=torch.long
-                        )
-                        for dst in self.dp_device_ranks[1:]:
-                            dist.send(host_only_size, dst=dst, group=group)
-                            dist.send(host_only_tensor, dst=dst, group=group)
-                    elif local_rank == 0:  # other device ranks
-                        # Other device ranks receive from rank 0
-                        host_only_size = torch.zeros(1, dtype=torch.long)
-                        dist.recv(host_only_size, src=0, group=group)
-                        host_only_tensor = torch.empty(
-                            host_only_size.item(), dtype=torch.uint8
-                        )
-                        dist.recv(host_only_tensor, src=0, group=group)
-                        gathered_host_only_sample_params = pickle.loads(
-                            host_only_tensor.numpy().tobytes()
-                        )
-
-            if local_rank == 0:
-                gathered_inputs = {
-                    "int_inputs": stacked_int,
-                    "float_inputs": stacked_float,
-                    "sampling_tokens_inputs": gathered_tokens_inputs,
-                    "host_only_sample_params": gathered_host_only_sample_params,
-                    "reset_batch": any_reset_batch,
-                    "all_sample_device": all_sample_device,
-                }
-
-        else:
-            # Prefill: use gather_object with variable sized inputs.
-            gathered_inputs = None
-            if rank == 0:
-                gathered_inputs = [None for _ in range(world)]  # type: ignore
-
-            # All_reduce to determine if any rank needs logprobs (for prefill).
-            logprobs_flag_t = torch.tensor([local_needs_logprobs], dtype=torch.int32)
-            dist.all_reduce(logprobs_flag_t, op=dist.ReduceOp.MAX, group=group)
-            any_needs_logprobs = logprobs_flag_t[0].item() > 0
-
-            # Gather to rank 0, then send to other device ranks (local rank 0).
-            # Note: if num device ranks == num world ranks, then this could be
-            # all_gather_object but we usually have device ranks << world.
-            dist.gather_object(local_input, gathered_inputs, dst=0, group=group)
-            if len(self.dp_device_ranks) > 1:
-                if rank == 0:
-                    # Rank 0 sends gathered list to other device ranks only.
-                    pickled_data = pickle.dumps(gathered_inputs)
-                    object_tensor = torch.frombuffer(pickled_data, dtype=torch.uint8)
-                    size_tensor = torch.tensor(
-                        [object_tensor.numel()], dtype=torch.long
-                    )
-                    for dst in self.dp_device_ranks[1:]:
-                        dist.send(size_tensor, dst=dst, group=group)
-                        dist.send(object_tensor, dst=dst, group=group)
-                elif local_rank == 0:  # other device ranks
-                    # Other device ranks receive from rank 0.
-                    size_tensor = torch.zeros(1, dtype=torch.long)
-                    dist.recv(size_tensor, src=0, group=group)
-                    object_tensor = torch.empty(size_tensor.item(), dtype=torch.uint8)
-                    dist.recv(object_tensor, src=0, group=group)
-                    gathered_inputs = pickle.loads(object_tensor.numpy().tobytes())
-        self.dlog("after_inputs_gather")
-
-        should_submit = is_decode or (
-            isinstance(gathered_inputs, list)
-            and any(x is not None for x in gathered_inputs)
-        )
-        if should_submit:
-            future = cast(
-                Future[tuple[torch.Tensor, list]],
-                self.model_executor.concat_and_execute_dp(
-                    gathered_inputs,
-                    is_decode,
-                    max_blocks_decode,
-                    any_structured_inputs,
-                    non_block=True,
-                ),
-            )
-        else:
-            future = self._completed_dp_gather_future()
-
-        return DPGatherHandle(
-            future=future,
-            scheduler_output=scheduler_output,
-            local_has_requests=local_has_requests,
-            is_decode=is_decode,
-            any_needs_logprobs=any_needs_logprobs,
-            req_ids=req_ids,
-            req_id_to_index=req_id_to_index,
-        )
+        return tt_dp_gather.dp_gather_submit(self, scheduler_output)
 
     def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
-        parallel_config = self.vllm_config.parallel_config
-        group = self.dp_group
-        rank = self.dp_rank
-        world = parallel_config.data_parallel_size
-        logprobs_per_dp: list = [None] * world
+        return tt_dp_gather.dp_gather_finalize(self, handle)
 
-        result = handle.future.result()  # Waiting for step output to be ready
-        assert isinstance(result, tuple) and len(result) == 2
-        send_tensor, logprobs_per_dp = result
-        assert isinstance(send_tensor, torch.Tensor)
-
-        # Global rank 0 scatters results to all ranks
-        my_ids = torch.empty_like(send_tensor[0])  # Shape (B, 1)
-        scatter_list = None
-        if rank == 0:
-            # Prepare scatter list: split send_tensor along first dimension
-            scatter_list = [send_tensor[i] for i in range(world)]
-        dist.scatter(my_ids, scatter_list, src=0, group=group)
-        self.dlog("after_results_gather my_ids_shape=%s", tuple(my_ids.shape))
-
-        # Scatter logprobs only if any rank needs them
-        # (determined in all_reduce).
-        my_logprobs_val = None
-        if handle.any_needs_logprobs:
-            my_logprobs: list = [None]
-            logprobs_scatter_list = logprobs_per_dp if rank == 0 else None
-            dist.scatter_object_list(
-                my_logprobs, logprobs_scatter_list, src=0, group=group
-            )
-            my_logprobs_val = my_logprobs[0]
-
-        # If rank had scheduled tokens, apply results locally and return output
-        if handle.local_has_requests:
-            output: ModelRunnerOutput = self.model_executor.collective_rpc(
-                "apply_dp_execution_result",
-                args=(
-                    my_ids,
-                    my_logprobs_val,
-                    handle.req_ids,
-                    handle.req_id_to_index,
-                ),
-            )[0]
-            return output
-        else:
-            return EMPTY_MODEL_RUNNER_OUTPUT
-
-    def _execute_model_dp_gather(self, scheduler_output: SchedulerOutput):
-        handle = self.dp_gather_submit(scheduler_output)
-        return self.dp_gather_finalize(handle)
+    def _execute_model_dp_gather(self, scheduler_output: SchedulerOutput | None):
+        return tt_dp_gather._execute_model_dp_gather(self, scheduler_output)
 
 
 class DPEngineCoreActor(DPEngineCoreProc):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -429,8 +429,21 @@ class EngineCore:
             assert hasattr(self, "_execute_model_dp_gather")
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
-            future = self.model_executor.execute_model(scheduler_output, non_block=True)
             grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+            if current_platform.is_tt():
+                # TT consumes grammar constraints inside execute_model
+                # (worker-side), so materialize them on scheduler_output before
+                # submission.
+                if grammar_output is not None:
+                    scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
+                else:
+                    scheduler_output.structured_output_request_ids = None
+                    scheduler_output.grammar_bitmask = None
+
+            future = self.model_executor.execute_model(scheduler_output, non_block=True)
             with self.log_error_detail(scheduler_output):
                 model_output = future.result()
                 if model_output is None:
@@ -478,22 +491,52 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
+        exec_future: Future[ModelRunnerOutput] | None = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule()
-            exec_future = self.model_executor.execute_model(
-                scheduler_output, non_block=True
-            )
             if not self.is_ec_producer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
 
             if self.is_pooling_model or not model_executed:
                 # No sampling required (no requests scheduled).
+                exec_future = cast(
+                    Future[ModelRunnerOutput],
+                    self.model_executor.execute_model(scheduler_output, non_block=True),
+                )
                 future = cast(Future[ModelRunnerOutput], exec_future)
             else:
                 if not scheduler_output.pending_structured_output_tokens:
                     if current_platform.is_tt():
+                        # TT consumes grammar constraints inside execute_model
+                        # (worker-side), so materialize grammar fields on
+                        # scheduler_output before execute_model submission.
+                        grammar_output = self.scheduler.get_grammar_bitmask(
+                            scheduler_output
+                        )
+                        if grammar_output is not None:
+                            scheduler_output.structured_output_request_ids = (
+                                grammar_output.structured_output_request_ids
+                            )
+                            scheduler_output.grammar_bitmask = (
+                                grammar_output.grammar_bitmask
+                            )
+                        else:
+                            scheduler_output.structured_output_request_ids = None
+                            scheduler_output.grammar_bitmask = None
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         future = cast(Future[ModelRunnerOutput], exec_future)
                     else:
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)
                         )
@@ -504,13 +547,24 @@ class EngineCore:
                             grammar_output, non_block=True
                         )
                 else:
-                    if not current_platform.is_tt():
+                    # Structured-output grammar needs previous-step tokens.
+                    # For TT, grammar is consumed in execute_model path, so we
+                    # must defer execute_model submission itself.
+                    if current_platform.is_tt():
+                        deferred_scheduler_output = scheduler_output
+                    else:
+                        exec_future = cast(
+                            Future[ModelRunnerOutput],
+                            self.model_executor.execute_model(
+                                scheduler_output, non_block=True
+                            ),
+                        )
                         exec_future.add_done_callback(
                             self._log_err_callback(scheduler_output)
                         )
-                    # We need to defer sampling until we have processed the model output
-                    # from the prior step.
-                    deferred_scheduler_output = scheduler_output
+                        # We need to defer sampling until we have processed the
+                        # model output from the prior step.
+                        deferred_scheduler_output = scheduler_output
 
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
@@ -546,6 +600,28 @@ class EngineCore:
             # We now have the tokens needed to compute the bitmask for the
             # deferred request. Get the bitmask and call sample tokens.
             if current_platform.is_tt():
+                # For TT async path, grammar must be computed after prior output
+                # has updated request states, and before execute_model consumes
+                # scheduler_output in build_model_input.
+                grammar_output = self.scheduler.get_grammar_bitmask(
+                    deferred_scheduler_output
+                )
+                if grammar_output is not None:
+                    deferred_scheduler_output.structured_output_request_ids = (
+                        grammar_output.structured_output_request_ids
+                    )
+                    deferred_scheduler_output.grammar_bitmask = (
+                        grammar_output.grammar_bitmask
+                    )
+                else:
+                    deferred_scheduler_output.structured_output_request_ids = None
+                    deferred_scheduler_output.grammar_bitmask = None
+                exec_future = cast(
+                    Future[ModelRunnerOutput],
+                    self.model_executor.execute_model(
+                        deferred_scheduler_output, non_block=True
+                    ),
+                )
                 batch_queue.appendleft(
                     (
                         cast(Future[ModelRunnerOutput], exec_future),

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -497,21 +497,12 @@ class EngineCore:
         assert batch_queue is not None
 
         is_tt = current_platform.is_tt()
-        oldest_future_done = bool(batch_queue and batch_queue[-1][0].done())
 
-        # TT async decode completion runs host-side postprocessing on the worker
-        # async thread before the EngineCore consumes the result. Once the
-        # oldest future is done, the TT runner state has already advanced, so
-        # issuing another schedule here would build a new SchedulerOutput
-        # against stale scheduler bookkeeping and can mismatch the in-flight
-        # request set. Drain the completed output first.
-        should_schedule = not (is_tt and oldest_future_done)
         if is_tt:
             self._tt_debug(
-                "enter queue_len=%d oldest_done=%s "
+                "enter queue_len=%d "
                 "has_requests=%s running=%d waiting=%d",
                 len(batch_queue),
-                oldest_future_done,
                 self.scheduler.has_requests(),
                 len(getattr(self.scheduler, "running", [])),
                 len(getattr(self.scheduler, "waiting", [])),

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -500,6 +500,7 @@ class EngineCore:
 
         model_executed = False
         deferred_scheduler_output = None
+        future: Future[ModelRunnerOutput] | None = None
         exec_future: Future[ModelRunnerOutput] | None = None
         if self.scheduler.has_requests():
             scheduler_output = self.scheduler.schedule()
@@ -511,7 +512,7 @@ class EngineCore:
                     Future[ModelRunnerOutput],
                     self.model_executor.execute_model(scheduler_output, non_block=True),
                 )
-                future = cast(Future[ModelRunnerOutput], exec_future)
+                future = exec_future
             else:
                 future, deferred_scheduler_output = (
                     self.model_executor.submit_scheduled_batch(

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -10,8 +10,10 @@ from collections import deque
 from collections.abc import Callable, Generator
 from concurrent.futures import Future
 from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from inspect import isclass, signature
 from logging import DEBUG
+from pathlib import Path
 from typing import Any, TypeVar, cast
 
 import msgspec
@@ -77,6 +79,17 @@ HANDSHAKE_TIMEOUT_MINS = 5
 _R = TypeVar("_R")  # Return type for collective_rpc
 
 
+@dataclass
+class DPGatherHandle:
+    future: Future[tuple[torch.Tensor, list]]
+    scheduler_output: SchedulerOutput | None
+    local_has_requests: bool
+    is_decode: bool
+    any_needs_logprobs: bool
+    req_ids: list[str]
+    req_id_to_index: dict[str, int]
+
+
 class EngineCore:
     """Inner loop of vLLM's Engine."""
 
@@ -101,6 +114,7 @@ class EngineCore:
             )
 
         self.log_stats = log_stats
+        self._init_debug_viztracer()
 
         # Setup Model.
         self.model_executor = executor_class(vllm_config)
@@ -424,38 +438,19 @@ class EngineCore:
             else:
                 self.dp_decode_streak = 0
 
-        if hasattr(self, "requires_gather") and self.requires_gather:
+        is_tt = current_platform.is_tt()
+        grammar_output = None
+
+        if requires_gather:
             # Different execution path for gathered batch DP.
+            if not is_tt:
+                grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
             assert hasattr(self, "_execute_model_dp_gather")
-            grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
-            # DP gather path for TT still consumes structured constraints from
-            # scheduler_output in worker-side model input building.
-            if current_platform.is_tt():
-                if grammar_output is not None:
-                    scheduler_output.structured_output_request_ids = (
-                        grammar_output.structured_output_request_ids
-                    )
-                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
-                else:
-                    scheduler_output.structured_output_request_ids = None
-                    scheduler_output.grammar_bitmask = None
             model_output = self._execute_model_dp_gather(scheduler_output)
         else:
-            grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
-            if current_platform.is_tt():
-                # TT consumes grammar constraints inside execute_model
-                # (worker-side), so materialize them on scheduler_output before
-                # submission.
-                if grammar_output is not None:
-                    scheduler_output.structured_output_request_ids = (
-                        grammar_output.structured_output_request_ids
-                    )
-                    scheduler_output.grammar_bitmask = grammar_output.grammar_bitmask
-                else:
-                    scheduler_output.structured_output_request_ids = None
-                    scheduler_output.grammar_bitmask = None
-
             future = self.model_executor.execute_model(scheduler_output, non_block=True)
+            if not is_tt:
+                grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
             with self.log_error_detail(scheduler_output):
                 model_output = future.result()
                 if model_output is None:
@@ -519,22 +514,6 @@ class EngineCore:
             else:
                 if not scheduler_output.pending_structured_output_tokens:
                     if current_platform.is_tt():
-                        # TT consumes grammar constraints inside execute_model
-                        # (worker-side), so materialize grammar fields on
-                        # scheduler_output before execute_model submission.
-                        grammar_output = self.scheduler.get_grammar_bitmask(
-                            scheduler_output
-                        )
-                        if grammar_output is not None:
-                            scheduler_output.structured_output_request_ids = (
-                                grammar_output.structured_output_request_ids
-                            )
-                            scheduler_output.grammar_bitmask = (
-                                grammar_output.grammar_bitmask
-                            )
-                        else:
-                            scheduler_output.structured_output_request_ids = None
-                            scheduler_output.grammar_bitmask = None
                         exec_future = cast(
                             Future[ModelRunnerOutput],
                             self.model_executor.execute_model(
@@ -615,19 +594,7 @@ class EngineCore:
                 # For TT async path, grammar must be computed after prior output
                 # has updated request states, and before execute_model consumes
                 # scheduler_output in build_model_input.
-                grammar_output = self.scheduler.get_grammar_bitmask(
-                    deferred_scheduler_output
-                )
-                if grammar_output is not None:
-                    deferred_scheduler_output.structured_output_request_ids = (
-                        grammar_output.structured_output_request_ids
-                    )
-                    deferred_scheduler_output.grammar_bitmask = (
-                        grammar_output.grammar_bitmask
-                    )
-                else:
-                    deferred_scheduler_output.structured_output_request_ids = None
-                    deferred_scheduler_output.grammar_bitmask = None
+                self.scheduler.get_grammar_bitmask(deferred_scheduler_output)
                 exec_future = cast(
                     Future[ModelRunnerOutput],
                     self.model_executor.execute_model(
@@ -651,7 +618,206 @@ class EngineCore:
 
         return engine_core_outputs, model_executed
 
+    def _init_debug_viztracer(self) -> None:
+        self._debug_viztracer = None
+        self._debug_viztracer_started = False
+        self._debug_viztracer_capture_active = False
+        # VizTracer env vars:
+        # - `VLLM_VIZTRACE_MODE`: enables tracing and selects when capture starts.
+        #   Supported values are `first_request` and `first_dp_decode_submit`.
+        #   Unset or empty disables VizTracer.
+        # - `VLLM_VIZTRACE_STEPS`: number of engine steps to capture after
+        #   tracing becomes active. Default `200`, minimum `1`.
+        # - `VLLM_VIZTRACE_ENTRIES`: VizTracer buffer size (`tracer_entries`).
+        #   Default `2000000`, minimum `1000`.
+        # - `VLLM_VIZTRACE_MIN_DURATION_US`: minimum event duration passed to
+        #   VizTracer as `min_duration`. Default `0`.
+        # - `VLLM_VIZTRACE_USE_INCLUDE_FILTER`: when set to `1`, restricts the
+        #   trace to the curated `include_files` list built below. Default `0`.
+        # - `VLLM_VIZTRACE_ALL_RANKS`: when set to `1` with
+        #   `VLLM_VIZTRACE_MODE=first_dp_decode_submit`, start armed tracers on
+        #   all local DP ranks instead of only local rank 0. Default `0`.
+        # - `VLLM_VIZTRACE_OUTPUT_DIR`: directory where the trace JSON is
+        #   written. Default is the current working directory.
+        # Example: set all VizTracer env vars.
+        #   export VLLM_VIZTRACE_MODE=first_dp_decode_submit
+        #   export VLLM_VIZTRACE_STEPS=8000
+        #   export VLLM_VIZTRACE_ENTRIES=4000000
+        #   export VLLM_VIZTRACE_MIN_DURATION_US=0
+        #   export VLLM_VIZTRACE_USE_INCLUDE_FILTER=1
+        #   export VLLM_VIZTRACE_ALL_RANKS=1
+        #   export VLLM_VIZTRACE_OUTPUT_DIR=/tmp/vllm-viztraces
+        # Example: unset all VizTracer env vars.
+        #   unset VLLM_VIZTRACE_MODE
+        #   unset VLLM_VIZTRACE_STEPS
+        #   unset VLLM_VIZTRACE_ENTRIES
+        #   unset VLLM_VIZTRACE_MIN_DURATION_US
+        #   unset VLLM_VIZTRACE_USE_INCLUDE_FILTER
+        #   unset VLLM_VIZTRACE_ALL_RANKS
+        #   unset VLLM_VIZTRACE_OUTPUT_DIR
+        self._debug_viztracer_mode = os.environ.get("VLLM_VIZTRACE_MODE", "")
+        self._debug_viztracer_enabled = bool(self._debug_viztracer_mode)
+        self._debug_viztracer_steps_remaining = max(
+            int(os.environ.get("VLLM_VIZTRACE_STEPS", "200")),
+            1,
+        )
+        self._debug_viztracer_entries = max(
+            int(os.environ.get("VLLM_VIZTRACE_ENTRIES", "2000000")),
+            1000,
+        )
+        self._debug_viztracer_min_duration_us = max(
+            float(os.environ.get("VLLM_VIZTRACE_MIN_DURATION_US", "0")),
+            0.0,
+        )
+        self._debug_viztracer_use_include_filter = (
+            os.environ.get("VLLM_VIZTRACE_USE_INCLUDE_FILTER") == "1"
+        )
+        self._debug_viztracer_all_ranks = (
+            os.environ.get("VLLM_VIZTRACE_ALL_RANKS") == "1"
+        )
+        self._debug_viztracer_output_dir = os.environ.get(
+            "VLLM_VIZTRACE_OUTPUT_DIR",
+            os.getcwd(),
+        )
+
+        repo_root = Path(__file__).resolve().parents[3]
+        include_files = [
+            repo_root / "vllm/v1/engine/core.py",
+            repo_root / "vllm/v1/executor/uniproc_executor.py",
+            repo_root / "vllm/v1/worker/tt_worker.py",
+            repo_root / "vllm/v1/worker/tt_model_runner.py",
+            repo_root.parent / "tt-metal/models/demos/llama3_70b_galaxy/tt/generator.py",
+            repo_root.parent / "tt-metal/models/tt_transformers/tt/generator.py",
+        ]
+        self._debug_viztracer_include_files = [
+            str(path) for path in include_files if path.exists()
+        ]
+
+        if self._debug_viztracer_mode == "first_dp_decode_submit":
+            self._start_debug_viztracer(armed_only=True)
+
+    def _start_debug_viztracer(self, armed_only: bool) -> None:
+        if not self._debug_viztracer_enabled or self._debug_viztracer_started:
+            return
+
+        try:
+            from viztracer import VizTracer
+        except ImportError:
+            logger.warning(
+                "VizTracer debugging was requested but viztracer is not installed."
+            )
+            self._debug_viztracer_enabled = False
+            return
+
+        dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+        local_dp_rank = self.vllm_config.parallel_config.data_parallel_rank_local
+        if (
+            self._debug_viztracer_mode == "first_dp_decode_submit"
+            and not self._debug_viztracer_all_ranks
+            and local_dp_rank != 0
+        ):
+            return
+
+        filename_stem = (
+            "viztrace-first-dp-decode-submit"
+            if self._debug_viztracer_mode == "first_dp_decode_submit"
+            else "viztrace-first-request"
+        )
+        output_path = os.path.join(
+            self._debug_viztracer_output_dir,
+            f"{filename_stem}-pid{os.getpid()}-dp{dp_rank}-ldp{local_dp_rank}.json",
+        )
+        tracer_kwargs: dict[str, Any] = {
+            "output_file": output_path,
+            "tracer_entries": self._debug_viztracer_entries,
+            "pid_suffix": False,
+            "min_duration": self._debug_viztracer_min_duration_us,
+        }
+        if self._debug_viztracer_use_include_filter:
+            tracer_kwargs["include_files"] = self._debug_viztracer_include_files
+        tracer_kwargs["process_name"] = (
+            f"EngineCore_DP{dp_rank}_LDP{local_dp_rank}"
+        )
+        tracer = VizTracer(**tracer_kwargs)
+        tracer.start()
+        self._debug_viztracer = tracer
+        self._debug_viztracer_started = True
+        self._debug_viztracer_capture_active = not armed_only
+        logger.info(
+            "Started VizTracer: mode=%s output=%s steps=%d entries=%d include_filter=%s armed_only=%s",
+            self._debug_viztracer_mode,
+            output_path,
+            self._debug_viztracer_steps_remaining,
+            self._debug_viztracer_entries,
+            self._debug_viztracer_use_include_filter,
+            armed_only,
+        )
+
+    def _maybe_start_debug_viztracer(
+        self, request_type: EngineCoreRequestType
+    ) -> None:
+        if (
+            self._debug_viztracer_mode != "first_request"
+            or request_type != EngineCoreRequestType.ADD
+        ):
+            return
+        self._start_debug_viztracer(armed_only=False)
+
+    def _maybe_trigger_debug_viztracer_on_dp_decode_submit(
+        self, is_decode: bool, local_dp_rank: int
+    ) -> None:
+        if (
+            self._debug_viztracer_mode != "first_dp_decode_submit"
+            or not self._debug_viztracer_started
+            or self._debug_viztracer_capture_active
+            or not is_decode
+            or local_dp_rank != 0
+        ):
+            return
+        assert self._debug_viztracer is not None
+        self._debug_viztracer_capture_active = True
+        self._debug_viztracer.log_instant(
+            "VLLM_VIZTRACE_TRIGGER:first_dp_decode_submit",
+            args={
+                "pid": os.getpid(),
+                "dp_rank": self.vllm_config.parallel_config.data_parallel_rank,
+                "local_dp_rank": local_dp_rank,
+            },
+            scope="p",
+        )
+        logger.info(
+            "Activated VizTracer capture on first DP decode submit: pid=%d dp_rank=%s local_dp_rank=%s",
+            os.getpid(),
+            self.vllm_config.parallel_config.data_parallel_rank,
+            local_dp_rank,
+        )
+
+    def _maybe_advance_debug_viztracer(self) -> None:
+        if (
+            not self._debug_viztracer_started
+            or not self._debug_viztracer_capture_active
+        ):
+            return
+        self._debug_viztracer_steps_remaining -= 1
+        if self._debug_viztracer_steps_remaining <= 0:
+            self._stop_debug_viztracer("captured configured number of engine steps")
+
+    def _stop_debug_viztracer(self, reason: str) -> None:
+        if not self._debug_viztracer_started or self._debug_viztracer is None:
+            return
+
+        tracer = self._debug_viztracer
+        self._debug_viztracer = None
+        self._debug_viztracer_started = False
+        try:
+            tracer.stop()
+            tracer.save()
+            logger.info("Saved VizTracer trace: %s", reason)
+        except Exception:
+            logger.exception("Failed to stop/save VizTracer trace")
+
     def shutdown(self):
+        self._stop_debug_viztracer("engine shutdown")
         self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()
@@ -1066,6 +1232,7 @@ class EngineCoreProc(EngineCore):
             not self.engines_running
             and not self.scheduler.has_requests()
             and not self.batch_queue
+            and not getattr(self, "_dp_in_flight", None)
         ):
             if hasattr(self, "requires_gather") and self.requires_gather:
                 # Non-blocking input polling so idle ranks can progress
@@ -1124,6 +1291,7 @@ class EngineCoreProc(EngineCore):
             self.output_queue.put_nowait(output)
         # Post-step hook.
         self.post_step(model_executed)
+        self._maybe_advance_debug_viztracer()
 
         return model_executed
 
@@ -1131,6 +1299,7 @@ class EngineCoreProc(EngineCore):
         self, request_type: EngineCoreRequestType, request: Any
     ) -> None:
         """Dispatch request from client."""
+        self._maybe_start_debug_viztracer(request_type)
 
         if request_type == EngineCoreRequestType.ADD:
             req, request_wave = request
@@ -1379,6 +1548,10 @@ class DPEngineCoreProc(EngineCoreProc):
             client_handshake_address,
             dp_rank,
         )
+        if self.requires_gather:
+            self._dp_in_flight: DPGatherHandle | None = None
+            if self.batch_queue is not None:
+                self.step_fn = self.step_dp_with_batch_queue
 
     def _init_dp_group(self, parallel_config: ParallelConfig) -> None:
         """Initialize DP group in self.dp_group. For DP gather execution, also
@@ -1613,7 +1786,141 @@ class DPEngineCoreProc(EngineCoreProc):
                 "Distributed environment reinitialized for DP rank %s", self.dp_rank
             )
 
-    def _execute_model_dp_gather(self, scheduler_output: SchedulerOutput):
+    def _completed_dp_gather_future(self) -> Future[tuple[torch.Tensor, list]]:
+        parallel_config = self.vllm_config.parallel_config
+        world = parallel_config.data_parallel_size
+        batch_size = self.vllm_config.scheduler_config.max_num_seqs
+        future: Future[tuple[torch.Tensor, list]] = Future()
+        future.set_result(
+            (torch.zeros((world, batch_size, 1), dtype=torch.int32), [None] * world)
+        )
+        return future
+
+    def _dp_any_rank_has_scheduler_requests(self) -> bool:
+        local_has_requests = 1 if self.scheduler.has_requests() else 0
+        has_requests_t = torch.tensor([local_has_requests], dtype=torch.int32)
+        try:
+            dist.all_reduce(has_requests_t, op=dist.ReduceOp.SUM, group=self.dp_group)
+        except RuntimeError as e:
+            # During shutdown, peers may close connections mid-collective.
+            # Exit gracefully to allow coordinated shutdown.
+            if "Connection closed by peer" in str(e):
+                logger.debug(
+                    "Collective failed during shutdown, exiting gracefully"
+                )
+                raise SystemExit() from e
+            raise
+        return int(has_requests_t.item()) > 0
+
+    def _dp_negotiate_forced_mode(self) -> int:
+        # Max-consecutive-decoding guard: if there are waiting prefills
+        # and we decoded for dp_max_consec_decodes steps consecutively,
+        # force one prefill step. Otherwise, prefer decode while running.
+        # Can't automatically set intent to be prefill if there are any
+        # waiting requests since we could get stuck in a loop where intent
+        # is prefill but it doesn't get scheduled.
+        has_running = bool(getattr(self.scheduler, "running", []))
+        has_waiting = bool(getattr(self.scheduler, "waiting", False))
+        must_prefill = has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
+        local_prefill_intent = (
+            1 if (has_waiting and (must_prefill or not has_running)) else 0
+        )
+        intent_tensor = torch.tensor([local_prefill_intent], dtype=torch.int32)
+        self.dlog("before_intent_allreduce intent_tensor=%s", intent_tensor)
+        dist.all_reduce(intent_tensor, op=dist.ReduceOp.MAX, group=self.dp_group)
+        forced_mode = int(intent_tensor.item())  # 1=prefill, 0=decode
+        self.dlog("after_intent_allreduce forced_mode=%d", forced_mode)
+        # Record forced_mode so it can be used by DP gather submission.
+        self._dp_gather_forced_mode = forced_mode
+        return forced_mode
+
+    def _dp_apply_forced_mode(self, forced_mode: int | None) -> None:
+        set_mode = getattr(self.scheduler, "set_forced_mode", None)
+        if callable(set_mode):
+            set_mode(forced_mode)
+
+    def _dp_update_decode_streak(
+        self, scheduler_output: SchedulerOutput | None, forced_mode: int | None
+    ) -> None:
+        if scheduler_output is None or forced_mode is None:
+            return
+        # This is intentionally stale by at most one step in async DP mode:
+        # forced-mode negotiation for step N+1 runs before update_from_output(N).
+        if scheduler_output.total_num_scheduled_tokens > 0 and forced_mode == 0:
+            self.dp_decode_streak += 1
+        else:
+            self.dp_decode_streak = 0
+
+    def step_dp_with_batch_queue(
+        self,
+    ) -> tuple[dict[int, EngineCoreOutputs] | None, bool]:
+        assert self.batch_queue is not None
+
+        global_has_requests = self._dp_any_rank_has_scheduler_requests()
+        in_flight = self._dp_in_flight
+        if not global_has_requests and in_flight is None:
+            return {}, False
+
+        forced_mode: int | None = None
+        scheduler_output: SchedulerOutput | None = None
+        model_executed = False
+        if global_has_requests:
+            forced_mode = self._dp_negotiate_forced_mode()
+            if self.scheduler.has_requests():
+                self._dp_apply_forced_mode(forced_mode)
+                scheduler_output = self.scheduler.schedule()
+                self._dp_apply_forced_mode(None)
+                self._dp_update_decode_streak(scheduler_output, forced_mode)
+                if not self.is_ec_producer:
+                    model_executed = (
+                        scheduler_output.total_num_scheduled_tokens > 0
+                    )
+
+        prev_model_output: ModelRunnerOutput | None = None
+        prev_scheduler_output: SchedulerOutput | None = None
+        engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
+        if in_flight is not None:
+            prev_model_output = self.dp_gather_finalize(in_flight)
+            prev_scheduler_output = in_flight.scheduler_output
+            self._dp_in_flight = None
+
+        if scheduler_output is not None and scheduler_output.pending_structured_output_tokens:
+            if prev_model_output is not None and prev_scheduler_output is not None:
+                engine_core_outputs = self.scheduler.update_from_output(
+                    prev_scheduler_output, prev_model_output
+                )
+                prev_model_output = None
+                prev_scheduler_output = None
+            self.scheduler.get_grammar_bitmask(scheduler_output)
+
+        if global_has_requests:
+            self._dp_in_flight = self.dp_gather_submit(scheduler_output)
+
+        if prev_model_output is not None and prev_scheduler_output is not None:
+            engine_core_outputs = self.scheduler.update_from_output(
+                prev_scheduler_output, prev_model_output
+            )
+            return engine_core_outputs, model_executed
+
+        if not global_has_requests:
+            return engine_core_outputs, False
+
+        return engine_core_outputs, model_executed
+
+    def dp_gather_submit(self, scheduler_output: SchedulerOutput | None) -> DPGatherHandle:
+        """Prepare and submit one gathered-DP execution step.
+
+        Collects per-rank DP inputs, negotiates the merged execution shape, and
+        returns a `DPGatherHandle` consumed by `dp_gather_finalize()` on the
+        next step.
+
+        This path is mixed-mode rather than purely sync or async:
+        - it is always synchronous for the host-side gather/orchestration work
+        - for prefill, the worker executes synchronously even though we pass
+          `non_block=True` through the executor boundary
+        - for decode, the worker uses the async decode submit path and returns
+          a future-like handle that is completed later in `dp_gather_finalize()`
+        """
         parallel_config = self.vllm_config.parallel_config
         group = self.dp_group
         rank = self.dp_rank
@@ -1630,6 +1937,10 @@ class DPEngineCoreProc(EngineCoreProc):
         # 0=decode, 1=prefill.
         assert hasattr(self, "_dp_gather_forced_mode"), "forced_mode not set"
         is_decode = self._dp_gather_forced_mode == 0
+        self._maybe_trigger_debug_viztracer_on_dp_decode_submit(
+            is_decode=is_decode,
+            local_dp_rank=local_rank,
+        )
 
         # Build local dp model input (or None).
         all_local_inputs = self.model_executor.collective_rpc(
@@ -1643,11 +1954,14 @@ class DPEngineCoreProc(EngineCoreProc):
             local_reset_batch,
             local_can_sample_device,
             local_needs_logprobs,
+            req_ids,
+            req_id_to_index,
         ) = all_local_inputs
         max_blocks_decode = None  # Only used for decode.
         any_structured_inputs = False  # Only used for decode.
         any_needs_logprobs = False
 
+        gathered_inputs: Any = None
         if is_decode:
             # Gather max_blocks, has_structured, has_penalties, reset_batch,
             # cannot_sample_on_device, and needs_logprobs from all ranks.
@@ -1850,32 +2164,45 @@ class DPEngineCoreProc(EngineCoreProc):
                     gathered_inputs = pickle.loads(object_tensor.numpy().tobytes())
         self.dlog("after_inputs_gather")
 
-        # Concatenate and execute DP inputs on local DP rank 0 (device ranks).
-        logprobs_per_dp: list = [None] * world
-        if local_rank == 0 and (
-            is_decode
-            or (
-                isinstance(gathered_inputs, list)
-                and any(x is not None for x in gathered_inputs)
-            )
-        ):
-            result: tuple[torch.Tensor, list] = self.model_executor.collective_rpc(
-                "concat_and_execute_dp",
-                args=(
+        should_submit = is_decode or (
+            isinstance(gathered_inputs, list)
+            and any(x is not None for x in gathered_inputs)
+        )
+        if should_submit:
+            future = cast(
+                Future[tuple[torch.Tensor, list]],
+                self.model_executor.concat_and_execute_dp(
                     gathered_inputs,
                     is_decode,
                     max_blocks_decode,
                     any_structured_inputs,
+                    non_block=True,
                 ),
-            )[0]
-            # Result is (send_tensor, logprobs_lists_per_dp)
-            assert isinstance(result, tuple) and len(result) == 2
-            send_tensor, logprobs_per_dp = result
-            assert isinstance(send_tensor, torch.Tensor)
+            )
         else:
-            B = self.vllm_config.scheduler_config.max_num_seqs
-            # Currently only supporting 1 output token per request.
-            send_tensor = torch.zeros((world, B, 1), dtype=torch.int32)
+            future = self._completed_dp_gather_future()
+
+        return DPGatherHandle(
+            future=future,
+            scheduler_output=scheduler_output,
+            local_has_requests=local_has_requests,
+            is_decode=is_decode,
+            any_needs_logprobs=any_needs_logprobs,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
+        )
+
+    def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
+        parallel_config = self.vllm_config.parallel_config
+        group = self.dp_group
+        rank = self.dp_rank
+        world = parallel_config.data_parallel_size
+        logprobs_per_dp: list = [None] * world
+
+        result = handle.future.result()  # Waiting for step output to be ready
+        assert isinstance(result, tuple) and len(result) == 2
+        send_tensor, logprobs_per_dp = result
+        assert isinstance(send_tensor, torch.Tensor)
 
         # Global rank 0 scatters results to all ranks
         my_ids = torch.empty_like(send_tensor[0])  # Shape (B, 1)
@@ -1889,7 +2216,7 @@ class DPEngineCoreProc(EngineCoreProc):
         # Scatter logprobs only if any rank needs them
         # (determined in all_reduce).
         my_logprobs_val = None
-        if any_needs_logprobs:
+        if handle.any_needs_logprobs:
             my_logprobs: list = [None]
             logprobs_scatter_list = logprobs_per_dp if rank == 0 else None
             dist.scatter_object_list(
@@ -1898,13 +2225,23 @@ class DPEngineCoreProc(EngineCoreProc):
             my_logprobs_val = my_logprobs[0]
 
         # If rank had scheduled tokens, apply results locally and return output
-        if local_has_requests:
+        if handle.local_has_requests:
             output: ModelRunnerOutput = self.model_executor.collective_rpc(
-                "apply_dp_execution_result", args=(my_ids, my_logprobs_val)
+                "apply_dp_execution_result",
+                args=(
+                    my_ids,
+                    my_logprobs_val,
+                    handle.req_ids,
+                    handle.req_id_to_index,
+                ),
             )[0]
             return output
         else:
             return EMPTY_MODEL_RUNNER_OUTPUT
+
+    def _execute_model_dp_gather(self, scheduler_output: SchedulerOutput):
+        handle = self.dp_gather_submit(scheduler_output)
+        return self.dp_gather_finalize(handle)
 
 
 class DPEngineCoreActor(DPEngineCoreProc):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -92,6 +92,12 @@ class DPGatherHandle:
 class EngineCore:
     """Inner loop of vLLM's Engine."""
 
+    # Gathered-DP subclasses initialize these before guarded access sites use
+    # them. Declaring them here lets mypy type-check direct attribute access.
+    requires_gather: bool
+    dp_decode_streak: int
+    dp_max_consec_decodes: int
+
     def __init__(
         self,
         vllm_config: VllmConfig,

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -373,9 +373,7 @@ class EngineCore:
                 # During shutdown, peers may close connections mid-collective.
                 # Exit gracefully to allow coordinated shutdown.
                 if "Connection closed by peer" in str(e):
-                    logger.debug(
-                        "Collective failed during shutdown, exiting gracefully"
-                    )
+                    logger.debug("Collective failed during shutdown, exiting gracefully")
                     raise SystemExit() from e
                 raise
             if int(has_requests_t.item()) == 0:
@@ -390,11 +388,7 @@ class EngineCore:
             # is prefill but it doesn't get scheduled.
             has_running = bool(getattr(self.scheduler, "running", []))
             has_waiting = bool(getattr(self.scheduler, "waiting", False))
-            must_prefill = (
-                has_waiting
-                and self.dp_decode_streak  # type: ignore[has-type]
-                >= self.dp_max_consec_decodes
-            )
+            must_prefill = has_waiting and self.dp_decode_streak >= self.dp_max_consec_decodes
             local_prefill_intent = (
                 1 if (has_waiting and (must_prefill or not has_running)) else 0
             )
@@ -1683,7 +1677,10 @@ class DPEngineCoreProc(EngineCoreProc):
             prev_scheduler_output = in_flight.scheduler_output
             self._dp_in_flight = None
 
-        if scheduler_output is not None and scheduler_output.pending_structured_output_tokens:
+        if (
+            scheduler_output is not None
+            and scheduler_output.pending_structured_output_tokens
+        ):
             if prev_model_output is not None and prev_scheduler_output is not None:
                 engine_core_outputs = self.scheduler.update_from_output(
                     prev_scheduler_output, prev_model_output
@@ -1706,7 +1703,9 @@ class DPEngineCoreProc(EngineCoreProc):
 
         return engine_core_outputs, model_executed
 
-    def dp_gather_submit(self, scheduler_output: SchedulerOutput | None) -> DPGatherHandle:
+    def dp_gather_submit(
+        self, scheduler_output: SchedulerOutput | None
+    ) -> DPGatherHandle:
         """Prepare and submit one gathered-DP execution step.
 
         Collects per-rank DP inputs, negotiates the merged execution shape, and

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -408,6 +408,7 @@ class EngineCore:
 
         is_tt = current_platform.is_tt()
         grammar_output = None
+        model_output: ModelRunnerOutput | None
 
         if requires_gather:
             # Gathered-DP routes through the TT helper, which coordinates the
@@ -432,7 +433,7 @@ class EngineCore:
                     # Most backends sample after execute_model(); TT keeps that
                     # work inside execute_model(), so this branch is skipped there.
                     model_output = self.model_executor.sample_tokens(grammar_output)
-                assert model_output is not None
+        assert model_output is not None
 
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -24,6 +24,7 @@ from vllm.distributed import stateless_destroy_torch_distributed_process_group
 from vllm.envs import enable_envs_cache
 from vllm.logger import init_logger
 from vllm.logging_utils.dump_input import dump_engine_exception
+from vllm.platforms import current_platform
 from vllm.lora.request import LoRARequest
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.cache import engine_receiver_cache_from_config
@@ -121,6 +122,11 @@ class EngineCore:
 
         # Setup scheduler.
         Scheduler = vllm_config.scheduler_config.get_scheduler_cls()
+        logger.info(
+            "Scheduler class: %s, async_scheduling=%s",
+            Scheduler.__name__,
+            vllm_config.scheduler_config.async_scheduling,
+        )
 
         if len(kv_cache_config.kv_cache_groups) == 0:
             # Encoder models without KV cache don't support
@@ -484,18 +490,26 @@ class EngineCore:
                 # No sampling required (no requests scheduled).
                 future = cast(Future[ModelRunnerOutput], exec_future)
             else:
-                exec_future.add_done_callback(self._log_err_callback(scheduler_output))
-
                 if not scheduler_output.pending_structured_output_tokens:
-                    # We aren't waiting for any tokens, get any grammar output
-                    # and sample immediately.
-                    grammar_output = self.scheduler.get_grammar_bitmask(
-                        scheduler_output
-                    )
-                    future = self.model_executor.sample_tokens(
-                        grammar_output, non_block=True
-                    )
+                    if current_platform.is_tt():
+                        future = cast(
+                            Future[ModelRunnerOutput], exec_future
+                        )
+                    else:
+                        exec_future.add_done_callback(
+                            self._log_err_callback(scheduler_output)
+                        )
+                        grammar_output = self.scheduler.get_grammar_bitmask(
+                            scheduler_output
+                        )
+                        future = self.model_executor.sample_tokens(
+                            grammar_output, non_block=True
+                        )
                 else:
+                    if not current_platform.is_tt():
+                        exec_future.add_done_callback(
+                            self._log_err_callback(scheduler_output)
+                        )
                     # We need to defer sampling until we have processed the model output
                     # from the prior step.
                     deferred_scheduler_output = scheduler_output
@@ -533,11 +547,21 @@ class EngineCore:
         if deferred_scheduler_output:
             # We now have the tokens needed to compute the bitmask for the
             # deferred request. Get the bitmask and call sample tokens.
-            grammar_output = self.scheduler.get_grammar_bitmask(
-                deferred_scheduler_output
-            )
-            future = self.model_executor.sample_tokens(grammar_output, non_block=True)
-            batch_queue.appendleft((future, deferred_scheduler_output))
+            if current_platform.is_tt():
+                batch_queue.appendleft(
+                    (
+                        cast(Future[ModelRunnerOutput], exec_future),
+                        deferred_scheduler_output,
+                    )
+                )
+            else:
+                grammar_output = self.scheduler.get_grammar_bitmask(
+                    deferred_scheduler_output
+                )
+                future = self.model_executor.sample_tokens(
+                    grammar_output, non_block=True
+                )
+                batch_queue.appendleft((future, deferred_scheduler_output))
 
         return engine_core_outputs, model_executed
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -114,6 +114,7 @@ class EngineCore:
             )
 
         self.log_stats = log_stats
+        self._tt_step_debug = os.environ.get("VLLM_TT_STEP_DEBUG") == "1"
         self._init_debug_viztracer()
 
         # Setup Model.
@@ -229,6 +230,10 @@ class EngineCore:
         # Mark the startup heap as static so that it's ignored by GC.
         # Reduces pause times of oldest generation collections.
         freeze_gc_heap()
+
+    def _tt_debug(self, msg: str, *args: object) -> None:
+        if self._tt_step_debug:
+            logger.info("[TT_STEP_DEBUG][core] " + msg, *args)
 
     def _initialize_kv_caches(
         self, vllm_config: VllmConfig
@@ -491,6 +496,27 @@ class EngineCore:
         batch_queue = self.batch_queue
         assert batch_queue is not None
 
+        is_tt = current_platform.is_tt()
+        oldest_future_done = bool(batch_queue and batch_queue[-1][0].done())
+
+        # TT async decode completion runs host-side postprocessing on the worker
+        # async thread before the EngineCore consumes the result. Once the
+        # oldest future is done, the TT runner state has already advanced, so
+        # issuing another schedule here would build a new SchedulerOutput
+        # against stale scheduler bookkeeping and can mismatch the in-flight
+        # request set. Drain the completed output first.
+        should_schedule = not (is_tt and oldest_future_done)
+        if is_tt:
+            self._tt_debug(
+                "enter queue_len=%d oldest_done=%s "
+                "has_requests=%s running=%d waiting=%d",
+                len(batch_queue),
+                oldest_future_done,
+                self.scheduler.has_requests(),
+                len(getattr(self.scheduler, "running", [])),
+                len(getattr(self.scheduler, "waiting", [])),
+            )
+
         # Try to schedule a new batch if the batch queue is not full, but
         # the scheduler may return an empty batch if all requests are scheduled.
         # Note that this is not blocking.
@@ -503,6 +529,16 @@ class EngineCore:
             scheduler_output = self.scheduler.schedule()
             if not self.is_ec_producer:
                 model_executed = scheduler_output.total_num_scheduled_tokens > 0
+            if is_tt:
+                self._tt_debug(
+                    "scheduled total_tokens=%d reqs=%s new=%s cached=%s "
+                    "pending_struct=%s",
+                    scheduler_output.total_num_scheduled_tokens,
+                    list(scheduler_output.num_scheduled_tokens.keys()),
+                    [r.req_id for r in scheduler_output.scheduled_new_reqs],
+                    list(scheduler_output.scheduled_cached_reqs.req_ids),
+                    scheduler_output.pending_structured_output_tokens,
+                )
 
             if self.is_pooling_model or not model_executed:
                 # No sampling required (no requests scheduled).
@@ -560,6 +596,13 @@ class EngineCore:
             if not deferred_scheduler_output:
                 # Add this step's future to the queue.
                 batch_queue.appendleft((future, scheduler_output))
+                if is_tt:
+                    self._tt_debug(
+                        "queued queue_len=%d newest_reqs=%s oldest_done=%s",
+                        len(batch_queue),
+                        list(scheduler_output.num_scheduled_tokens.keys()),
+                        bool(batch_queue[-1][0].done()),
+                    )
                 if (
                     model_executed
                     and len(batch_queue) < self.batch_queue_size
@@ -577,12 +620,25 @@ class EngineCore:
 
         # Block until the next result is available.
         future, scheduler_output = batch_queue.pop()
+        if is_tt:
+            self._tt_debug(
+                "drain queue_len_after_pop=%d reqs=%s future_done=%s",
+                len(batch_queue),
+                list(scheduler_output.num_scheduled_tokens.keys()),
+                future.done(),
+            )
         with self.log_error_detail(scheduler_output):
             model_output = future.result()
 
         engine_core_outputs = self.scheduler.update_from_output(
             scheduler_output, model_output
         )
+        if is_tt:
+            self._tt_debug(
+                "updated reqs=%s output_reqs=%s",
+                list(scheduler_output.num_scheduled_tokens.keys()),
+                list(model_output.req_ids),
+            )
 
         # NOTE(nick): We can either handle the deferred tasks here or save
         # in a field and do it immediately once step_with_batch_queue is

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -591,6 +591,10 @@ class EngineCore:
                 # For TT async path, grammar must be computed after prior output
                 # has updated request states, and before execute_model consumes
                 # scheduler_output in build_model_input.
+                # NOTE: get_grammar_bitmask writes the bitmask directly into
+                # deferred_scheduler_output.grammar_bitmask in-place; there is
+                # no return value to capture here (contrast with the non-TT path
+                # below, which passes the bitmask explicitly to sample_tokens).
                 self.scheduler.get_grammar_bitmask(deferred_scheduler_output)
                 exec_future = cast(
                     Future[ModelRunnerOutput],

--- a/vllm/v1/engine/tt_dp_gather.py
+++ b/vllm/v1/engine/tt_dp_gather.py
@@ -1,0 +1,482 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from __future__ import annotations
+
+import pickle
+from concurrent.futures import Future
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+import torch.distributed as dist
+
+from vllm.logger import init_logger
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.engine.core import DPEngineCoreProc, DPGatherHandle
+
+logger = init_logger(__name__)
+
+
+def _completed_dp_gather_future(
+    core: DPEngineCoreProc,
+) -> Future[tuple[torch.Tensor, list]]:
+    parallel_config = core.vllm_config.parallel_config
+    world = parallel_config.data_parallel_size
+    batch_size = core.vllm_config.scheduler_config.max_num_seqs
+    future: Future[tuple[torch.Tensor, list]] = Future()
+    future.set_result(
+        (torch.zeros((world, batch_size, 1), dtype=torch.int32), [None] * world)
+    )
+    return future
+
+
+def _dp_any_rank_has_scheduler_requests(core: DPEngineCoreProc) -> bool:
+    local_has_requests = 1 if core.scheduler.has_requests() else 0
+    has_requests_t = torch.tensor([local_has_requests], dtype=torch.int32)
+    try:
+        dist.all_reduce(has_requests_t, op=dist.ReduceOp.SUM, group=core.dp_group)
+    except RuntimeError as e:
+        # During shutdown, peers may close connections mid-collective.
+        # Exit gracefully to allow coordinated shutdown.
+        if "Connection closed by peer" in str(e):
+            logger.debug("Collective failed during shutdown, exiting gracefully")
+            raise SystemExit() from e
+        raise
+    return int(has_requests_t.item()) > 0
+
+
+def _dp_negotiate_forced_mode(core: DPEngineCoreProc) -> int:
+    # Max-consecutive-decoding guard: if there are waiting prefills
+    # and we decoded for dp_max_consec_decodes steps consecutively,
+    # force one prefill step. Otherwise, prefer decode while running.
+    # Can't automatically set intent to be prefill if there are any
+    # waiting requests since we could get stuck in a loop where intent
+    # is prefill but it doesn't get scheduled.
+    has_running = bool(getattr(core.scheduler, "running", []))
+    has_waiting = bool(getattr(core.scheduler, "waiting", False))
+    must_prefill = has_waiting and core.dp_decode_streak >= core.dp_max_consec_decodes
+    local_prefill_intent = (
+        1 if (has_waiting and (must_prefill or not has_running)) else 0
+    )
+    intent_tensor = torch.tensor([local_prefill_intent], dtype=torch.int32)
+    core.dlog("before_intent_allreduce intent_tensor=%s", intent_tensor)
+    dist.all_reduce(intent_tensor, op=dist.ReduceOp.MAX, group=core.dp_group)
+    forced_mode = int(intent_tensor.item())  # 1=prefill, 0=decode
+    core.dlog("after_intent_allreduce forced_mode=%d", forced_mode)
+    # Record forced_mode so it can be used by DP gather submission.
+    core._dp_gather_forced_mode = forced_mode
+    return forced_mode
+
+
+def _dp_apply_forced_mode(core: DPEngineCoreProc, forced_mode: int | None) -> None:
+    set_mode = getattr(core.scheduler, "set_forced_mode", None)
+    if callable(set_mode):
+        set_mode(forced_mode)
+
+
+def _dp_update_decode_streak(
+    core: DPEngineCoreProc,
+    scheduler_output: SchedulerOutput | None,
+    forced_mode: int | None,
+) -> None:
+    if scheduler_output is None or forced_mode is None:
+        return
+    # This is intentionally stale by at most one step in async DP mode:
+    # forced-mode negotiation for step N+1 runs before update_from_output(N).
+    if scheduler_output.total_num_scheduled_tokens > 0 and forced_mode == 0:
+        core.dp_decode_streak += 1
+    else:
+        core.dp_decode_streak = 0
+
+
+def step_dp_with_batch_queue(
+    core: DPEngineCoreProc,
+) -> tuple[dict[int, EngineCoreOutputs] | None, bool]:
+    assert core.batch_queue is not None
+
+    global_has_requests = _dp_any_rank_has_scheduler_requests(core)
+    in_flight = core._dp_in_flight
+    if not global_has_requests and in_flight is None:
+        return {}, False
+
+    forced_mode: int | None = None
+    scheduler_output: SchedulerOutput | None = None
+    model_executed = False
+    if global_has_requests:
+        forced_mode = _dp_negotiate_forced_mode(core)
+        if core.scheduler.has_requests():
+            _dp_apply_forced_mode(core, forced_mode)
+            scheduler_output = core.scheduler.schedule()
+            _dp_apply_forced_mode(core, None)
+            _dp_update_decode_streak(core, scheduler_output, forced_mode)
+            if not core.is_ec_producer:
+                model_executed = scheduler_output.total_num_scheduled_tokens > 0
+
+    prev_model_output: ModelRunnerOutput | None = None
+    prev_scheduler_output: SchedulerOutput | None = None
+    engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
+    if in_flight is not None:
+        prev_model_output = dp_gather_finalize(core, in_flight)
+        prev_scheduler_output = in_flight.scheduler_output
+        core._dp_in_flight = None
+
+    if (
+        scheduler_output is not None
+        and scheduler_output.pending_structured_output_tokens
+    ):
+        if prev_model_output is not None and prev_scheduler_output is not None:
+            engine_core_outputs = core.scheduler.update_from_output(
+                prev_scheduler_output, prev_model_output
+            )
+            prev_model_output = None
+            prev_scheduler_output = None
+        core.scheduler.get_grammar_bitmask(scheduler_output)
+
+    if global_has_requests:
+        core._dp_in_flight = dp_gather_submit(core, scheduler_output)
+
+    if prev_model_output is not None and prev_scheduler_output is not None:
+        engine_core_outputs = core.scheduler.update_from_output(
+            prev_scheduler_output, prev_model_output
+        )
+        return engine_core_outputs, model_executed
+
+    if not global_has_requests:
+        return engine_core_outputs, False
+
+    return engine_core_outputs, model_executed
+
+
+def dp_gather_submit(
+    core: DPEngineCoreProc, scheduler_output: SchedulerOutput | None
+) -> DPGatherHandle:
+    """Prepare and submit one gathered-DP execution step.
+
+    Collects per-rank DP inputs, negotiates the merged execution shape, and
+    returns a `DPGatherHandle` consumed by `dp_gather_finalize()` on the
+    next step.
+
+    This path is mixed-mode rather than purely sync or async:
+    - it is always synchronous for the host-side gather/orchestration work
+    - for prefill, the worker executes synchronously even though we pass
+      `non_block=True` through the executor boundary
+    - for decode, the worker uses the async decode submit path and returns
+      a future-like handle that is completed later in `dp_gather_finalize()`
+    """
+    from vllm.v1.engine.core import DPGatherHandle
+
+    parallel_config = core.vllm_config.parallel_config
+    group = core.dp_group
+    rank = core.dp_rank
+    local_rank = parallel_config.data_parallel_rank_local
+    world = parallel_config.data_parallel_size
+
+    local_has_requests = scheduler_output is not None
+    if scheduler_output is not None:
+        core.dlog("enter_gather tokens=%d", scheduler_output.total_num_scheduled_tokens)
+
+    # Detect decode vs prefill using forced_mode negotiated earlier.
+    # 0=decode, 1=prefill.
+    assert hasattr(core, "_dp_gather_forced_mode"), "forced_mode not set"
+    is_decode = core._dp_gather_forced_mode == 0
+
+    # Build local dp model input (or None).
+    all_local_inputs = core.model_executor.collective_rpc(
+        "build_dp_model_input", args=(scheduler_output,)
+    )[0]  # type: ignore[var-annotated]
+    (
+        local_input,
+        local_max_blocks,
+        local_has_structured,
+        local_has_penalties,
+        local_reset_batch,
+        local_can_sample_device,
+        local_needs_logprobs,
+        req_ids,
+        req_id_to_index,
+    ) = all_local_inputs
+    max_blocks_decode = None  # Only used for decode.
+    any_structured_inputs = False  # Only used for decode.
+    any_needs_logprobs = False
+
+    gathered_inputs: Any = None
+    if is_decode:
+        # Gather max_blocks, has_structured, has_penalties, reset_batch,
+        # cannot_sample_on_device, and needs_logprobs from all ranks.
+        input_info_t = torch.tensor(
+            [
+                local_max_blocks,
+                local_has_structured,
+                local_has_penalties,
+                local_reset_batch,
+                # Invert so we can use MAX reduction and still compute
+                # "all ranks can sample on device".
+                1 - local_can_sample_device,
+                local_needs_logprobs,
+            ],
+            dtype=torch.int32,
+        )
+        dist.all_reduce(input_info_t, op=dist.ReduceOp.MAX, group=group)
+        max_blocks_decode = int(input_info_t[0].item())
+        any_structured_inputs = input_info_t[1].item() > 0
+        any_penalties_inputs = input_info_t[2].item() > 0
+        any_reset_batch = input_info_t[3].item() > 0
+        all_sample_device = input_info_t[4].item() == 0
+        any_needs_logprobs = input_info_t[5].item() > 0
+
+        # Build tensorized gather input for decode.
+        decode_inputs: dict[str, Any] = core.model_executor.collective_rpc(
+            "build_dp_decode_gather_input",
+            args=(
+                local_input,
+                max_blocks_decode,
+                any_structured_inputs,
+                any_penalties_inputs,
+            ),
+        )[0]
+
+        # Decode: use gather with fixed-shape inputs.
+        int_local = decode_inputs["int_inputs"]  # 1D int32
+        float_local = decode_inputs["float_inputs"]  # 1D float32
+
+        # Only rank 0 needs buffers for the gather operation.
+        # Pre-allocate stacked tensors and create list views for gather.
+        stacked_int = None
+        stacked_float = None
+        gather_list_int = None
+        gather_list_float = None
+        if rank == 0:
+            stacked_int = torch.empty((world, *int_local.shape), dtype=int_local.dtype)
+            stacked_float = torch.empty(
+                (world, *float_local.shape), dtype=float_local.dtype
+            )
+            gather_list_int = [stacked_int[i] for i in range(world)]
+            gather_list_float = [stacked_float[i] for i in range(world)]
+
+        # Gather to rank 0, then send to other device ranks (local rank 0).
+        # Note: if num device ranks == num world ranks, then this could be
+        # all_gather but we usually have device ranks << world.
+        dist.gather(int_local, gather_list_int, dst=0, group=group)
+        dist.gather(float_local, gather_list_float, dst=0, group=group)
+        if len(core.dp_device_ranks) > 1:
+            if rank == 0:
+                # Rank 0 sends stacked tensors to other device ranks.
+                for dst in core.dp_device_ranks[1:]:
+                    dist.send(stacked_int, dst=dst, group=group)
+                    dist.send(stacked_float, dst=dst, group=group)
+            elif local_rank == 0:  # other device ranks
+                # Other device ranks receive from rank 0.
+                stacked_int = torch.empty(
+                    (world, *int_local.shape), dtype=int_local.dtype
+                )
+                stacked_float = torch.empty(
+                    (world, *float_local.shape), dtype=float_local.dtype
+                )
+                dist.recv(stacked_int, src=0, group=group)
+                dist.recv(stacked_float, src=0, group=group)
+
+        # Gather prompt/output tokens only when they are needed (penalties)
+        # and (if sampling on host or the decode batch layout changed).
+        gathered_tokens_inputs = None
+        if any_penalties_inputs and (not all_sample_device or any_reset_batch):
+            # Gather token dicts (containing tensors) to rank 0
+            if rank == 0:
+                gathered_tokens_inputs = [None for _ in range(world)]
+            local_tokens_inputs = decode_inputs["sampling_tokens_inputs"]
+            dist.gather_object(
+                local_tokens_inputs, gathered_tokens_inputs, dst=0, group=group
+            )
+
+            if len(core.dp_device_ranks) > 1:
+                if rank == 0:
+                    # Rank 0 sends gathered tokens to other device ranks
+                    pickled_tokens = pickle.dumps(gathered_tokens_inputs)
+                    tokens_tensor = torch.frombuffer(pickled_tokens, dtype=torch.uint8)
+                    tokens_size = torch.tensor(
+                        [tokens_tensor.numel()], dtype=torch.long
+                    )
+                    for dst in core.dp_device_ranks[1:]:
+                        dist.send(tokens_size, dst=dst, group=group)
+                        dist.send(tokens_tensor, dst=dst, group=group)
+                elif local_rank == 0:  # other device ranks
+                    # Other device ranks receive from rank 0
+                    tokens_size = torch.zeros(1, dtype=torch.long)
+                    dist.recv(tokens_size, src=0, group=group)
+                    tokens_tensor = torch.empty(tokens_size.item(), dtype=torch.uint8)
+                    dist.recv(tokens_tensor, src=0, group=group)
+                    gathered_tokens_inputs = pickle.loads(
+                        tokens_tensor.numpy().tobytes()
+                    )
+
+        # Gather host-only sampling params (logprobs, allowed_token_ids,
+        # bad_words, logit_bias, min_p, min_tokens) when sampling on host.
+        gathered_host_only_sample_params = None
+        if not all_sample_device:
+            if rank == 0:
+                gathered_host_only_sample_params = [None for _ in range(world)]
+            local_host_only_sample_params = decode_inputs.get("host_only_sample_params")
+            dist.gather_object(
+                local_host_only_sample_params,
+                gathered_host_only_sample_params,
+                dst=0,
+                group=group,
+            )
+
+            if len(core.dp_device_ranks) > 1:
+                if rank == 0:
+                    # Rank 0 sends gathered host_only params to device ranks
+                    pickled_host_only = pickle.dumps(gathered_host_only_sample_params)
+                    host_only_tensor = torch.frombuffer(
+                        pickled_host_only, dtype=torch.uint8
+                    )
+                    host_only_size = torch.tensor(
+                        [host_only_tensor.numel()], dtype=torch.long
+                    )
+                    for dst in core.dp_device_ranks[1:]:
+                        dist.send(host_only_size, dst=dst, group=group)
+                        dist.send(host_only_tensor, dst=dst, group=group)
+                elif local_rank == 0:  # other device ranks
+                    # Other device ranks receive from rank 0
+                    host_only_size = torch.zeros(1, dtype=torch.long)
+                    dist.recv(host_only_size, src=0, group=group)
+                    host_only_tensor = torch.empty(
+                        host_only_size.item(), dtype=torch.uint8
+                    )
+                    dist.recv(host_only_tensor, src=0, group=group)
+                    gathered_host_only_sample_params = pickle.loads(
+                        host_only_tensor.numpy().tobytes()
+                    )
+
+        if local_rank == 0:
+            gathered_inputs = {
+                "int_inputs": stacked_int,
+                "float_inputs": stacked_float,
+                "sampling_tokens_inputs": gathered_tokens_inputs,
+                "host_only_sample_params": gathered_host_only_sample_params,
+                "reset_batch": any_reset_batch,
+                "all_sample_device": all_sample_device,
+            }
+
+    else:
+        # Prefill: use gather_object with variable sized inputs.
+        gathered_inputs = None
+        if rank == 0:
+            gathered_inputs = [None for _ in range(world)]  # type: ignore
+
+        # All_reduce to determine if any rank needs logprobs (for prefill).
+        logprobs_flag_t = torch.tensor([local_needs_logprobs], dtype=torch.int32)
+        dist.all_reduce(logprobs_flag_t, op=dist.ReduceOp.MAX, group=group)
+        any_needs_logprobs = logprobs_flag_t[0].item() > 0
+
+        # Gather to rank 0, then send to other device ranks (local rank 0).
+        # Note: if num device ranks == num world ranks, then this could be
+        # all_gather_object but we usually have device ranks << world.
+        dist.gather_object(local_input, gathered_inputs, dst=0, group=group)
+        if len(core.dp_device_ranks) > 1:
+            if rank == 0:
+                # Rank 0 sends gathered list to other device ranks only.
+                pickled_data = pickle.dumps(gathered_inputs)
+                object_tensor = torch.frombuffer(pickled_data, dtype=torch.uint8)
+                size_tensor = torch.tensor([object_tensor.numel()], dtype=torch.long)
+                for dst in core.dp_device_ranks[1:]:
+                    dist.send(size_tensor, dst=dst, group=group)
+                    dist.send(object_tensor, dst=dst, group=group)
+            elif local_rank == 0:  # other device ranks
+                # Other device ranks receive from rank 0.
+                size_tensor = torch.zeros(1, dtype=torch.long)
+                dist.recv(size_tensor, src=0, group=group)
+                object_tensor = torch.empty(size_tensor.item(), dtype=torch.uint8)
+                dist.recv(object_tensor, src=0, group=group)
+                gathered_inputs = pickle.loads(object_tensor.numpy().tobytes())
+    core.dlog("after_inputs_gather")
+
+    should_submit = is_decode or (
+        isinstance(gathered_inputs, list)
+        and any(x is not None for x in gathered_inputs)
+    )
+    if should_submit:
+        future = cast(
+            Future[tuple[torch.Tensor, list]],
+            core.model_executor.collective_rpc(
+                "concat_and_execute_dp",
+                args=(
+                    gathered_inputs,
+                    is_decode,
+                    max_blocks_decode,
+                    any_structured_inputs,
+                ),
+                kwargs={"non_block": True},
+                non_block=True,
+                single_value=True,
+            ),
+        )
+    else:
+        future = _completed_dp_gather_future(core)
+
+    return DPGatherHandle(
+        future=future,
+        scheduler_output=scheduler_output,
+        local_has_requests=local_has_requests,
+        is_decode=is_decode,
+        any_needs_logprobs=any_needs_logprobs,
+        req_ids=req_ids,
+        req_id_to_index=req_id_to_index,
+    )
+
+
+def dp_gather_finalize(
+    core: DPEngineCoreProc, handle: DPGatherHandle
+) -> ModelRunnerOutput:
+    parallel_config = core.vllm_config.parallel_config
+    group = core.dp_group
+    rank = core.dp_rank
+    world = parallel_config.data_parallel_size
+    logprobs_per_dp: list = [None] * world
+
+    result = handle.future.result()  # Waiting for step output to be ready
+    assert isinstance(result, tuple) and len(result) == 2
+    send_tensor, logprobs_per_dp = result
+    assert isinstance(send_tensor, torch.Tensor)
+
+    # Global rank 0 scatters results to all ranks
+    my_ids = torch.empty_like(send_tensor[0])  # Shape (B, 1)
+    scatter_list = None
+    if rank == 0:
+        # Prepare scatter list: split send_tensor along first dimension
+        scatter_list = [send_tensor[i] for i in range(world)]
+    dist.scatter(my_ids, scatter_list, src=0, group=group)
+    core.dlog("after_results_gather my_ids_shape=%s", tuple(my_ids.shape))
+
+    # Scatter logprobs only if any rank needs them
+    # (determined in all_reduce).
+    my_logprobs_val = None
+    if handle.any_needs_logprobs:
+        my_logprobs: list = [None]
+        logprobs_scatter_list = logprobs_per_dp if rank == 0 else None
+        dist.scatter_object_list(my_logprobs, logprobs_scatter_list, src=0, group=group)
+        my_logprobs_val = my_logprobs[0]
+
+    # If rank had scheduled tokens, apply results locally and return output
+    if handle.local_has_requests:
+        output: ModelRunnerOutput = core.model_executor.collective_rpc(
+            "apply_dp_execution_result",
+            args=(
+                my_ids,
+                my_logprobs_val,
+                handle.req_ids,
+                handle.req_id_to_index,
+            ),
+        )[0]
+        return output
+    else:
+        return EMPTY_MODEL_RUNNER_OUTPUT
+
+
+def _execute_model_dp_gather(
+    core: DPEngineCoreProc, scheduler_output: SchedulerOutput | None
+) -> ModelRunnerOutput:
+    handle = dp_gather_submit(core, scheduler_output)
+    return dp_gather_finalize(core, handle)

--- a/vllm/v1/engine/tt_dp_gather.py
+++ b/vllm/v1/engine/tt_dp_gather.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pickle
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import torch
 import torch.distributed as dist
@@ -18,6 +18,22 @@ if TYPE_CHECKING:
     from vllm.v1.engine.core import DPEngineCoreProc, DPGatherHandle
 
 logger = init_logger(__name__)
+_T = TypeVar("_T")
+
+
+def _unwrap_single_worker_future(future: Future[list[_T]]) -> Future[_T]:
+    single_future: Future[_T] = Future()
+
+    def _set_single_result(done_future: Future[list[_T]]) -> None:
+        try:
+            results = done_future.result()
+            assert len(results) == 1
+            single_future.set_result(results[0])
+        except Exception as exc:
+            single_future.set_exception(exc)
+
+    future.add_done_callback(_set_single_result)
+    return single_future
 
 
 def _completed_dp_gather_future(
@@ -398,8 +414,8 @@ def dp_gather_submit(
         and any(x is not None for x in gathered_inputs)
     )
     if should_submit:
-        future = cast(
-            Future[tuple[torch.Tensor, list]],
+        collective_future = cast(
+            Future[list[tuple[torch.Tensor, list]]],
             core.model_executor.collective_rpc(
                 "concat_and_execute_dp",
                 args=(
@@ -410,9 +426,9 @@ def dp_gather_submit(
                 ),
                 kwargs={"non_block": True},
                 non_block=True,
-                single_value=True,
             ),
         )
+        future = _unwrap_single_worker_future(collective_future)
     else:
         future = _completed_dp_gather_future(core)
 

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -236,13 +236,20 @@ class Executor(ABC):
         """
         return self.device_config.device_type == "tt"
 
+    @staticmethod
+    def _as_future(value: _R) -> Future[_R]:
+        future: Future[_R] = Future()
+        future.set_result(value)
+        return future
+
     def submit_scheduled_batch(
         self,
         scheduler_output: SchedulerOutput,
         get_grammar_bitmask: Callable[[SchedulerOutput], GrammarOutput | None],
         *,
         non_block: bool,
-        failure_callback: Callable[[Future[ModelRunnerOutput | None]], None] | None = None,
+        failure_callback: Callable[[Future[ModelRunnerOutput | None]], None]
+        | None = None,
     ) -> tuple[Future[ModelRunnerOutput | None] | None, SchedulerOutput | None]:
         """Start work for one scheduled batch.
 
@@ -255,16 +262,26 @@ class Executor(ABC):
         if self.samples_tokens_in_execute_model():
             if scheduler_output.pending_structured_output_tokens:
                 return None, scheduler_output
-            future = cast(
-                Future[ModelRunnerOutput | None],
-                self.execute_model(scheduler_output, non_block=non_block),
-            )
+            if non_block:
+                future = cast(
+                    Future[ModelRunnerOutput | None],
+                    self.execute_model(scheduler_output, non_block=True),
+                )
+            else:
+                future = self._as_future(
+                    self.execute_model(scheduler_output, non_block=False)
+                )
             return future, None
 
-        exec_future = cast(
-            Future[ModelRunnerOutput | None],
-            self.execute_model(scheduler_output, non_block=non_block),
-        )
+        if non_block:
+            exec_future = cast(
+                Future[ModelRunnerOutput | None],
+                self.execute_model(scheduler_output, non_block=True),
+            )
+        else:
+            exec_future = self._as_future(
+                self.execute_model(scheduler_output, non_block=False)
+            )
         if failure_callback is not None:
             exec_future.add_done_callback(failure_callback)
 
@@ -272,10 +289,16 @@ class Executor(ABC):
             return None, scheduler_output
 
         grammar_output = get_grammar_bitmask(scheduler_output)
-        future = cast(
-            Future[ModelRunnerOutput | None],
-            self.sample_tokens(grammar_output, non_block=non_block),
-        )
+        if non_block:
+            future = cast(
+                Future[ModelRunnerOutput | None],
+                self.sample_tokens(grammar_output, non_block=True),
+            )
+        else:
+            future = cast(
+                Future[ModelRunnerOutput | None],
+                self._as_future(self.sample_tokens(grammar_output, non_block=False)),
+            )
         return future, None
 
     def submit_deferred_scheduled_batch(
@@ -291,15 +314,24 @@ class Executor(ABC):
             # inside execute_model(), so computing the bitmask is a required
             # side effect before submission.
             get_grammar_bitmask(scheduler_output)
-            return cast(
-                Future[ModelRunnerOutput | None],
-                self.execute_model(scheduler_output, non_block=non_block),
+            if non_block:
+                return cast(
+                    Future[ModelRunnerOutput | None],
+                    self.execute_model(scheduler_output, non_block=True),
+                )
+            return self._as_future(
+                self.execute_model(scheduler_output, non_block=False)
             )
 
         grammar_output = get_grammar_bitmask(scheduler_output)
+        if non_block:
+            return cast(
+                Future[ModelRunnerOutput | None],
+                self.sample_tokens(grammar_output, non_block=True),
+            )
         return cast(
             Future[ModelRunnerOutput | None],
-            self.sample_tokens(grammar_output, non_block=non_block),
+            self._as_future(self.sample_tokens(grammar_output, non_block=False)),
         )
 
     def execute_dummy_batch(self) -> None:

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
@@ -224,6 +224,83 @@ class Executor(ABC):
             "sample_tokens", args=(grammar_output,), non_block=non_block
         )
         return output[0]
+
+    def samples_tokens_in_execute_model(self) -> bool:
+        """Return True when execute_model() already applies sampling/output work.
+
+        Most executors follow the default vLLM flow: execute_model() produces
+        model state/logits, then sample_tokens() consumes the grammar bitmask
+        and returns the final ModelRunnerOutput. TT keeps that sampling/output
+        path inside execute_model(), so the engine must defer execute_model()
+        itself until structured-output grammar is available.
+        """
+        return self.device_config.device_type == "tt"
+
+    def submit_scheduled_batch(
+        self,
+        scheduler_output: SchedulerOutput,
+        get_grammar_bitmask: Callable[[SchedulerOutput], GrammarOutput | None],
+        *,
+        non_block: bool,
+        failure_callback: Callable[[Future[ModelRunnerOutput | None]], None] | None = None,
+    ) -> tuple[Future[ModelRunnerOutput | None] | None, SchedulerOutput | None]:
+        """Start work for one scheduled batch.
+
+        Returns a `(future, deferred_scheduler_output)` pair. Executors that
+        sample inside execute_model() return a future directly when grammar is
+        already available, or defer execute_model() itself until a later call.
+        Executors that keep sampling separate submit execute_model() first and,
+        when possible, immediately enqueue sample_tokens().
+        """
+        if self.samples_tokens_in_execute_model():
+            if scheduler_output.pending_structured_output_tokens:
+                return None, scheduler_output
+            future = cast(
+                Future[ModelRunnerOutput | None],
+                self.execute_model(scheduler_output, non_block=non_block),
+            )
+            return future, None
+
+        exec_future = cast(
+            Future[ModelRunnerOutput | None],
+            self.execute_model(scheduler_output, non_block=non_block),
+        )
+        if failure_callback is not None:
+            exec_future.add_done_callback(failure_callback)
+
+        if scheduler_output.pending_structured_output_tokens:
+            return None, scheduler_output
+
+        grammar_output = get_grammar_bitmask(scheduler_output)
+        future = cast(
+            Future[ModelRunnerOutput | None],
+            self.sample_tokens(grammar_output, non_block=non_block),
+        )
+        return future, None
+
+    def submit_deferred_scheduled_batch(
+        self,
+        scheduler_output: SchedulerOutput,
+        get_grammar_bitmask: Callable[[SchedulerOutput], GrammarOutput | None],
+        *,
+        non_block: bool,
+    ) -> Future[ModelRunnerOutput | None]:
+        """Submit a batch whose structured-output grammar became available later."""
+        if self.samples_tokens_in_execute_model():
+            # Executors such as TT consume scheduler_output.grammar_bitmask
+            # inside execute_model(), so computing the bitmask is a required
+            # side effect before submission.
+            get_grammar_bitmask(scheduler_output)
+            return cast(
+                Future[ModelRunnerOutput | None],
+                self.execute_model(scheduler_output, non_block=non_block),
+            )
+
+        grammar_output = get_grammar_bitmask(scheduler_output)
+        return cast(
+            Future[ModelRunnerOutput | None],
+            self.sample_tokens(grammar_output, non_block=non_block),
+        )
 
     def execute_dummy_batch(self) -> None:
         self.collective_rpc("execute_dummy_batch")

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
@@ -224,18 +224,6 @@ class Executor(ABC):
             "sample_tokens", args=(grammar_output,), non_block=non_block
         )
         return output[0]
-
-    def concat_and_execute_dp(
-        self,
-        inputs: Any,
-        is_decode: bool,
-        max_blocks_decode_batch: int | None,
-        any_structured_inputs: bool,
-        non_block: bool = False,
-    ) -> tuple[Any, list[Any]] | Future[tuple[Any, list[Any]]]:
-        raise NotImplementedError(
-            "concat_and_execute_dp is only supported by gathered-DP executors"
-        )
 
     def samples_tokens_in_execute_model(self) -> bool:
         """Return True when execute_model() already applies sampling/output work.

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import Future
 from functools import cached_property
-from typing import TYPE_CHECKING, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast, overload
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.utils import KVOutputAggregator
@@ -225,6 +225,18 @@ class Executor(ABC):
         )
         return output[0]
 
+    def concat_and_execute_dp(
+        self,
+        inputs: Any,
+        is_decode: bool,
+        max_blocks_decode_batch: int | None,
+        any_structured_inputs: bool,
+        non_block: bool = False,
+    ) -> tuple[Any, list[Any]] | Future[tuple[Any, list[Any]]]:
+        raise NotImplementedError(
+            "concat_and_execute_dp is only supported by gathered-DP executors"
+        )
+
     def samples_tokens_in_execute_model(self) -> bool:
         """Return True when execute_model() already applies sampling/output work.
 
@@ -250,7 +262,7 @@ class Executor(ABC):
         non_block: bool,
         failure_callback: Callable[[Future[ModelRunnerOutput | None]], None]
         | None = None,
-    ) -> tuple[Future[ModelRunnerOutput | None] | None, SchedulerOutput | None]:
+    ) -> tuple[Future[ModelRunnerOutput] | None, SchedulerOutput | None]:
         """Start work for one scheduled batch.
 
         Returns a `(future, deferred_scheduler_output)` pair. Executors that
@@ -264,12 +276,15 @@ class Executor(ABC):
                 return None, scheduler_output
             if non_block:
                 future = cast(
-                    Future[ModelRunnerOutput | None],
+                    Future[ModelRunnerOutput],
                     self.execute_model(scheduler_output, non_block=True),
                 )
             else:
-                future = self._as_future(
-                    self.execute_model(scheduler_output, non_block=False)
+                future = cast(
+                    Future[ModelRunnerOutput],
+                    self._as_future(
+                        self.execute_model(scheduler_output, non_block=False)
+                    ),
                 )
             return future, None
 
@@ -291,12 +306,12 @@ class Executor(ABC):
         grammar_output = get_grammar_bitmask(scheduler_output)
         if non_block:
             future = cast(
-                Future[ModelRunnerOutput | None],
+                Future[ModelRunnerOutput],
                 self.sample_tokens(grammar_output, non_block=True),
             )
         else:
             future = cast(
-                Future[ModelRunnerOutput | None],
+                Future[ModelRunnerOutput],
                 self._as_future(self.sample_tokens(grammar_output, non_block=False)),
             )
         return future, None
@@ -307,7 +322,7 @@ class Executor(ABC):
         get_grammar_bitmask: Callable[[SchedulerOutput], GrammarOutput | None],
         *,
         non_block: bool,
-    ) -> Future[ModelRunnerOutput | None]:
+    ) -> Future[ModelRunnerOutput]:
         """Submit a batch whose structured-output grammar became available later."""
         if self.samples_tokens_in_execute_model():
             # Executors such as TT consume scheduler_output.grammar_bitmask
@@ -316,21 +331,22 @@ class Executor(ABC):
             get_grammar_bitmask(scheduler_output)
             if non_block:
                 return cast(
-                    Future[ModelRunnerOutput | None],
+                    Future[ModelRunnerOutput],
                     self.execute_model(scheduler_output, non_block=True),
                 )
-            return self._as_future(
-                self.execute_model(scheduler_output, non_block=False)
+            return cast(
+                Future[ModelRunnerOutput],
+                self._as_future(self.execute_model(scheduler_output, non_block=False)),
             )
 
         grammar_output = get_grammar_bitmask(scheduler_output)
         if non_block:
             return cast(
-                Future[ModelRunnerOutput | None],
+                Future[ModelRunnerOutput],
                 self.sample_tokens(grammar_output, non_block=True),
             )
         return cast(
-            Future[ModelRunnerOutput | None],
+            Future[ModelRunnerOutput],
             self._as_future(self.sample_tokens(grammar_output, non_block=False)),
         )
 

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import cached_property
 from multiprocessing import Lock
-from typing import Any, cast
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -99,30 +99,6 @@ class UniProcExecutor(Executor):
             args=(scheduler_output,),
             non_block=non_block,
             single_value=True,
-        )
-
-    def concat_and_execute_dp(
-        self,
-        inputs: Any,
-        is_decode: bool,
-        max_blocks_decode_batch: int | None,
-        any_structured_inputs: bool,
-        non_block: bool = False,
-    ) -> tuple[torch.Tensor, list[Any]] | Future[tuple[torch.Tensor, list[Any]]]:
-        return cast(
-            tuple[torch.Tensor, list[Any]] | Future[tuple[torch.Tensor, list[Any]]],
-            self.collective_rpc(
-                "concat_and_execute_dp",
-                args=(
-                    inputs,
-                    is_decode,
-                    max_blocks_decode_batch,
-                    any_structured_inputs,
-                ),
-                kwargs={"non_block": non_block},
-                non_block=non_block,
-                single_value=True,
-            ),
         )
 
     def sample_tokens(  # type: ignore[override]

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -59,19 +59,6 @@ class UniProcExecutor(Executor):
     def max_concurrent_batches(self) -> int:
         return 2 if self.scheduler_config.async_scheduling else 1
 
-    @staticmethod
-    def _run_instrumented_async_output(task: Callable[[], Any]) -> Any:
-        """Enable VizTracer on the async output thread before running work."""
-        try:
-            from viztracer import get_tracer
-        except ImportError:
-            return task()
-
-        tracer = get_tracer()
-        if tracer is not None:
-            tracer.enable_thread_tracing()
-        return task()
-
     def collective_rpc(  # type: ignore[override]
         self,
         method: str | Callable,
@@ -95,9 +82,7 @@ class UniProcExecutor(Executor):
                     get_output = result.get_output
                     if not single_value:
                         get_output = lambda go=result.get_output: [go()]
-                    return async_thread.submit(
-                        self._run_instrumented_async_output, get_output
-                    )
+                    return async_thread.submit(get_output)
                 result = result.get_output()
             future = Future[Any]()
             future.set_result(result if single_value else [result])

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -101,6 +101,27 @@ class UniProcExecutor(Executor):
             single_value=True,
         )
 
+    def concat_and_execute_dp(
+        self,
+        inputs: Any,
+        is_decode: bool,
+        max_blocks_decode_batch: int | None,
+        any_structured_inputs: bool,
+        non_block: bool = False,
+    ) -> tuple[torch.Tensor, list[Any]] | Future[tuple[torch.Tensor, list[Any]]]:
+        return self.collective_rpc(
+            "concat_and_execute_dp",
+            args=(
+                inputs,
+                is_decode,
+                max_blocks_decode_batch,
+                any_structured_inputs,
+            ),
+            kwargs={"non_block": non_block},
+            non_block=non_block,
+            single_value=True,
+        )
+
     def sample_tokens(  # type: ignore[override]
         self, grammar_output: GrammarOutput | None, non_block: bool = False
     ) -> ModelRunnerOutput | None | Future[ModelRunnerOutput | None]:

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from functools import cached_property
 from multiprocessing import Lock
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.distributed as dist
@@ -24,26 +24,6 @@ logger = init_logger(__name__)
 
 
 class UniProcExecutor(Executor):
-    def _create_async_output_thread(self) -> ThreadPoolExecutor | None:
-        if self.max_concurrent_batches <= 1:
-            return None
-        return ThreadPoolExecutor(max_workers=1, thread_name_prefix="WorkerAsyncOutput")
-
-    def _submit_async_output(
-        self,
-        output: AsyncModelRunnerOutput,
-        *,
-        single_value: bool,
-    ) -> Future[Any | list[Any]] | Any | list[Any]:
-        if (async_thread := self.async_output_thread) is None:
-            result = output.get_output()
-            return result if single_value else [result]
-
-        get_output = output.get_output
-        if not single_value:
-            get_output = lambda go=output.get_output: [go()]
-        return async_thread.submit(get_output)
-
     def _init_executor(self) -> None:
         """Initialize the worker and load the model."""
         self.driver_worker = WorkerWrapperBase(vllm_config=self.vllm_config, rpc_rank=0)
@@ -57,7 +37,11 @@ class UniProcExecutor(Executor):
             shared_worker_lock=Lock(),
         )
 
-        self.async_output_thread = self._create_async_output_thread()
+        self.async_output_thread: ThreadPoolExecutor | None = None
+        if self.max_concurrent_batches > 1:
+            self.async_output_thread = ThreadPoolExecutor(
+                max_workers=1, thread_name_prefix="WorkerAsyncOutput"
+            )
 
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
@@ -94,7 +78,12 @@ class UniProcExecutor(Executor):
         try:
             result = run_method(self.driver_worker, method, args, kwargs)
             if isinstance(result, AsyncModelRunnerOutput):
-                return self._submit_async_output(result, single_value=single_value)
+                if (async_thread := self.async_output_thread) is not None:
+                    get_output = result.get_output
+                    if not single_value:
+                        get_output = lambda go=result.get_output: [go()]
+                    return async_thread.submit(get_output)
+                result = result.get_output()
             future = Future[Any]()
             future.set_result(result if single_value else [result])
         except Exception as e:
@@ -120,17 +109,20 @@ class UniProcExecutor(Executor):
         any_structured_inputs: bool,
         non_block: bool = False,
     ) -> tuple[torch.Tensor, list[Any]] | Future[tuple[torch.Tensor, list[Any]]]:
-        return self.collective_rpc(
-            "concat_and_execute_dp",
-            args=(
-                inputs,
-                is_decode,
-                max_blocks_decode_batch,
-                any_structured_inputs,
+        return cast(
+            tuple[torch.Tensor, list[Any]] | Future[tuple[torch.Tensor, list[Any]]],
+            self.collective_rpc(
+                "concat_and_execute_dp",
+                args=(
+                    inputs,
+                    is_decode,
+                    max_blocks_decode_batch,
+                    any_structured_inputs,
+                ),
+                kwargs={"non_block": non_block},
+                non_block=non_block,
+                single_value=True,
             ),
-            kwargs={"non_block": non_block},
-            non_block=non_block,
-            single_value=True,
         )
 
     def sample_tokens(  # type: ignore[override]

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -24,6 +24,26 @@ logger = init_logger(__name__)
 
 
 class UniProcExecutor(Executor):
+    def _create_async_output_thread(self) -> ThreadPoolExecutor | None:
+        if self.max_concurrent_batches <= 1:
+            return None
+        return ThreadPoolExecutor(max_workers=1, thread_name_prefix="WorkerAsyncOutput")
+
+    def _submit_async_output(
+        self,
+        output: AsyncModelRunnerOutput,
+        *,
+        single_value: bool,
+    ) -> Future[Any | list[Any]] | Any | list[Any]:
+        if (async_thread := self.async_output_thread) is None:
+            result = output.get_output()
+            return result if single_value else [result]
+
+        get_output = output.get_output
+        if not single_value:
+            get_output = lambda go=output.get_output: [go()]
+        return async_thread.submit(get_output)
+
     def _init_executor(self) -> None:
         """Initialize the worker and load the model."""
         self.driver_worker = WorkerWrapperBase(vllm_config=self.vllm_config, rpc_rank=0)
@@ -37,11 +57,7 @@ class UniProcExecutor(Executor):
             shared_worker_lock=Lock(),
         )
 
-        self.async_output_thread: ThreadPoolExecutor | None = None
-        if self.max_concurrent_batches > 1:
-            self.async_output_thread = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="WorkerAsyncOutput"
-            )
+        self.async_output_thread = self._create_async_output_thread()
 
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
@@ -78,12 +94,7 @@ class UniProcExecutor(Executor):
         try:
             result = run_method(self.driver_worker, method, args, kwargs)
             if isinstance(result, AsyncModelRunnerOutput):
-                if (async_thread := self.async_output_thread) is not None:
-                    get_output = result.get_output
-                    if not single_value:
-                        get_output = lambda go=result.get_output: [go()]
-                    return async_thread.submit(get_output)
-                result = result.get_output()
+                return self._submit_async_output(result, single_value=single_value)
             future = Future[Any]()
             future.set_result(result if single_value else [result])
         except Exception as e:

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -59,6 +59,19 @@ class UniProcExecutor(Executor):
     def max_concurrent_batches(self) -> int:
         return 2 if self.scheduler_config.async_scheduling else 1
 
+    @staticmethod
+    def _run_instrumented_async_output(task: Callable[[], Any]) -> Any:
+        """Enable VizTracer on the async output thread before running work."""
+        try:
+            from viztracer import get_tracer
+        except ImportError:
+            return task()
+
+        tracer = get_tracer()
+        if tracer is not None:
+            tracer.enable_thread_tracing()
+        return task()
+
     def collective_rpc(  # type: ignore[override]
         self,
         method: str | Callable,
@@ -82,7 +95,9 @@ class UniProcExecutor(Executor):
                     get_output = result.get_output
                     if not single_value:
                         get_output = lambda go=result.get_output: [go()]
-                    return async_thread.submit(get_output)
+                    return async_thread.submit(
+                        self._run_instrumented_async_output, get_output
+                    )
                 result = result.get_output()
             future = Future[Any]()
             future.set_result(result if single_value else [result])

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -282,12 +282,11 @@ class TTModelRunner:
         self.enable_model_warmup = enable_model_warmup
         # Whether to sample on device
         self.sample_on_device_mode = TTPlatform.sample_on_device_mode
-        self.async_read_mode = os.getenv("VLLM_TT_ASYNC_READ_MODE", "event").strip().lower()
+        self.async_read_mode = (
+            os.getenv("VLLM_TT_ASYNC_READ_MODE", "event").strip().lower()
+        )
         if self.async_read_mode not in {"event", "blocking_worker"}:
-            raise ValueError(
-                "VLLM_TT_ASYNC_READ_MODE must be 'event' or 'blocking_worker', "
-                f"got {self.async_read_mode!r}"
-            )
+            self.async_read_mode = "event"
 
         logger.info(
             "TTModelRunner: trace_mode=%s, "
@@ -1728,8 +1727,7 @@ class TTModelRunner:
         else:
             is_host_tensor = isinstance(tt_out, torch.Tensor)
             is_host_tensor_tuple = isinstance(tt_out, tuple) and all(
-                tensor is None or isinstance(tensor, torch.Tensor)
-                for tensor in tt_out
+                tensor is None or isinstance(tensor, torch.Tensor) for tensor in tt_out
             )
             if not (is_host_tensor or is_host_tensor_tuple):
                 raise AttributeError(

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -106,11 +106,41 @@ class TTModelInput:
     reset_batch: bool = False
 
 
-class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
-    """Wraps a non-blocking TT decode submission.
+@dataclass(frozen=True)
+class TTDecodeSubmission:
+    """Carries the raw result of decode submission until finalization.
 
-    Returned by ``_execute_model_async_decode`` so that the executor can
-    defer the blocking device-sync / readback to a worker thread while the
+    Decode submission and decode finalization happen on different threads in
+    async mode, but they are one logical service. This record gives both sync
+    and async paths one shared hand-off format instead of open-coded tuples and
+    ad hoc unpacking.
+    """
+
+    tt_out: Any | None
+    read_events: list[Any] | None
+    batch_size_per_dp: list[int]
+    sampling_params: TTSamplingParams
+    perform_device_sampling: bool
+
+
+@dataclass(frozen=True)
+class TTFinalizedDecode:
+    """Normalized decode result after any TT event waits and host processing.
+
+    Every decode path eventually needs the same two things: postprocessed TT
+    outputs plus optional device logprobs. Centralizing that contract keeps
+    token extraction independent from how the decode completed.
+    """
+
+    tt_out: torch.Tensor
+    tt_log_probs: torch.Tensor | None
+
+
+class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
+    """Wraps a non-blocking TT decode submission plus async read submit.
+
+    Returned by ``submit_async_non_dp_decode`` so that the executor can
+    defer the blocking event wait / host postprocessing to a worker thread while the
     main thread continues scheduling the next batch.
 
     ``req_ids`` and ``req_id_to_index`` are captured at submit time because
@@ -121,21 +151,15 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
     def __init__(
         self,
         runner: TTModelRunner,
-        tt_out: Any | None,
+        submission: TTDecodeSubmission,
         model_input: TTModelInput,
-        batch_size_per_dp: list[int],
-        sampling_params: TTSamplingParams,
-        perform_device_sampling: bool,
         completion_event: threading.Event,
         req_ids: list[str],
         req_id_to_index: dict[str, int],
     ):
         self._runner = runner
-        self._tt_out = tt_out
+        self._submission = submission
         self._model_input = model_input
-        self._batch_size_per_dp = batch_size_per_dp
-        self._sampling_params = sampling_params
-        self._perform_device_sampling = perform_device_sampling
         self._completion_event = completion_event
         self._req_ids = req_ids
         self._req_id_to_index = req_id_to_index
@@ -148,34 +172,17 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
 
     def _get_output_impl(self) -> ModelRunnerOutput:
         runner = self._runner
-        tt_out_raw = self._tt_out
-
-        if tt_out_raw is None:
+        finalized = runner.finalize_decode(self._submission)
+        if finalized is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
-        tt_out = runner.model.sync_and_read_decode_output(
-            tt_out_raw,
-            is_tokens=self._perform_device_sampling,
-        )
-
-        tt_log_probs = None
-        assert isinstance(self._sampling_params.enable_log_probs, torch.Tensor)
-        if (
-            self._perform_device_sampling
-            and self._sampling_params.enable_log_probs.any()
-        ):
-            assert isinstance(tt_out, tuple) and len(tt_out) == 2
-            tt_out, tt_log_probs = tt_out
-        elif isinstance(tt_out, tuple):
-            tt_out, _ = tt_out
-
         sampled_token_ids_per_dp, logprobs_per_dp = runner._get_output_tokens(
-            tt_out=tt_out,
-            tt_log_probs=tt_log_probs,
-            sampling_params=self._sampling_params,
+            tt_out=finalized.tt_out,
+            tt_log_probs=finalized.tt_log_probs,
+            sampling_params=self._submission.sampling_params,
             model_input=self._model_input,
-            batch_size_per_dp=self._batch_size_per_dp,
-            perform_device_sampling=self._perform_device_sampling,
+            batch_size_per_dp=self._submission.batch_size_per_dp,
+            perform_device_sampling=self._submission.perform_device_sampling,
             is_decode=True,
         )
 
@@ -183,11 +190,59 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
 
-        return runner.generate_runner_output_from_async(
-            req_ids=self._req_ids,
-            req_id_to_index=self._req_id_to_index,
+        return runner.apply_and_build_runner_output(
             sampled_token_ids=sampled_token_ids,
             logprobs=logprobs,
+            req_ids=self._req_ids,
+            req_id_to_index=self._req_id_to_index,
+        )
+
+
+class AsyncTTDPGatherOutput(AsyncModelRunnerOutput):
+    """Wraps a non-blocking DP>1 decode submission plus async read submit.
+
+    Returned by ``submit_async_dp_decode`` so that the executor can
+    defer the blocking event wait / host postprocessing / token extraction to its
+    async output thread while the main thread continues scheduling.
+
+    ``get_output()`` returns ``tuple[torch.Tensor, list]`` (stacked
+    per-DP sampled ids + per-DP logprobs lists) rather than a
+    ``ModelRunnerOutput``, matching the contract expected by
+    ``dp_gather_finalize``.
+    """
+
+    def __init__(
+        self,
+        runner: TTModelRunner,
+        submission: TTDecodeSubmission,
+        model_input: TTModelInput,
+    ):
+        self._runner = runner
+        self._submission = submission
+        self._model_input = model_input
+
+    def get_output(self) -> tuple[torch.Tensor, list]:  # type: ignore[override]
+        runner = self._runner
+        finalized = runner.finalize_decode(self._submission)
+        if finalized is None:
+            return runner.pack_dp_results(
+                [torch.tensor([], dtype=torch.int32)]
+                * len(self._submission.batch_size_per_dp),
+                [None] * len(self._submission.batch_size_per_dp),
+            )
+
+        sampled_token_ids_per_dp, logprobs_per_dp = runner._get_output_tokens(
+            tt_out=finalized.tt_out,
+            tt_log_probs=finalized.tt_log_probs,
+            sampling_params=self._submission.sampling_params,
+            model_input=self._model_input,
+            batch_size_per_dp=self._submission.batch_size_per_dp,
+            perform_device_sampling=self._submission.perform_device_sampling,
+            is_decode=True,
+        )
+
+        return runner.pack_dp_results(
+            sampled_token_ids_per_dp, logprobs_per_dp
         )
 
 
@@ -1391,16 +1446,14 @@ class TTModelRunner:
         scheduler_output: SchedulerOutput,
         intermediate_tensors: IntermediateTensors | None = None,
     ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
-        """Execution path for non-DP case.
-        Execute the model with the given scheduler output.
+        """Public non-DP runner entrypoint used by the TT worker.
 
-        When ``async_scheduling`` is enabled and the step is a decode,
-        returns ``AsyncTTModelRunnerOutput`` (the trace is submitted but
-        the device has not been synced yet).  The executor puts
-        ``get_output()`` on its async thread and returns a Future.
+        Dispatches one non-DP step from scheduler output to the appropriate TT
+        execution path and returns either a completed `ModelRunnerOutput` or an
+        async decode wrapper.
         """
         # In the DP case, this function is skipped!
-        # tt_worker.py directly calls execute_with_model_input
+        # tt_worker.py uses the dedicated DP facade instead.
         # With DP, the actual model pass happens on a batch
         # produced by concatenating the inputs from all DP ranks.
 
@@ -1416,49 +1469,109 @@ class TTModelRunner:
 
         is_decode = model_input.prompt_lens is None
         if self.async_scheduling and is_decode:
-            return self._execute_model_async_decode(model_input)
+            return self.submit_async_non_dp_decode(model_input)
 
         # Synchronous path (prefill, or decode without async scheduling)
-        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(  # noqa: E501
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_sync_with_model_input(  # noqa: E501
             model_input
         )
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
-        output = self.generate_runner_output(sampled_token_ids, logprobs)
+        output = self.apply_and_build_runner_output(sampled_token_ids, logprobs)
         return output
 
-    def _execute_model_async_decode(
+    def submit_async_non_dp_decode(
         self,
         model_input: TTModelInput,
     ) -> AsyncTTModelRunnerOutput:
-        """Submit a decode trace without blocking for device completion.
+        """Submit non-DP decode work for async completion.
 
-        Mirrors the decode path of ``execute_with_model_input`` but passes
-        ``read_from_device=False`` so that ``decode_forward`` returns device
-        tensors immediately.  The actual sync + readback + sampling happens
-        later inside ``AsyncTTModelRunnerOutput.get_output()``.
+        Returns an `AsyncTTModelRunnerOutput` after issuing TT decode work and
+        async read submission. The wrapper carries the captured request
+        identity needed to build the final non-DP output on the async thread.
         """
         event = threading.Event()
+        submission = self.submit_decode(
+            model_input, read_from_device=False, async_read=True
+        )
 
-        batch_size_per_dp = model_input.unpadded_batch_size
-        if not isinstance(batch_size_per_dp, list):
-            batch_size_per_dp = [batch_size_per_dp]
-
-        if not any(bs > 0 for bs in batch_size_per_dp):
+        if submission.tt_out is None:
+            # No decode work was submitted to the device for this step
+            # (for example, the merged batch was effectively empty), so the
+            # async output wrapper should be marked complete immediately.
             event.set()
             self._pending_async_event = event
             num_reqs = self.input_batch.num_reqs
             return AsyncTTModelRunnerOutput(
                 runner=self,
-                tt_out=None,
+                submission=submission,
                 model_input=model_input,
-                batch_size_per_dp=batch_size_per_dp,
-                sampling_params=model_input.tt_sampling_params,
-                perform_device_sampling=model_input.perform_device_sampling,
                 completion_event=event,
                 req_ids=list(self.input_batch.req_ids[:num_reqs]),
                 req_id_to_index=dict(self.input_batch.req_id_to_index),
+            )
+
+        # Capture req_ids/req_id_to_index now - input_batch will be
+        # overwritten by the next step's build_model_input before
+        # get_output() runs on the async thread.
+        self._pending_async_event = event
+        num_reqs = self.input_batch.num_reqs
+        return AsyncTTModelRunnerOutput(
+            runner=self,
+            submission=submission,
+            model_input=model_input,
+            completion_event=event,
+            req_ids=list(self.input_batch.req_ids[:num_reqs]),
+            req_id_to_index=dict(self.input_batch.req_id_to_index),
+        )
+
+    def submit_async_dp_decode(
+        self,
+        model_input: TTModelInput,
+    ) -> AsyncTTDPGatherOutput:
+        """Submit merged DP decode work for async completion.
+
+        Returns an `AsyncTTDPGatherOutput` after issuing merged DP decode work
+        and async read submission. The wrapper later produces the packed
+        per-DP payload consumed by gathered-DP finalization.
+        """
+        submission = self.submit_decode(
+            model_input, read_from_device=False, async_read=True
+        )
+
+        return AsyncTTDPGatherOutput(
+            runner=self,
+            submission=submission,
+            model_input=model_input,
+        )
+
+    def submit_decode(
+        self,
+        model_input: TTModelInput,
+        *,
+        read_from_device: bool,
+        async_read: bool = False,
+    ) -> TTDecodeSubmission:
+        """Submit decode work and return a normalized submission record.
+
+        Launches TT decode with either immediate readback or async read submit
+        and returns a normalized record consumed by sync and async completion
+        paths.
+        """
+        batch_size_per_dp = model_input.unpadded_batch_size
+        if not isinstance(batch_size_per_dp, list):
+            batch_size_per_dp = [batch_size_per_dp]
+
+        sampling_params = model_input.tt_sampling_params
+        perform_device_sampling = model_input.perform_device_sampling
+        if not any(bs > 0 for bs in batch_size_per_dp):
+            return TTDecodeSubmission(
+                tt_out=None,
+                read_events=None,
+                batch_size_per_dp=batch_size_per_dp,
+                sampling_params=sampling_params,
+                perform_device_sampling=perform_device_sampling,
             )
 
         kwargs: dict[str, Any] = {
@@ -1467,9 +1580,6 @@ class TTModelRunner:
             "kv_cache": self.kv_caches,
             "start_pos": model_input.input_positions,
         }
-
-        sampling_params = model_input.tt_sampling_params
-        perform_device_sampling = model_input.perform_device_sampling
         if perform_device_sampling:
             sampling_param_dict = {
                 field.name: (
@@ -1513,25 +1623,93 @@ class TTModelRunner:
             **kwargs,
             **enc_dec_kwargs,
             enable_trace=enable_trace,
-            read_from_device=False,
+            read_from_device=read_from_device,
         )
-
-        # Capture req_ids/req_id_to_index now - input_batch will be
-        # overwritten by the next step's build_model_input before
-        # get_output() runs on the async thread.
-        self._pending_async_event = event
-        num_reqs = self.input_batch.num_reqs
-        return AsyncTTModelRunnerOutput(
-            runner=self,
+        read_events = None
+        if async_read:
+            tt_out, read_events = cast(
+                tuple[Any, list[Any]],
+                self.model.read_decode_output(tt_out, async_read=True),
+            )
+        return TTDecodeSubmission(
             tt_out=tt_out,
-            model_input=model_input,
+            read_events=read_events,
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
-            completion_event=event,
-            req_ids=list(self.input_batch.req_ids[:num_reqs]),
-            req_id_to_index=dict(self.input_batch.req_id_to_index),
         )
+
+    def finalize_decode(
+        self,
+        submission: TTDecodeSubmission,
+    ) -> TTFinalizedDecode | None:
+        """Finish decode after submission and normalize TT outputs.
+
+        Waits for any pending TT read events, runs host-side postprocessing,
+        and returns normalized decode outputs plus optional device logprobs.
+        """
+        if submission.tt_out is None:
+            return None
+
+        if submission.read_events is not None:
+            for read_event in submission.read_events:
+                ttnn.event_synchronize(read_event)
+
+        tt_out = self.model.process_decode_output_host(
+            submission.tt_out,
+            is_tokens=submission.perform_device_sampling,
+        )
+
+        tt_log_probs = None
+        assert isinstance(submission.sampling_params.enable_log_probs, torch.Tensor)
+        if (
+            submission.perform_device_sampling
+            and submission.sampling_params.enable_log_probs.any()
+        ):
+            assert isinstance(tt_out, tuple) and len(tt_out) == 2
+            tt_out, tt_log_probs = tt_out
+        elif isinstance(tt_out, tuple):
+            tt_out, _ = tt_out
+
+        return TTFinalizedDecode(tt_out=tt_out, tt_log_probs=tt_log_probs)
+
+    def pack_dp_results(
+        self,
+        sampled_token_ids_per_dp: list[torch.Tensor],
+        logprobs_per_dp: list,
+    ) -> tuple[torch.Tensor, list]:
+        """Pack per-DP results into the gathered-DP wire format.
+
+        Converts per-DP sampled tokens and logprobs into the stacked tensor/list
+        payload consumed by gathered-DP finalization.
+        """
+        logprobs_lists_per_dp = [
+            lp.tolists() if lp is not None else None for lp in logprobs_per_dp
+        ]
+        world = self.parallel_config.data_parallel_size
+        B = int(self.scheduler_config.max_num_seqs)
+        for dp_rank in range(world):
+            token_ids = sampled_token_ids_per_dp[dp_rank].to(torch.int32)
+            if token_ids.numel() == 0:
+                token_ids = torch.zeros((B, 1), dtype=torch.int32)
+            else:
+                assert token_ids.dim() == 2 and token_ids.shape[1] == 1, (
+                    "Currently only supporting 1 output token per request"
+                )
+                pad_rows = B - token_ids.shape[0]
+                if pad_rows > 0:
+                    token_ids = torch.cat(
+                        [
+                            token_ids,
+                            torch.zeros(
+                                (pad_rows, token_ids.shape[1]),
+                                dtype=torch.int32,
+                            ),
+                        ],
+                        dim=0,
+                    )
+            sampled_token_ids_per_dp[dp_rank] = token_ids
+        return torch.stack(sampled_token_ids_per_dp), logprobs_lists_per_dp
 
     def check_perform_device_sampling(
         self, is_decode: bool, has_structured_outputs: bool
@@ -1583,14 +1761,67 @@ class TTModelRunner:
         )
         return params_device_supported
 
-    def execute_with_model_input(
+    def submit_prefill(
+        self,
+        model_input: TTModelInput,
+        batch_size_per_dp: list[int],
+    ) -> Any:
+        """Submit a prefill step and return the raw TT output.
+
+        Launches TT prefill and returns the raw TT output used by the
+        synchronous extraction path.
+        """
+        kwargs = {
+            "tokens": model_input.input_tokens,
+            "page_table": model_input.block_tables,
+            "kv_cache": self.kv_caches,
+            "enable_trace": self.trace_mode in ["all"],
+            "prompt_lens": model_input.prompt_lens,
+            "start_pos": model_input.input_positions,
+        }
+        kwargs.update(model_input.multi_modal_kwargs)
+        if model_input.perform_device_sampling:
+            sampling_params = model_input.tt_sampling_params
+            sampling_param_dict = {
+                field.name: (
+                    getattr(sampling_params, field.name).tolist()
+                    if getattr(sampling_params, field.name) is not None
+                    else None
+                )
+                for field in fields(sampling_params)
+            }
+            sampling_param_dict["seed"] = [
+                None if s == SEED_NONE_SENTINEL else s
+                for s in sampling_param_dict["seed"]
+            ]
+            kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
+        if len(batch_size_per_dp) > 1:
+            # TODO: the model should only require DP ranks, but passing
+            # "global" user ids instead for backwards compatibility.
+            stride = int(self.scheduler_config.max_num_seqs)
+            empty_slots = []
+            for dp_rank, sz in enumerate(batch_size_per_dp):
+                for i in range(int(sz)):
+                    empty_slots.append(dp_rank * stride + i)
+            kwargs["empty_slots"] = empty_slots
+
+        if self.request_specific_rope:
+            tt_out, rope_deltas = self.model.prefill_forward(**kwargs)
+            # Store rope_deltas for each prefilled request
+            for i, req_id in enumerate(self.input_batch.req_ids):
+                self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
+            return tt_out
+        return self.model.prefill_forward(**kwargs)
+
+    def execute_sync_with_model_input(
         self,
         model_input: TTModelInput,
     ) -> tuple[list[torch.Tensor], list[LogprobsTensors | None]]:
-        """
-        Execute with a prebuilt input and return per-DP sampled ids without
-        mutating internal state. In DP case, called by DP rank 0 to run merged
-        batch. Note: currently does not support chunked prefill.
+        """Run a fully synchronous TT execution for a prebuilt model input.
+
+        Executes a prebuilt TT input to completion, including prefill or decode
+        submission, decode finalization when needed, and per-DP token/logprob
+        extraction.
 
         Returns:
             Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
@@ -1606,111 +1837,30 @@ class TTModelRunner:
             num_dp = len(batch_size_per_dp)
             return ([torch.tensor([], dtype=torch.int32)] * num_dp, [None] * num_dp)
 
-        kwargs = {
-            "tokens": model_input.input_tokens,
-            "page_table": model_input.block_tables,
-            "kv_cache": self.kv_caches,
-        }
-
-        if not is_decode:
-            kwargs["enable_trace"] = self.trace_mode in ["all"]
-            kwargs["prompt_lens"] = model_input.prompt_lens
-            kwargs.update(model_input.multi_modal_kwargs)
-            if len(batch_size_per_dp) > 1:
-                # TODO: the model should only require DP ranks, but passing
-                # "global" user ids instead for backwards compatibility.
-                stride = int(self.scheduler_config.max_num_seqs)
-                empty_slots = []
-                for dp_rank, sz in enumerate(batch_size_per_dp):
-                    for i in range(int(sz)):
-                        empty_slots.append(dp_rank * stride + i)
-                kwargs["empty_slots"] = empty_slots
-
-        kwargs["start_pos"] = model_input.input_positions
-
-        # Sampling decision
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
-        if perform_device_sampling:
-            # On-device sampling currently needs sampling param attributes to
-            # be lists instead of tensors.
-            sampling_param_dict = {
-                field.name: (
-                    getattr(sampling_params, field.name).tolist()
-                    if getattr(sampling_params, field.name) is not None
-                    else None
-                )
-                for field in fields(sampling_params)
-            }
-            # Convert seed sentinel value back to None
-            # (vLLM treats -1 as equivalent to None for seeds)
-            sampling_param_dict["seed"] = [
-                None if s == SEED_NONE_SENTINEL else s
-                for s in sampling_param_dict["seed"]
-            ]
-            kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
-
-            # Pass prompt and output tokens for decode with sampling penalties
-            if is_decode and model_input.prompt_tokens is not None:
-                assert model_input.output_tokens is not None
-                kwargs["prompt_tokens"] = model_input.prompt_tokens
-                kwargs["output_tokens"] = model_input.output_tokens
-
-            # For decode on-device sampling, signal whether the decode batch
-            # layout changed since the previous step.
-            if is_decode:
-                # reset_batch is precomputed (for non-DP in
-                # _prepare_model_inputs; for DP after inputs are gathered).
-                kwargs["reset_batch"] = model_input.reset_batch
+        tt_log_probs = None
 
         # Execute model
         if not is_decode:
-            if self.request_specific_rope:
-                tt_out, rope_deltas = self.model.prefill_forward(**kwargs)
-                # Store rope_deltas for each prefilled request
-                for i, req_id in enumerate(self.input_batch.req_ids):
-                    self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
-            else:
-                tt_out = self.model.prefill_forward(**kwargs)
+            tt_out = self.submit_prefill(model_input, batch_size_per_dp)
         else:
-            # TODO: Add encoder-decoder support
-            enc_dec_kwargs: dict[str, Any] = {}
-            if self.request_specific_rope:
-                if any(
-                    req_id not in self.previous_req_ids
-                    for req_id in self.input_batch.req_ids
-                ):
-                    # Gather and pass rope_deltas from prefill step to decode
-                    enc_dec_kwargs = {
-                        "rope_deltas_all_users": [
-                            self.requests[req_id].mrope_position_delta
-                            for req_id in self.input_batch.req_ids
-                        ]
-                    }
-                else:
-                    enc_dec_kwargs = {"rope_deltas_all_users": None}
-                self.previous_req_ids = set(self.input_batch.req_ids)
-
-            enable_trace = self.trace_mode in ["all", "decode_only"]
-            # In the DP case, the model outputs for all ranks are concatenated.
-            tt_out = self.model.decode_forward(
-                **kwargs,
-                **enc_dec_kwargs,
-                enable_trace=enable_trace,
-                read_from_device=True,
+            submission = self.submit_decode(
+                model_input, read_from_device=True, async_read=False
             )
+            finalized = self.finalize_decode(submission)
+            assert finalized is not None
+            tt_out = finalized.tt_out
+            tt_log_probs = finalized.tt_log_probs
+            batch_size_per_dp = submission.batch_size_per_dp
+            sampling_params = submission.sampling_params
+            perform_device_sampling = submission.perform_device_sampling
 
-        # tt_out can be a tuple of (logits_or_tokens, logprobs) when device
-        # sampling is enabled with logprobs. Extract both components.
-        tt_log_probs = None
-
-        # Always tensors - turned into lists only right before passing to model
         assert isinstance(sampling_params.enable_log_probs, torch.Tensor)
         if perform_device_sampling and sampling_params.enable_log_probs.any():
             assert isinstance(tt_out, tuple) and len(tt_out) == 2
             tt_out, tt_log_probs = tt_out
         elif isinstance(tt_out, tuple):
-            # Model may return (logits, dummy_logprobs) even when not requested
             tt_out, _ = tt_out
 
         return self._get_output_tokens(
@@ -1721,6 +1871,103 @@ class TTModelRunner:
             batch_size_per_dp=batch_size_per_dp,
             perform_device_sampling=perform_device_sampling,
             is_decode=is_decode,
+        )
+
+    def prepare_dp_model_input(
+        self, scheduler_output: SchedulerOutput | None
+    ) -> tuple[
+        TTModelInput | None,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        list[str],
+        dict[str, int],
+    ]:
+        """Build the per-rank DP payload consumed by gather orchestration.
+
+        Returns the local TT model input plus the per-rank metadata needed by
+        gathered-DP negotiation and input gathering.
+        """
+        model_input = None
+        has_penalties = 0
+        reset_batch = 0
+        can_sample_device = 1
+        needs_logprobs = 0
+        req_ids: list[str] = []
+        req_id_to_index: dict[str, int] = {}
+        if scheduler_output is not None:
+            model_input = self.build_model_input(scheduler_output)
+            if model_input is not None:
+                has_penalties = int(not self.input_batch.no_penalties)
+                reset_batch = int(model_input.reset_batch)
+                can_sample_device = int(model_input.perform_device_sampling)
+                needs_logprobs = int(model_input.max_num_logprobs[0] > 0)
+                num_reqs = self.input_batch.num_reqs
+                req_ids = list(self.input_batch.req_ids[:num_reqs])
+                req_id_to_index = dict(self.input_batch.req_id_to_index)
+        max_blocks = model_input.block_tables.shape[1] if model_input else 0
+        has_structured_input = (
+            int(model_input.grammar_bitmask[0] is not None) if model_input else 0
+        )
+        return (
+            model_input,
+            max_blocks,
+            has_structured_input,
+            has_penalties,
+            reset_batch,
+            can_sample_device,
+            needs_logprobs,
+            req_ids,
+            req_id_to_index,
+        )
+
+    def submit_dp_execution(
+        self,
+        inputs: list[TTModelInput | None] | dict[str, Any],
+        is_decode: bool,
+        max_blocks_decode_batch: int | None,
+        any_structured_inputs: bool,
+        non_block: bool = False,
+    ) -> Any:
+        """Execute one merged DP batch and return the DP-facing result shape.
+
+        Merges gathered DP inputs, selects sync or async decode execution, and
+        returns the packed DP-facing result expected by the worker facade.
+        """
+        merged = self.concat_dp_model_inputs(
+            inputs, is_decode, max_blocks_decode_batch, any_structured_inputs
+        )
+
+        if non_block and is_decode:
+            return self.submit_async_dp_decode(merged)
+
+        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_sync_with_model_input(
+            merged
+        )
+        return self.pack_dp_results(sampled_token_ids_per_dp, logprobs_per_dp)
+
+    def apply_dp_execution_result(
+        self,
+        sampled_token_ids: torch.Tensor,
+        logprobs_lists: LogprobsLists | None = None,
+        req_ids: list[str] | None = None,
+        req_id_to_index: dict[str, int] | None = None,
+    ) -> ModelRunnerOutput:
+        """Apply the local DP rank result to runner state and build output.
+
+        Converts the local gathered-DP result into the same state update and
+        `ModelRunnerOutput` used by non-DP execution.
+        """
+        num_reqs = self.input_batch.num_reqs
+        sampled_token_ids = sampled_token_ids[:num_reqs]
+        return self.apply_and_build_runner_output(
+            sampled_token_ids,
+            logprobs_lists,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
         )
 
     def _get_output_tokens(
@@ -1957,25 +2204,31 @@ class TTModelRunner:
         ]
         logits.masked_fill_(unpacked_bitmask, -float("inf"))
 
-    def generate_runner_output(
+    def apply_and_build_runner_output(
         self,
         sampled_token_ids: torch.Tensor,
         logprobs: LogprobsLists | None = None,
+        req_ids: list[str] | None = None,
+        req_id_to_index: dict[str, int] | None = None,
     ):
-        """Generate ModelRunnerOutput from sampled tokens and optional logprobs.
+        """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
-        Args:
-            sampled_token_ids: Sampled token IDs tensor.
-            logprobs: LogprobsLists (already converted from tensors).
+        Updates persistent runner state from sampled tokens and returns the
+        `ModelRunnerOutput` consumed by the rest of vLLM.
         """
         # Cache the sampled tokens in the model runner, so that the scheduler
         # doesn't need to send them back.
-        num_reqs = self.input_batch.num_reqs
-        # Snapshot request mapping for this step. The batch queue may allow a
-        # later step to run and mutate input_batch before EngineCore consumes
-        # this ModelRunnerOutput.
-        req_ids = list(self.input_batch.req_ids[:num_reqs])
-        req_id_to_index = dict(self.input_batch.req_id_to_index)
+        use_captured_req_ids = req_ids is not None
+        num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
+        # Async decode passes captured request state because input_batch may be
+        # updated before get_output runs. Sync callers can reuse the live
+        # input_batch references directly to avoid per-step copying.
+        output_req_ids = req_ids if req_ids is not None else self.input_batch.req_ids
+        output_req_id_to_index = (
+            req_id_to_index
+            if req_id_to_index is not None
+            else self.input_batch.req_id_to_index
+        )
         assert sampled_token_ids.shape[0] == num_reqs, (
             f"Number of request outputs {sampled_token_ids.shape[0]} != "
             f"number of requests in input batch {num_reqs}"
@@ -2001,77 +2254,26 @@ class TTModelRunner:
         self.input_batch.token_ids_cpu[rows, start_idxs] = sampled_token_ids_np
         self.input_batch.num_tokens[:num_reqs] = end_idxs
 
-        # Update request state (output token lists) without dict lookups.
-        # NOTE: `InputBatch.req_output_token_ids[i]` is a direct reference to
-        # the underlying `CachedRequestState.output_token_ids` list (stored in
-        # `self.requests[req_id]`). Appending here updates request state too,
-        # while avoiding a per-request dict lookup.
+        # Update request state (output token lists). Sync callers can reuse the
+        # direct references cached in `input_batch`; async callers pass captured
+        # request ids because the visible batch ordering may have advanced.
         for req_idx in range(num_reqs):
-            output_token_ids = self.input_batch.req_output_token_ids[req_idx]
-            assert output_token_ids is not None
+            if not use_captured_req_ids:
+                output_token_ids = self.input_batch.req_output_token_ids[req_idx]
+                assert output_token_ids is not None
+            else:
+                output_token_ids = self.requests[output_req_ids[req_idx]].output_token_ids
             output_token_ids.append(int(sampled_token_ids_np[req_idx]))
 
         # Empty prompt log probs
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
-            req_ids, None
+            (output_req_ids[i] for i in range(num_reqs)), None
         )
 
         # Note: currently does not support speculative decoding or pooling.
         return ModelRunnerOutput(
-            req_ids=req_ids,
-            req_id_to_index=req_id_to_index,
-            sampled_token_ids=[
-                sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
-            ],
-            logprobs=logprobs,
-            prompt_logprobs_dict=prompt_logprobs_dict,
-            pooler_output=[],
-        )
-
-    def generate_runner_output_from_async(
-        self,
-        req_ids: list[str],
-        req_id_to_index: dict[str, int],
-        sampled_token_ids: torch.Tensor,
-        logprobs: LogprobsLists | None = None,
-    ) -> ModelRunnerOutput:
-        """Build ``ModelRunnerOutput`` for an async decode step.
-
-        Runs on the async output thread after device sync + sampling.
-        Updates ``self.input_batch`` (token_ids_cpu and num_tokens) so
-        that the next step's ``_prepare_model_inputs`` reads the correct
-        decode input token.  Thread-safe: ``_pending_async_event.wait()``
-        on the main thread guarantees this method completes before
-        ``build_model_input`` accesses ``input_batch``.
-
-        Uses *captured* ``req_ids`` / ``req_id_to_index`` for the
-        ``ModelRunnerOutput`` since those reflect the batch at submit time.
-        """
-        num_reqs = len(req_ids)
-        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
-        if sampled_token_ids_np.dtype != np.int32:
-            sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
-
-        # Write the sampled token into persistent batch token storage so
-        # that _prepare_model_inputs reads it as the next decode input.
-        start_idxs = self.input_batch.num_tokens[:num_reqs]
-        end_idxs = start_idxs + 1
-        rows = np.arange(num_reqs)
-        self.input_batch.token_ids_cpu[rows, start_idxs] = sampled_token_ids_np
-        self.input_batch.num_tokens[:num_reqs] = end_idxs
-
-        for req_idx in range(num_reqs):
-            req_id = req_ids[req_idx]
-            output_token_ids = self.requests[req_id].output_token_ids
-            output_token_ids.append(int(sampled_token_ids_np[req_idx]))
-
-        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
-            req_ids, None
-        )
-
-        return ModelRunnerOutput(
-            req_ids=req_ids,
-            req_id_to_index=req_id_to_index,
+            req_ids=output_req_ids,
+            req_id_to_index=output_req_id_to_index,
             sampled_token_ids=[
                 sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
             ],

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1698,10 +1698,22 @@ class TTModelRunner:
         )
         read_events = None
         if async_read:
-            tt_out, read_events = cast(
-                tuple[Any, list[Any]],
-                self.model.read_decode_output(tt_out, async_read=True),
-            )
+            if hasattr(self.model, "read_decode_output"):
+                tt_out, read_events = cast(
+                    tuple[Any, list[Any]],
+                    self.model.read_decode_output(tt_out, async_read=True),
+                )
+            else:
+                is_host_tensor = isinstance(tt_out, torch.Tensor)
+                is_host_tensor_tuple = isinstance(tt_out, tuple) and all(
+                    tensor is None or isinstance(tensor, torch.Tensor)
+                    for tensor in tt_out
+                )
+                if not (is_host_tensor or is_host_tensor_tuple):
+                    raise AttributeError(
+                        "TT model must implement read_decode_output() "
+                        "unless decode_forward() already returns host tensors"
+                    )
         return TTDecodeSubmission(
             tt_out=tt_out,
             read_events=read_events,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -120,7 +120,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
 
     def __init__(
         self,
-        runner: "TTModelRunner",
+        runner: TTModelRunner,
         tt_out: Any | None,
         model_input: TTModelInput,
         batch_size_per_dp: list[int],
@@ -159,9 +159,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         )
 
         tt_log_probs = None
-        assert isinstance(
-            self._sampling_params.enable_log_probs, torch.Tensor
-        )
+        assert isinstance(self._sampling_params.enable_log_probs, torch.Tensor)
         if (
             self._perform_device_sampling
             and self._sampling_params.enable_log_probs.any()
@@ -2047,9 +2045,7 @@ class TTModelRunner:
         num_reqs = len(req_ids)
         sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
         if sampled_token_ids_np.dtype != np.int32:
-            sampled_token_ids_np = sampled_token_ids_np.astype(
-                np.int32, copy=False
-            )
+            sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
 
         # Write the sampled token into persistent batch token storage so
         # that _prepare_model_inputs reads it as the next decode input.
@@ -2064,8 +2060,8 @@ class TTModelRunner:
             output_token_ids = self.requests[req_id].output_token_ids
             output_token_ids.append(int(sampled_token_ids_np[req_idx]))
 
-        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = (
-            dict.fromkeys(req_ids, None)
+        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
+            req_ids, None
         )
 
         return ModelRunnerOutput(

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -172,11 +172,6 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
 
     def _get_output_impl(self) -> ModelRunnerOutput:
         runner = self._runner
-        runner._tt_debug(
-            "async_get_output start captured_reqs=%s current_batch=%s",
-            self._req_ids,
-            list(runner.input_batch.req_ids[: runner.input_batch.num_reqs]),
-        )
         finalized = runner.finalize_decode(self._submission)
         if finalized is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
@@ -200,12 +195,6 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
             logprobs=logprobs,
             req_ids=self._req_ids,
             req_id_to_index=self._req_id_to_index,
-        )
-        runner._tt_debug(
-            "async_get_output done captured_reqs=%s output_reqs=%s current_batch=%s",
-            self._req_ids,
-            list(output.req_ids),
-            list(runner.input_batch.req_ids[: runner.input_batch.num_reqs]),
         )
         return output
 
@@ -329,7 +318,6 @@ class TTModelRunner:
             self.scheduler_config.async_scheduling
             and self.parallel_config.data_parallel_size == 1
         )
-        self._tt_step_debug = os.environ.get("VLLM_TT_STEP_DEBUG") == "1"
         # Guards single in-flight async decode. Set when an async decode is
         # submitted; cleared when get_output() completes on the async thread.
         self._pending_async_event: threading.Event | None = None
@@ -349,10 +337,6 @@ class TTModelRunner:
             is_pooling_model=False,
             custom_logitsprocs=(self.model_config.logits_processors or ()),
         )
-
-    def _tt_debug(self, msg: str, *args: object) -> None:
-        if self._tt_step_debug:
-            logger.info("[TT_STEP_DEBUG][runner] " + msg, *args)
 
     def load_model(self) -> None:
         loader = TTModelLoader(self.load_config)
@@ -462,13 +446,6 @@ class TTModelRunner:
         Based on _update_states for GPU/TPU backends.
         """
         persistent_batch_layout_changed = False
-        if self._tt_step_debug:
-            self._tt_debug(
-                "_update_states start scheduled=%s current_batch=%s finished=%s",
-                list(scheduler_output.num_scheduled_tokens.keys()),
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                list(scheduler_output.finished_req_ids),
-            )
 
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
@@ -499,11 +476,6 @@ class TTModelRunner:
         scheduled_req_ids = scheduler_output.num_scheduled_tokens.keys()
         cached_req_ids = self.input_batch.req_id_to_index.keys()
         unscheduled_req_ids = cached_req_ids - scheduled_req_ids
-        if self._tt_step_debug and unscheduled_req_ids:
-            self._tt_debug(
-                "_update_states unscheduled=%s",
-                list(unscheduled_req_ids),
-            )
         # NOTE(woosuk): The persistent batch optimization assumes that
         # consecutive batches contain mostly the same requests. If batches
         # have low request overlap (e.g., alternating between two distinct
@@ -604,12 +576,6 @@ class TTModelRunner:
 
         # Refresh logits processors with batch state changes
         self.input_batch.refresh_logitsprocs()
-        if self._tt_step_debug:
-            self._tt_debug(
-                "_update_states done batch=%s decode_layout_changed=%s",
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                self._decode_layout_changed_since_last_decode,
-            )
 
     def _validate_mm_feature(self, mm_feature: MultiModalFeatureSpec) -> None:
         """Validate the multimodal feature is an image."""
@@ -949,20 +915,10 @@ class TTModelRunner:
         # Update cached state
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
-            if self._tt_step_debug:
-                self._tt_debug("build_model_input empty scheduled batch")
             return None
 
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output)
-        if self._tt_step_debug:
-            self._tt_debug(
-                "build_model_input mode=%s reqs=%s prompt_lens=%s reset_batch=%s",
-                "prefill" if model_input.prompt_lens is not None else "decode",
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                model_input.prompt_lens,
-                model_input.reset_batch,
-            )
         return model_input
 
     def build_dp_decode_gather_input(
@@ -1504,20 +1460,8 @@ class TTModelRunner:
 
         # Wait for any in-flight async decode from the previous step.
         if self._pending_async_event is not None:
-            if self._tt_step_debug:
-                self._tt_debug(
-                    "execute_model waiting for previous async completion "
-                    "batch_before=%s",
-                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                )
             self._pending_async_event.wait()
             self._pending_async_event = None
-            if self._tt_step_debug:
-                self._tt_debug(
-                    "execute_model previous async completion observed "
-                    "batch_after=%s",
-                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                )
 
         # Update cached state and prepare model inputs
         model_input = self.build_model_input(scheduler_output)
@@ -1525,13 +1469,6 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         is_decode = model_input.prompt_lens is None
-        if self._tt_step_debug:
-            self._tt_debug(
-                "execute_model prepared mode=%s scheduled=%s batch=%s",
-                "decode" if is_decode else "prefill",
-                list(scheduler_output.num_scheduled_tokens.keys()),
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-            )
         if self.async_scheduling and is_decode:
             return self.submit_async_non_dp_decode(model_input)
 
@@ -1559,13 +1496,6 @@ class TTModelRunner:
         submission = self.submit_decode(
             model_input, read_from_device=False, async_read=True
         )
-        if self._tt_step_debug:
-            self._tt_debug(
-                "submit_async_non_dp_decode reqs=%s batch=%s reset_batch=%s",
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                model_input.reset_batch,
-            )
 
         if submission.tt_out is None:
             # No decode work was submitted to the device for this step
@@ -1944,20 +1874,8 @@ class TTModelRunner:
 
         # Execute model
         if not is_decode:
-            if self._tt_step_debug:
-                self._tt_debug(
-                    "execute_sync_with_model_input prefill reqs=%s prompt_lens=%s",
-                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                    model_input.prompt_lens,
-                )
             tt_out = self.submit_prefill(model_input, batch_size_per_dp)
         else:
-            if self._tt_step_debug:
-                self._tt_debug(
-                    "execute_sync_with_model_input decode reqs=%s reset_batch=%s",
-                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-                    model_input.reset_batch,
-                )
             submission = self.submit_decode(
                 model_input, read_from_device=False, async_read=False
             )
@@ -2333,14 +2251,6 @@ class TTModelRunner:
         # doesn't need to send them back.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
-        if self._tt_step_debug:
-            self._tt_debug(
-                "apply_and_build_runner_output use_captured=%s req_ids=%s "
-                "current_batch=%s",
-                use_captured_req_ids,
-                req_ids if req_ids is not None else list(self.input_batch.req_ids[:num_reqs]),
-                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
-            )
         # Queueing can delay consumption of ModelRunnerOutput until after the
         # persistent batch has been repacked for a newer step, so always
         # snapshot request identity instead of aliasing mutable input_batch

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -242,9 +242,7 @@ class AsyncTTDPGatherOutput(AsyncModelRunnerOutput):
             is_decode=True,
         )
 
-        return runner.pack_dp_results(
-            sampled_token_ids_per_dp, logprobs_per_dp
-        )
+        return runner.pack_dp_results(sampled_token_ids_per_dp, logprobs_per_dp)
 
 
 class TTModelRunner:
@@ -2318,7 +2316,9 @@ class TTModelRunner:
                 output_token_ids = self.input_batch.req_output_token_ids[req_idx]
                 assert output_token_ids is not None
             else:
-                output_token_ids = self.requests[output_req_ids[req_idx]].output_token_ids
+                output_token_ids = self.requests[
+                    output_req_ids[req_idx]
+                ].output_token_ids
             output_token_ids.append(int(sampled_token_ids_np[req_idx]))
 
         # Empty prompt log probs

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -172,6 +172,11 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
 
     def _get_output_impl(self) -> ModelRunnerOutput:
         runner = self._runner
+        runner._tt_debug(
+            "async_get_output start captured_reqs=%s current_batch=%s",
+            self._req_ids,
+            list(runner.input_batch.req_ids[: runner.input_batch.num_reqs]),
+        )
         finalized = runner.finalize_decode(self._submission)
         if finalized is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
@@ -190,12 +195,19 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
 
-        return runner.apply_and_build_runner_output(
+        output = runner.apply_and_build_runner_output(
             sampled_token_ids=sampled_token_ids,
             logprobs=logprobs,
             req_ids=self._req_ids,
             req_id_to_index=self._req_id_to_index,
         )
+        runner._tt_debug(
+            "async_get_output done captured_reqs=%s output_reqs=%s current_batch=%s",
+            self._req_ids,
+            list(output.req_ids),
+            list(runner.input_batch.req_ids[: runner.input_batch.num_reqs]),
+        )
+        return output
 
 
 class AsyncTTDPGatherOutput(AsyncModelRunnerOutput):
@@ -317,6 +329,7 @@ class TTModelRunner:
             self.scheduler_config.async_scheduling
             and self.parallel_config.data_parallel_size == 1
         )
+        self._tt_step_debug = os.environ.get("VLLM_TT_STEP_DEBUG") == "1"
         # Guards single in-flight async decode. Set when an async decode is
         # submitted; cleared when get_output() completes on the async thread.
         self._pending_async_event: threading.Event | None = None
@@ -336,6 +349,10 @@ class TTModelRunner:
             is_pooling_model=False,
             custom_logitsprocs=(self.model_config.logits_processors or ()),
         )
+
+    def _tt_debug(self, msg: str, *args: object) -> None:
+        if self._tt_step_debug:
+            logger.info("[TT_STEP_DEBUG][runner] " + msg, *args)
 
     def load_model(self) -> None:
         loader = TTModelLoader(self.load_config)
@@ -445,6 +462,13 @@ class TTModelRunner:
         Based on _update_states for GPU/TPU backends.
         """
         persistent_batch_layout_changed = False
+        if self._tt_step_debug:
+            self._tt_debug(
+                "_update_states start scheduled=%s current_batch=%s finished=%s",
+                list(scheduler_output.num_scheduled_tokens.keys()),
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                list(scheduler_output.finished_req_ids),
+            )
 
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
@@ -475,6 +499,11 @@ class TTModelRunner:
         scheduled_req_ids = scheduler_output.num_scheduled_tokens.keys()
         cached_req_ids = self.input_batch.req_id_to_index.keys()
         unscheduled_req_ids = cached_req_ids - scheduled_req_ids
+        if self._tt_step_debug and unscheduled_req_ids:
+            self._tt_debug(
+                "_update_states unscheduled=%s",
+                list(unscheduled_req_ids),
+            )
         # NOTE(woosuk): The persistent batch optimization assumes that
         # consecutive batches contain mostly the same requests. If batches
         # have low request overlap (e.g., alternating between two distinct
@@ -575,6 +604,12 @@ class TTModelRunner:
 
         # Refresh logits processors with batch state changes
         self.input_batch.refresh_logitsprocs()
+        if self._tt_step_debug:
+            self._tt_debug(
+                "_update_states done batch=%s decode_layout_changed=%s",
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                self._decode_layout_changed_since_last_decode,
+            )
 
     def _validate_mm_feature(self, mm_feature: MultiModalFeatureSpec) -> None:
         """Validate the multimodal feature is an image."""
@@ -914,10 +949,20 @@ class TTModelRunner:
         # Update cached state
         self._update_states(scheduler_output)
         if not scheduler_output.total_num_scheduled_tokens:
+            if self._tt_step_debug:
+                self._tt_debug("build_model_input empty scheduled batch")
             return None
 
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output)
+        if self._tt_step_debug:
+            self._tt_debug(
+                "build_model_input mode=%s reqs=%s prompt_lens=%s reset_batch=%s",
+                "prefill" if model_input.prompt_lens is not None else "decode",
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                model_input.prompt_lens,
+                model_input.reset_batch,
+            )
         return model_input
 
     def build_dp_decode_gather_input(
@@ -1459,8 +1504,20 @@ class TTModelRunner:
 
         # Wait for any in-flight async decode from the previous step.
         if self._pending_async_event is not None:
+            if self._tt_step_debug:
+                self._tt_debug(
+                    "execute_model waiting for previous async completion "
+                    "batch_before=%s",
+                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                )
             self._pending_async_event.wait()
             self._pending_async_event = None
+            if self._tt_step_debug:
+                self._tt_debug(
+                    "execute_model previous async completion observed "
+                    "batch_after=%s",
+                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                )
 
         # Update cached state and prepare model inputs
         model_input = self.build_model_input(scheduler_output)
@@ -1468,6 +1525,13 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
         is_decode = model_input.prompt_lens is None
+        if self._tt_step_debug:
+            self._tt_debug(
+                "execute_model prepared mode=%s scheduled=%s batch=%s",
+                "decode" if is_decode else "prefill",
+                list(scheduler_output.num_scheduled_tokens.keys()),
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+            )
         if self.async_scheduling and is_decode:
             return self.submit_async_non_dp_decode(model_input)
 
@@ -1495,6 +1559,13 @@ class TTModelRunner:
         submission = self.submit_decode(
             model_input, read_from_device=False, async_read=True
         )
+        if self._tt_step_debug:
+            self._tt_debug(
+                "submit_async_non_dp_decode reqs=%s batch=%s reset_batch=%s",
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                model_input.reset_batch,
+            )
 
         if submission.tt_out is None:
             # No decode work was submitted to the device for this step
@@ -1843,10 +1914,22 @@ class TTModelRunner:
 
         # Execute model
         if not is_decode:
+            if self._tt_step_debug:
+                self._tt_debug(
+                    "execute_sync_with_model_input prefill reqs=%s prompt_lens=%s",
+                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                    model_input.prompt_lens,
+                )
             tt_out = self.submit_prefill(model_input, batch_size_per_dp)
         else:
+            if self._tt_step_debug:
+                self._tt_debug(
+                    "execute_sync_with_model_input decode reqs=%s reset_batch=%s",
+                    list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+                    model_input.reset_batch,
+                )
             submission = self.submit_decode(
-                model_input, read_from_device=True, async_read=False
+                model_input, read_from_device=False, async_read=False
             )
             finalized = self.finalize_decode(submission)
             assert finalized is not None
@@ -2220,14 +2303,27 @@ class TTModelRunner:
         # doesn't need to send them back.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
-        # Async decode passes captured request state because input_batch may be
-        # updated before get_output runs. Sync callers can reuse the live
-        # input_batch references directly to avoid per-step copying.
-        output_req_ids = req_ids if req_ids is not None else self.input_batch.req_ids
+        if self._tt_step_debug:
+            self._tt_debug(
+                "apply_and_build_runner_output use_captured=%s req_ids=%s "
+                "current_batch=%s",
+                use_captured_req_ids,
+                req_ids if req_ids is not None else list(self.input_batch.req_ids[:num_reqs]),
+                list(self.input_batch.req_ids[: self.input_batch.num_reqs]),
+            )
+        # Queueing can delay consumption of ModelRunnerOutput until after the
+        # persistent batch has been repacked for a newer step, so always
+        # snapshot request identity instead of aliasing mutable input_batch
+        # state into the returned output.
+        output_req_ids = (
+            list(req_ids)
+            if req_ids is not None
+            else list(self.input_batch.req_ids[:num_reqs])
+        )
         output_req_id_to_index = (
-            req_id_to_index
+            dict(req_id_to_index)
             if req_id_to_index is not None
-            else self.input_batch.req_id_to_index
+            else {req_id: idx for idx, req_id in enumerate(output_req_ids)}
         )
         assert sampled_token_ids.shape[0] == num_reqs, (
             f"Number of request outputs {sampled_token_ids.shape[0]} != "

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -118,6 +118,7 @@ class TTDecodeSubmission:
 
     tt_out: Any | None
     read_events: list[Any] | None
+    defer_blocking_read: bool
     batch_size_per_dp: list[int]
     sampling_params: TTSamplingParams
     perform_device_sampling: bool
@@ -281,13 +282,21 @@ class TTModelRunner:
         self.enable_model_warmup = enable_model_warmup
         # Whether to sample on device
         self.sample_on_device_mode = TTPlatform.sample_on_device_mode
+        self.async_read_mode = os.getenv("VLLM_TT_ASYNC_READ_MODE", "event").strip().lower()
+        if self.async_read_mode not in {"event", "blocking_worker"}:
+            raise ValueError(
+                "VLLM_TT_ASYNC_READ_MODE must be 'event' or 'blocking_worker', "
+                f"got {self.async_read_mode!r}"
+            )
 
         logger.info(
             "TTModelRunner: trace_mode=%s, "
-            "sample_on_device_mode=%s, enable_model_warmup=%s",
+            "sample_on_device_mode=%s, enable_model_warmup=%s, "
+            "async_read_mode=%s",
             self.trace_mode,
             self.sample_on_device_mode,
             self.enable_model_warmup,
+            self.async_read_mode,
         )
 
         # mm_hash -> encoder_output
@@ -1493,8 +1502,10 @@ class TTModelRunner:
         """Submit non-DP decode work for async completion.
 
         Returns an `AsyncTTModelRunnerOutput` after issuing TT decode work and
-        async read submission. The wrapper carries the captured request
-        identity needed to build the final non-DP output on the async thread.
+        either async read submission (`event` mode) or deferred blocking
+        readback on the worker thread (`blocking_worker` mode). The wrapper
+        carries the captured request identity needed to build the final non-DP
+        output on the async thread.
         """
         event = threading.Event()
         submission = self.submit_decode(
@@ -1538,8 +1549,10 @@ class TTModelRunner:
         """Submit merged DP decode work for async completion.
 
         Returns an `AsyncTTDPGatherOutput` after issuing merged DP decode work
-        and async read submission. The wrapper later produces the packed
-        per-DP payload consumed by gathered-DP finalization.
+        and either async read submission (`event` mode) or deferred blocking
+        readback on the worker thread (`blocking_worker` mode). The wrapper
+        later produces the packed per-DP payload consumed by gathered-DP
+        finalization.
         """
         submission = self.submit_decode(
             model_input, read_from_device=False, async_read=True
@@ -1560,9 +1573,11 @@ class TTModelRunner:
     ) -> TTDecodeSubmission:
         """Submit decode work and return a normalized submission record.
 
-        Launches TT decode with either immediate readback or async read submit
-        and returns a normalized record consumed by sync and async completion
-        paths.
+        Launches TT decode and returns a normalized record consumed by sync and
+        async completion paths. In async mode, the readback strategy depends on
+        `VLLM_TT_ASYNC_READ_MODE`: `event` submits non-blocking reads on the
+        caller thread and later waits on events; `blocking_worker` defers the
+        blocking readback to `finalize_decode()` on the async worker thread.
         """
         batch_size_per_dp = model_input.unpadded_batch_size
         if not isinstance(batch_size_per_dp, list):
@@ -1574,6 +1589,7 @@ class TTModelRunner:
             return TTDecodeSubmission(
                 tt_out=None,
                 read_events=None,
+                defer_blocking_read=False,
                 batch_size_per_dp=batch_size_per_dp,
                 sampling_params=sampling_params,
                 perform_device_sampling=perform_device_sampling,
@@ -1631,7 +1647,8 @@ class TTModelRunner:
             read_from_device=read_from_device,
         )
         read_events = None
-        if async_read:
+        defer_blocking_read = False
+        if async_read and self.async_read_mode == "event":
             if hasattr(self.model, "read_decode_output"):
                 tt_out, read_events = cast(
                     tuple[Any, list[Any]],
@@ -1648,9 +1665,15 @@ class TTModelRunner:
                         "TT model must implement read_decode_output() "
                         "unless decode_forward() already returns host tensors"
                     )
+        elif async_read:
+            # Match the older async path from viktorpus/async-sched: hand off the
+            # raw TT decode result and let finalize_decode() perform a blocking
+            # read on the async worker thread.
+            defer_blocking_read = True
         return TTDecodeSubmission(
             tt_out=tt_out,
             read_events=read_events,
+            defer_blocking_read=defer_blocking_read,
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
@@ -1668,9 +1691,30 @@ class TTModelRunner:
         if submission.tt_out is None:
             return None
 
-        if submission.read_events is not None:
+        if submission.defer_blocking_read:
+            if hasattr(self.model, "read_decode_output"):
+                tt_out = self.model.read_decode_output(
+                    submission.tt_out, async_read=False
+                )
+            else:
+                raw_tt_out = submission.tt_out
+                is_host_tensor = isinstance(raw_tt_out, torch.Tensor)
+                is_host_tensor_tuple = isinstance(raw_tt_out, tuple) and all(
+                    tensor is None or isinstance(tensor, torch.Tensor)
+                    for tensor in raw_tt_out
+                )
+                if not (is_host_tensor or is_host_tensor_tuple):
+                    raise AttributeError(
+                        "TT model must implement read_decode_output() "
+                        "unless decode_forward() already returns host tensors"
+                    )
+                tt_out = raw_tt_out
+        elif submission.read_events is not None:
             for read_event in submission.read_events:
                 ttnn.event_synchronize(read_event)
+            tt_out = submission.tt_out
+        else:
+            tt_out = submission.tt_out
 
         # Real TT generator models expose `process_decode_output_host()` to
         # convert readback tensors into torch outputs. Keep compatibility with
@@ -1678,22 +1722,20 @@ class TTModelRunner:
         # not implement the newer hook.
         if hasattr(self.model, "process_decode_output_host"):
             tt_out = self.model.process_decode_output_host(
-                submission.tt_out,
+                tt_out,
                 is_tokens=submission.perform_device_sampling,
             )
         else:
-            raw_tt_out = submission.tt_out
-            is_host_tensor = isinstance(raw_tt_out, torch.Tensor)
-            is_host_tensor_tuple = isinstance(raw_tt_out, tuple) and all(
+            is_host_tensor = isinstance(tt_out, torch.Tensor)
+            is_host_tensor_tuple = isinstance(tt_out, tuple) and all(
                 tensor is None or isinstance(tensor, torch.Tensor)
-                for tensor in raw_tt_out
+                for tensor in tt_out
             )
             if not (is_host_tensor or is_host_tensor_tuple):
                 raise AttributeError(
                     "TT model must implement process_decode_output_host() "
                     "unless decode output is already a torch tensor"
                 )
-            tt_out = raw_tt_out
 
         tt_log_probs = None
         assert isinstance(submission.sampling_params.enable_log_probs, torch.Tensor)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1458,7 +1458,13 @@ class TTModelRunner:
         # With DP, the actual model pass happens on a batch
         # produced by concatenating the inputs from all DP ranks.
 
-        # Wait for any in-flight async decode from the previous step.
+        # Wait for any in-flight async decode from the previous step to finish
+        # writing its results (token_ids_cpu, num_tokens, output_token_ids) into
+        # input_batch and self.requests before _update_states (called inside
+        # build_model_input below) mutates those same structures.  This is the
+        # sole synchronisation point that prevents a data-race between the
+        # WorkerAsyncOutput thread and the main engine thread.  Do NOT move this
+        # wait after build_model_input.
         if self._pending_async_event is not None:
             self._pending_async_event.wait()
             self._pending_async_event = None
@@ -2277,6 +2283,20 @@ class TTModelRunner:
             sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
 
         # Vectorized update of persistent batch token storage.
+        #
+        # When called from the sync path (use_captured_req_ids=False) the
+        # positional ordering in input_batch matches the ordering used during
+        # build_model_input, so arange(num_reqs) is a valid row index.
+        #
+        # When called from the async path (use_captured_req_ids=True) this
+        # function runs on the WorkerAsyncOutput thread, but the wait on
+        # _pending_async_event in execute_model (see above) guarantees that
+        # _update_states for step N+1 cannot run until this function has
+        # returned and the completion event is set.  Therefore the positional
+        # indices here are still consistent with what was observed when
+        # build_model_input ran for this step.  This invariant must be
+        # preserved: never remove or move the _pending_async_event.wait()
+        # call without re-evaluating the safety of these positional writes.
         start_idxs = self.input_batch.num_tokens[:num_reqs]
         end_idxs = start_idxs + 1
         max_end = int(end_idxs.max()) if num_reqs > 0 else 0

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1726,10 +1726,28 @@ class TTModelRunner:
             for read_event in submission.read_events:
                 ttnn.event_synchronize(read_event)
 
-        tt_out = self.model.process_decode_output_host(
-            submission.tt_out,
-            is_tokens=submission.perform_device_sampling,
-        )
+        # Real TT generator models expose `process_decode_output_host()` to
+        # convert readback tensors into torch outputs. Keep compatibility with
+        # lightweight/no-op test models that already return host tensors and do
+        # not implement the newer hook.
+        if hasattr(self.model, "process_decode_output_host"):
+            tt_out = self.model.process_decode_output_host(
+                submission.tt_out,
+                is_tokens=submission.perform_device_sampling,
+            )
+        else:
+            raw_tt_out = submission.tt_out
+            is_host_tensor = isinstance(raw_tt_out, torch.Tensor)
+            is_host_tensor_tuple = isinstance(raw_tt_out, tuple) and all(
+                tensor is None or isinstance(tensor, torch.Tensor)
+                for tensor in raw_tt_out
+            )
+            if not (is_host_tensor or is_host_tensor_tuple):
+                raise AttributeError(
+                    "TT model must implement process_decode_output_host() "
+                    "unless decode output is already a torch tensor"
+                )
+            tt_out = raw_tt_out
 
         tt_log_probs = None
         assert isinstance(submission.sampling_params.enable_log_probs, torch.Tensor)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass, fields
 from typing import TYPE_CHECKING, Any, cast
 
@@ -22,6 +23,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
 from vllm.v1.outputs import (
     EMPTY_MODEL_RUNNER_OUTPUT,
+    AsyncModelRunnerOutput,
     LogprobsLists,
     LogprobsTensors,
     ModelRunnerOutput,
@@ -104,6 +106,93 @@ class TTModelInput:
     reset_batch: bool = False
 
 
+class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
+    """Wraps a non-blocking TT decode submission.
+
+    Returned by ``_execute_model_async_decode`` so that the executor can
+    defer the blocking device-sync / readback to a worker thread while the
+    main thread continues scheduling the next batch.
+
+    ``req_ids`` and ``req_id_to_index`` are captured at submit time because
+    ``input_batch`` may be overwritten by the next step before
+    ``get_output()`` runs.
+    """
+
+    def __init__(
+        self,
+        runner: "TTModelRunner",
+        tt_out: Any | None,
+        model_input: TTModelInput,
+        batch_size_per_dp: list[int],
+        sampling_params: TTSamplingParams,
+        perform_device_sampling: bool,
+        completion_event: threading.Event,
+        req_ids: list[str],
+        req_id_to_index: dict[str, int],
+    ):
+        self._runner = runner
+        self._tt_out = tt_out
+        self._model_input = model_input
+        self._batch_size_per_dp = batch_size_per_dp
+        self._sampling_params = sampling_params
+        self._perform_device_sampling = perform_device_sampling
+        self._completion_event = completion_event
+        self._req_ids = req_ids
+        self._req_id_to_index = req_id_to_index
+
+    def get_output(self) -> ModelRunnerOutput:
+        try:
+            return self._get_output_impl()
+        finally:
+            self._completion_event.set()
+
+    def _get_output_impl(self) -> ModelRunnerOutput:
+        runner = self._runner
+        tt_out_raw = self._tt_out
+
+        if tt_out_raw is None:
+            return EMPTY_MODEL_RUNNER_OUTPUT
+
+        tt_out = runner.model.sync_and_read_decode_output(
+            tt_out_raw,
+            is_tokens=self._perform_device_sampling,
+        )
+
+        tt_log_probs = None
+        assert isinstance(
+            self._sampling_params.enable_log_probs, torch.Tensor
+        )
+        if (
+            self._perform_device_sampling
+            and self._sampling_params.enable_log_probs.any()
+        ):
+            assert isinstance(tt_out, tuple) and len(tt_out) == 2
+            tt_out, tt_log_probs = tt_out
+        elif isinstance(tt_out, tuple):
+            tt_out, _ = tt_out
+
+        sampled_token_ids_per_dp, logprobs_per_dp = runner._get_output_tokens(
+            tt_out=tt_out,
+            tt_log_probs=tt_log_probs,
+            sampling_params=self._sampling_params,
+            model_input=self._model_input,
+            batch_size_per_dp=self._batch_size_per_dp,
+            perform_device_sampling=self._perform_device_sampling,
+            is_decode=True,
+        )
+
+        sampled_token_ids = sampled_token_ids_per_dp[0]
+        logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
+        logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
+
+        return runner.generate_runner_output_from_async(
+            req_ids=self._req_ids,
+            req_id_to_index=self._req_id_to_index,
+            sampled_token_ids=sampled_token_ids,
+            logprobs=logprobs,
+        )
+
+
 class TTModelRunner:
     def __init__(
         self,
@@ -168,6 +257,16 @@ class TTModelRunner:
         # change during prefill steps (e.g. new requests added), so we keep a
         # sticky flag and clear it only after a decode input consumes it.
         self._decode_layout_changed_since_last_decode: bool = True
+
+        # Async scheduling: overlap CPU scheduling with device execution.
+        # Only supported for DP=1 (DP>1 uses a different execution path).
+        self.async_scheduling = (
+            self.scheduler_config.async_scheduling
+            and self.parallel_config.data_parallel_size == 1
+        )
+        # Guards single in-flight async decode. Set when an async decode is
+        # submitted; cleared when get_output() completes on the async thread.
+        self._pending_async_event: threading.Event | None = None
 
         # Sampler for sampling on host when device sampling is not supported.
         # Only used by device ranks (local dp rank 0).
@@ -1293,20 +1392,35 @@ class TTModelRunner:
         self,
         scheduler_output: SchedulerOutput,
         intermediate_tensors: IntermediateTensors | None = None,
-    ) -> ModelRunnerOutput:
+    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
         """Execution path for non-DP case.
-        Execute the model with the given scheduler output."""
+        Execute the model with the given scheduler output.
+
+        When ``async_scheduling`` is enabled and the step is a decode,
+        returns ``AsyncTTModelRunnerOutput`` (the trace is submitted but
+        the device has not been synced yet).  The executor puts
+        ``get_output()`` on its async thread and returns a Future.
+        """
         # In the DP case, this function is skipped!
         # tt_worker.py directly calls execute_with_model_input
         # With DP, the actual model pass happens on a batch
         # produced by concatenating the inputs from all DP ranks.
+
+        # Wait for any in-flight async decode from the previous step.
+        if self._pending_async_event is not None:
+            self._pending_async_event.wait()
+            self._pending_async_event = None
 
         # Update cached state and prepare model inputs
         model_input = self.build_model_input(scheduler_output)
         if model_input is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
-        # Only 1 DP rank here
+        is_decode = model_input.prompt_lens is None
+        if self.async_scheduling and is_decode:
+            return self._execute_model_async_decode(model_input)
+
+        # Synchronous path (prefill, or decode without async scheduling)
         sampled_token_ids_per_dp, logprobs_per_dp = self.execute_with_model_input(  # noqa: E501
             model_input
         )
@@ -1315,6 +1429,111 @@ class TTModelRunner:
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
         output = self.generate_runner_output(sampled_token_ids, logprobs)
         return output
+
+    def _execute_model_async_decode(
+        self,
+        model_input: TTModelInput,
+    ) -> AsyncTTModelRunnerOutput:
+        """Submit a decode trace without blocking for device completion.
+
+        Mirrors the decode path of ``execute_with_model_input`` but passes
+        ``read_from_device=False`` so that ``decode_forward`` returns device
+        tensors immediately.  The actual sync + readback + sampling happens
+        later inside ``AsyncTTModelRunnerOutput.get_output()``.
+        """
+        event = threading.Event()
+
+        batch_size_per_dp = model_input.unpadded_batch_size
+        if not isinstance(batch_size_per_dp, list):
+            batch_size_per_dp = [batch_size_per_dp]
+
+        if not any(bs > 0 for bs in batch_size_per_dp):
+            event.set()
+            self._pending_async_event = event
+            num_reqs = self.input_batch.num_reqs
+            return AsyncTTModelRunnerOutput(
+                runner=self,
+                tt_out=None,
+                model_input=model_input,
+                batch_size_per_dp=batch_size_per_dp,
+                sampling_params=model_input.tt_sampling_params,
+                perform_device_sampling=model_input.perform_device_sampling,
+                completion_event=event,
+                req_ids=list(self.input_batch.req_ids[:num_reqs]),
+                req_id_to_index=dict(self.input_batch.req_id_to_index),
+            )
+
+        kwargs: dict[str, Any] = {
+            "tokens": model_input.input_tokens,
+            "page_table": model_input.block_tables,
+            "kv_cache": self.kv_caches,
+            "start_pos": model_input.input_positions,
+        }
+
+        sampling_params = model_input.tt_sampling_params
+        perform_device_sampling = model_input.perform_device_sampling
+        if perform_device_sampling:
+            sampling_param_dict = {
+                field.name: (
+                    getattr(sampling_params, field.name).tolist()
+                    if getattr(sampling_params, field.name) is not None
+                    else None
+                )
+                for field in fields(sampling_params)
+            }
+            sampling_param_dict["seed"] = [
+                None if s == SEED_NONE_SENTINEL else s
+                for s in sampling_param_dict["seed"]
+            ]
+            kwargs["sampling_params"] = TTSamplingParams(**sampling_param_dict)
+
+            if model_input.prompt_tokens is not None:
+                assert model_input.output_tokens is not None
+                kwargs["prompt_tokens"] = model_input.prompt_tokens
+                kwargs["output_tokens"] = model_input.output_tokens
+
+            kwargs["reset_batch"] = model_input.reset_batch
+
+        enc_dec_kwargs: dict[str, Any] = {}
+        if self.request_specific_rope:
+            if any(
+                req_id not in self.previous_req_ids
+                for req_id in self.input_batch.req_ids
+            ):
+                enc_dec_kwargs = {
+                    "rope_deltas_all_users": [
+                        self.requests[req_id].mrope_position_delta
+                        for req_id in self.input_batch.req_ids
+                    ]
+                }
+            else:
+                enc_dec_kwargs = {"rope_deltas_all_users": None}
+            self.previous_req_ids = set(self.input_batch.req_ids)
+
+        enable_trace = self.trace_mode in ["all", "decode_only"]
+        tt_out = self.model.decode_forward(
+            **kwargs,
+            **enc_dec_kwargs,
+            enable_trace=enable_trace,
+            read_from_device=False,
+        )
+
+        # Capture req_ids/req_id_to_index now - input_batch will be
+        # overwritten by the next step's build_model_input before
+        # get_output() runs on the async thread.
+        self._pending_async_event = event
+        num_reqs = self.input_batch.num_reqs
+        return AsyncTTModelRunnerOutput(
+            runner=self,
+            tt_out=tt_out,
+            model_input=model_input,
+            batch_size_per_dp=batch_size_per_dp,
+            sampling_params=sampling_params,
+            perform_device_sampling=perform_device_sampling,
+            completion_event=event,
+            req_ids=list(self.input_batch.req_ids[:num_reqs]),
+            req_id_to_index=dict(self.input_batch.req_id_to_index),
+        )
 
     def check_perform_device_sampling(
         self, is_decode: bool, has_structured_outputs: bool
@@ -1798,6 +2017,60 @@ class TTModelRunner:
         return ModelRunnerOutput(
             req_ids=self.input_batch.req_ids,
             req_id_to_index=self.input_batch.req_id_to_index,
+            sampled_token_ids=[
+                sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
+            ],
+            logprobs=logprobs,
+            prompt_logprobs_dict=prompt_logprobs_dict,
+            pooler_output=[],
+        )
+
+    def generate_runner_output_from_async(
+        self,
+        req_ids: list[str],
+        req_id_to_index: dict[str, int],
+        sampled_token_ids: torch.Tensor,
+        logprobs: LogprobsLists | None = None,
+    ) -> ModelRunnerOutput:
+        """Build ``ModelRunnerOutput`` for an async decode step.
+
+        Runs on the async output thread after device sync + sampling.
+        Updates ``self.input_batch`` (token_ids_cpu and num_tokens) so
+        that the next step's ``_prepare_model_inputs`` reads the correct
+        decode input token.  Thread-safe: ``_pending_async_event.wait()``
+        on the main thread guarantees this method completes before
+        ``build_model_input`` accesses ``input_batch``.
+
+        Uses *captured* ``req_ids`` / ``req_id_to_index`` for the
+        ``ModelRunnerOutput`` since those reflect the batch at submit time.
+        """
+        num_reqs = len(req_ids)
+        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        if sampled_token_ids_np.dtype != np.int32:
+            sampled_token_ids_np = sampled_token_ids_np.astype(
+                np.int32, copy=False
+            )
+
+        # Write the sampled token into persistent batch token storage so
+        # that _prepare_model_inputs reads it as the next decode input.
+        start_idxs = self.input_batch.num_tokens[:num_reqs]
+        end_idxs = start_idxs + 1
+        rows = np.arange(num_reqs)
+        self.input_batch.token_ids_cpu[rows, start_idxs] = sampled_token_ids_np
+        self.input_batch.num_tokens[:num_reqs] = end_idxs
+
+        for req_idx in range(num_reqs):
+            req_id = req_ids[req_idx]
+            output_token_ids = self.requests[req_id].output_token_ids
+            output_token_ids.append(int(sampled_token_ids_np[req_idx]))
+
+        prompt_logprobs_dict: dict[str, LogprobsTensors | None] = (
+            dict.fromkeys(req_ids, None)
+        )
+
+        return ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
             sampled_token_ids=[
                 sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
             ],

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1971,6 +1971,11 @@ class TTModelRunner:
         # Cache the sampled tokens in the model runner, so that the scheduler
         # doesn't need to send them back.
         num_reqs = self.input_batch.num_reqs
+        # Snapshot request mapping for this step. The batch queue may allow a
+        # later step to run and mutate input_batch before EngineCore consumes
+        # this ModelRunnerOutput.
+        req_ids = list(self.input_batch.req_ids[:num_reqs])
+        req_id_to_index = dict(self.input_batch.req_id_to_index)
         assert sampled_token_ids.shape[0] == num_reqs, (
             f"Number of request outputs {sampled_token_ids.shape[0]} != "
             f"number of requests in input batch {num_reqs}"
@@ -2008,13 +2013,13 @@ class TTModelRunner:
 
         # Empty prompt log probs
         prompt_logprobs_dict: dict[str, LogprobsTensors | None] = dict.fromkeys(
-            self.input_batch.req_ids[:num_reqs], None
+            req_ids, None
         )
 
         # Note: currently does not support speculative decoding or pooling.
         return ModelRunnerOutput(
-            req_ids=self.input_batch.req_ids,
-            req_id_to_index=self.input_batch.req_id_to_index,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
             sampled_token_ids=[
                 sampled_token_ids_np[i : i + 1] for i in range(num_reqs)
             ],

--- a/vllm/v1/worker/tt_worker.py
+++ b/vllm/v1/worker/tt_worker.py
@@ -210,6 +210,11 @@ class TTWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | None:
+        """Expose the non-DP TT execution service to the executor layer.
+
+        Returns the runner's non-DP execution result for the provided
+        scheduler output.
+        """
         assert self.is_driver_worker, "There should only be one Worker for TT"
         output = self.model_runner.execute_model(scheduler_output)
         return output
@@ -222,36 +227,23 @@ class TTWorker(WorkerBase):
 
     def build_dp_model_input(
         self, scheduler_output: Optional["SchedulerOutput"]
-    ) -> tuple[TTModelInput | None, int, int, int, int, int, int]:
-        """Called by each DP rank to build model input from scheduler output.
-        Returns: (model_input, max_blocks, has_structured_input, has_penalties,
-        reset_batch, can_sample_device, needs_logprobs)
+    ) -> tuple[
+        TTModelInput | None,
+        int,
+        int,
+        int,
+        int,
+        int,
+        int,
+        list[str],
+        dict[str, int],
+    ]:
+        """Build the local DP payload consumed by gathered-DP orchestration.
+
+        Returns the local TT input and the per-rank metadata required by
+        gathered-DP orchestration in `core.py`.
         """
-        model_input = None
-        has_penalties = 0
-        reset_batch = 0
-        can_sample_device = 1
-        needs_logprobs = 0
-        if scheduler_output is not None:
-            model_input = self.model_runner.build_model_input(scheduler_output)
-            if model_input is not None:
-                has_penalties = int(not self.model_runner.input_batch.no_penalties)
-                reset_batch = int(model_input.reset_batch)
-                can_sample_device = int(model_input.perform_device_sampling)
-                needs_logprobs = int(model_input.max_num_logprobs[0] > 0)
-        max_blocks = model_input.block_tables.shape[1] if model_input else 0
-        has_structured_input = (
-            int(model_input.grammar_bitmask[0] is not None) if model_input else 0
-        )
-        return (
-            model_input,
-            max_blocks,
-            has_structured_input,
-            has_penalties,
-            reset_batch,
-            can_sample_device,
-            needs_logprobs,
-        )
+        return self.model_runner.prepare_dp_model_input(scheduler_output)
 
     def build_dp_decode_gather_input(
         self,
@@ -260,6 +252,11 @@ class TTWorker(WorkerBase):
         any_structured_inputs: bool,
         any_penalties_inputs: bool,
     ) -> dict[str, Any]:
+        """Prepare the fixed-shape decode gather payload for DP orchestration.
+
+        Returns the fixed-shape decode gather payload used by gathered-DP
+        orchestration.
+        """
         return self.model_runner.build_dp_decode_gather_input(
             model_input,
             max_blocks_decode_batch,
@@ -273,75 +270,55 @@ class TTWorker(WorkerBase):
         is_decode: bool,
         max_blocks_decode_batch: int | None,
         any_structured_inputs: bool,
-    ) -> tuple[torch.Tensor, list]:
-        """Called by TT device ranks (local DP rank 0) to concatenate DP-sized
-        inputs and execute. Returns a tuple of:
-        - stacked tensor [world, max_num_seqs, 1] of sampled ids
-        - list of logprobs per DP rank (as picklable lists, or None)
-        Each DP slice is right-padded with zeros to max_num_seqs; empty entries
-        are zeros. Same behavior for both prefill and decode."""
+        non_block: bool = False,
+    ) -> Any:
+        """Execute one merged DP batch through the worker facade.
 
-        assert self.parallel_config.data_parallel_rank_local == 0, (
-            "concat_and_execute_dp must run on local DP rank 0 (device rank)"
-        )
+        Returns either the packed DP execution result or an async DP decode
+        wrapper for the merged batch. The worker also enforces the "device rank
+        0 only" rule for merged TT execution.
+        """
         assert self.is_driver_worker, "concat_and_execute_dp must run on driver"
-        merged = self.model_runner.concat_dp_model_inputs(
-            inputs, is_decode, max_blocks_decode_batch, any_structured_inputs
-        )
-        sampled_token_ids_per_dp, logprobs_per_dp = (
-            self.model_runner.execute_with_model_input(merged)
+
+        local_dp_rank = self.parallel_config.data_parallel_rank_local
+        if local_dp_rank != 0:
+            return self._empty_dp_execute_result()
+
+        return self.model_runner.submit_dp_execution(
+            inputs,
+            is_decode,
+            max_blocks_decode_batch,
+            any_structured_inputs,
+            non_block=non_block,
         )
 
-        # Convert LogprobsTensors to picklable lists for scatter
-        logprobs_lists_per_dp = [
-            lp.tolists() if lp is not None else None for lp in logprobs_per_dp
-        ]
+    def _empty_dp_execute_result(self) -> tuple[torch.Tensor, list]:
+        """Return the neutral DP payload for non-device local ranks.
 
-        # Pad each DP result to uniform shape for tensor all_gather.
+        Produces the correctly shaped no-op DP payload for colocated ranks that
+        do not execute the merged TT batch.
+        """
         world = self.parallel_config.data_parallel_size
-        assert len(sampled_token_ids_per_dp) == world
-        B = int(self.model_runner.scheduler_config.max_num_seqs)
-        for dp_rank in range(world):
-            token_ids = sampled_token_ids_per_dp[dp_rank].to(torch.int32)
-            if token_ids.numel() == 0:
-                token_ids = torch.zeros((B, 1), dtype=torch.int32)
-            else:
-                assert token_ids.dim() == 2 and token_ids.shape[1] == 1, (
-                    "Currently only supporting 1 output token per request"
-                )
-                pad_rows = B - token_ids.shape[0]
-                if pad_rows > 0:
-                    token_ids = torch.cat(
-                        [
-                            token_ids,
-                            torch.zeros(
-                                (pad_rows, token_ids.shape[1]), dtype=torch.int32
-                            ),
-                        ],
-                        dim=0,
-                    )
-            sampled_token_ids_per_dp[dp_rank] = token_ids
-        return torch.stack(
-            sampled_token_ids_per_dp
-        ), logprobs_lists_per_dp  # [world, B, 1], [world]
+        batch_size = int(self.model_runner.scheduler_config.max_num_seqs)
+        return torch.zeros((world, batch_size, 1), dtype=torch.int32), [None] * world
 
     def apply_dp_execution_result(
         self,
         sampled_token_ids: torch.Tensor,
         logprobs_lists: Optional["LogprobsLists"] = None,
+        req_ids: list[str] | None = None,
+        req_id_to_index: dict[str, int] | None = None,
     ) -> ModelRunnerOutput:
-        """Called by each DP rank to apply sampled tokens to internal caches.
+        """Apply the local DP rank result through the worker facade.
 
-        Args:
-            sampled_token_ids: Sampled token IDs for this DP rank.
-            logprobs_lists: Logprobs as lists (already converted from tensors)
-                for this DP rank, or None if not requested.
+        Applies the local DP rank result and returns the corresponding
+        `ModelRunnerOutput`.
         """
-        # Trim to active local batch size to drop padding rows.
-        num_reqs = self.model_runner.input_batch.num_reqs
-        sampled_token_ids = sampled_token_ids[:num_reqs]
-        return self.model_runner.generate_runner_output(
-            sampled_token_ids, logprobs_lists
+        return self.model_runner.apply_dp_execution_result(
+            sampled_token_ids,
+            logprobs_lists,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
         )
 
     # ---- Destructor (used to close devices) ----


### PR DESCRIPTION
# Purpose

Reduce ITL by overlapping CPU and device work. Specifically, VLLM's AsyncScheduler is able to run on step N+1 even before step N has finished. And while N+1 is running on device, AsyncScheduler is able to accept the results from step N.

Issue: https://github.com/tenstorrent/vllm/issues/339
Related tt-metal PR: https://github.com/tenstorrent/tt-metal/pull/40032

# Test Plan
Performance: TBD tests to run
Conformance: VLLM CI: https://github.com/tenstorrent/tt-metal/actions/runs/23197506122

# Test Setup
Server cmd:
TBD

Bench cmd:
TBD

# 
Test results

TBD

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

