### PR TITLE
Add top-K logprobs support

### DIFF
--- a/tests/tt/test_build_logprobs_from_topk.py
+++ b/tests/tt/test_build_logprobs_from_topk.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for _build_logprobs_from_topk helper in tt_model_runner.
+
+These tests use synthetic data only (no device required) to verify
+that the helper correctly packs top-K logprobs into LogprobsTensors
+for the downstream vLLM pipeline.
+"""
+
+import pytest
+import torch
+
+from vllm.v1.worker.tt_model_runner import _build_logprobs_from_topk
+
+
+class TestBuildLogprobsFromTopk:
+    """Tests for _build_logprobs_from_topk."""
+
+    def _make_sorted_topk(self, sz: int, k: int = 32):
+        """Create synthetic sorted top-K data.
+
+        Returns (top_k_logprobs[sz, k], top_k_indices[sz, k])
+        where logprobs are sorted descending per row.
+        """
+        # Generate sorted descending logprobs
+        logprobs = torch.sort(
+            torch.randn(sz, k), dim=-1, descending=True
+        ).values
+        # Generate unique token indices per row
+        indices = torch.stack([
+            torch.randperm(10000)[:k] for _ in range(sz)
+        ])
+        return logprobs, indices.to(torch.int32)
+
+    def test_basic_shape(self):
+        """Output shape is [sz, max_num_logprobs + 1]."""
+        sz, N = 4, 5
+        logprobs, indices = self._make_sorted_topk(sz)
+        sampled = indices[:, 0]  # sampled = top-1 token
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, N)
+
+        assert result.logprob_token_ids.shape == (sz, N + 1)
+        assert result.logprobs.shape == (sz, N + 1)
+        assert result.selected_token_ranks.shape == (sz,)
+
+    def test_sampled_token_at_col0(self):
+        """Column 0 always contains the sampled token ID and logprob."""
+        sz = 8
+        logprobs, indices = self._make_sorted_topk(sz)
+        # Sampled token is at rank 3 in the sorted list
+        sampled = indices[:, 3].clone()
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 5)
+
+        assert torch.equal(result.logprob_token_ids[:, 0], sampled)
+        expected_lps = logprobs[:, 3]
+        assert torch.allclose(
+            result.logprobs[:, 0], expected_lps, atol=1e-6
+        )
+
+    def test_top_n_at_cols_1_to_n(self):
+        """Columns 1..N contain top-N tokens from sorted list."""
+        sz, N = 4, 5
+        logprobs, indices = self._make_sorted_topk(sz)
+        sampled = indices[:, 0]
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, N)
+
+        assert torch.equal(
+            result.logprob_token_ids[:, 1:N + 1],
+            indices[:, :N].to(torch.int32),
+        )
+        assert torch.allclose(
+            result.logprobs[:, 1:N + 1],
+            logprobs[:, :N].to(torch.float32),
+            atol=1e-6,
+        )
+
+    def test_selected_token_ranks(self):
+        """selected_token_ranks matches the sampled token's position."""
+        sz = 4
+        logprobs, indices = self._make_sorted_topk(sz)
+
+        for rank in [0, 1, 5, 31]:
+            sampled = indices[:, rank].clone()
+            result = _build_logprobs_from_topk(logprobs, indices, sampled, 5)
+            assert torch.all(result.selected_token_ranks == rank)
+
+    def test_sampled_at_rank0(self):
+        """Edge case: sampled token is the most likely (rank 0)."""
+        sz = 4
+        logprobs, indices = self._make_sorted_topk(sz)
+        sampled = indices[:, 0]
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 10)
+
+        assert torch.all(result.selected_token_ranks == 0)
+        assert torch.equal(result.logprob_token_ids[:, 0], sampled)
+
+    def test_max_num_logprobs_zero(self):
+        """max_num_logprobs=0 → shape [sz, 1] (sampled token only)."""
+        sz = 4
+        logprobs, indices = self._make_sorted_topk(sz)
+        sampled = indices[:, 2]
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 0)
+
+        assert result.logprob_token_ids.shape == (sz, 1)
+        assert result.logprobs.shape == (sz, 1)
+        assert torch.equal(result.logprob_token_ids[:, 0], sampled)
+
+    def test_max_num_logprobs_exceeds_k(self):
+        """max_num_logprobs > 32 is clamped to 32."""
+        sz = 4
+        logprobs, indices = self._make_sorted_topk(sz, k=32)
+        sampled = indices[:, 0]
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 100)
+
+        # N = min(100, 32) = 32
+        assert result.logprob_token_ids.shape == (sz, 33)
+
+    def test_dtypes(self):
+        """Output dtypes match LogprobsTensors contract."""
+        logprobs, indices = self._make_sorted_topk(4)
+        sampled = indices[:, 0]
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 5)
+
+        assert result.logprob_token_ids.dtype == torch.int32
+        assert result.logprobs.dtype == torch.float32
+        assert result.selected_token_ranks.dtype == torch.int32
+
+    def test_per_user_different_sampled(self):
+        """Each user can have a different sampled token at different ranks."""
+        sz = 4
+        logprobs, indices = self._make_sorted_topk(sz)
+        # User 0 sampled rank 0, user 1 rank 5, user 2 rank 31, user 3 rank 2
+        ranks = [0, 5, 31, 2]
+        sampled = torch.tensor([
+            indices[i, r].item() for i, r in enumerate(ranks)
+        ], dtype=torch.int32)
+
+        result = _build_logprobs_from_topk(logprobs, indices, sampled, 10)
+
+        for i, r in enumerate(ranks):
+            assert result.selected_token_ranks[i].item() == r
+            assert result.logprob_token_ids[i, 0].item() == sampled[i].item()

--- a/tests/tt/test_build_logprobs_from_topk.py
+++ b/tests/tt/test_build_logprobs_from_topk.py
@@ -110,15 +110,15 @@ class TestBuildLogprobsFromTopk:
         assert torch.equal(result.logprob_token_ids[:, 0], sampled)
 
     def test_max_num_logprobs_exceeds_k(self):
-        """max_num_logprobs > 32 is clamped to 32."""
+        """max_num_logprobs > 20 is clamped to MAX_LOGPROBS (20)."""
         sz = 4
         logprobs, indices = self._make_sorted_topk(sz, k=32)
         sampled = indices[:, 0]
 
         result = _build_logprobs_from_topk(logprobs, indices, sampled, 100)
 
-        # N = min(100, 32) = 32
-        assert result.logprob_token_ids.shape == (sz, 33)
+        # N = min(100, 20) = 20
+        assert result.logprob_token_ids.shape == (sz, 21)
 
     def test_dtypes(self):
         """Output dtypes match LogprobsTensors contract."""

--- a/tests/tt/test_build_logprobs_from_topk.py
+++ b/tests/tt/test_build_logprobs_from_topk.py
@@ -103,17 +103,6 @@ class TestBuildLogprobsFromTopk:
         assert result.logprobs.shape == (sz, 1)
         assert torch.equal(result.logprob_token_ids[:, 0], sampled)
 
-    def test_max_num_logprobs_exceeds_k(self):
-        """max_num_logprobs > 20 is clamped to MAX_LOGPROBS (20)."""
-        sz = 4
-        logprobs, indices = self._make_sorted_topk(sz, k=32)
-        sampled = indices[:, 0]
-
-        result = _build_logprobs_from_topk(logprobs, indices, sampled, 100)
-
-        # N = min(100, 20) = 20
-        assert result.logprob_token_ids.shape == (sz, 21)
-
     def test_dtypes(self):
         """Output dtypes match LogprobsTensors contract."""
         logprobs, indices = self._make_sorted_topk(4)

--- a/tests/tt/test_build_logprobs_from_topk.py
+++ b/tests/tt/test_build_logprobs_from_topk.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for _build_logprobs_from_topk helper in tt_model_runner.
 
 These tests use synthetic data only (no device required) to verify
@@ -6,7 +7,6 @@ that the helper correctly packs top-K logprobs into LogprobsTensors
 for the downstream vLLM pipeline.
 """
 
-import pytest
 import torch
 
 from vllm.v1.worker.tt_model_runner import _build_logprobs_from_topk
@@ -22,13 +22,9 @@ class TestBuildLogprobsFromTopk:
         where logprobs are sorted descending per row.
         """
         # Generate sorted descending logprobs
-        logprobs = torch.sort(
-            torch.randn(sz, k), dim=-1, descending=True
-        ).values
+        logprobs = torch.sort(torch.randn(sz, k), dim=-1, descending=True).values
         # Generate unique token indices per row
-        indices = torch.stack([
-            torch.randperm(10000)[:k] for _ in range(sz)
-        ])
+        indices = torch.stack([torch.randperm(10000)[:k] for _ in range(sz)])
         return logprobs, indices.to(torch.int32)
 
     def test_basic_shape(self):
@@ -54,9 +50,7 @@ class TestBuildLogprobsFromTopk:
 
         assert torch.equal(result.logprob_token_ids[:, 0], sampled)
         expected_lps = logprobs[:, 3]
-        assert torch.allclose(
-            result.logprobs[:, 0], expected_lps, atol=1e-6
-        )
+        assert torch.allclose(result.logprobs[:, 0], expected_lps, atol=1e-6)
 
     def test_top_n_at_cols_1_to_n(self):
         """Columns 1..N contain top-N tokens from sorted list."""
@@ -67,11 +61,11 @@ class TestBuildLogprobsFromTopk:
         result = _build_logprobs_from_topk(logprobs, indices, sampled, N)
 
         assert torch.equal(
-            result.logprob_token_ids[:, 1:N + 1],
+            result.logprob_token_ids[:, 1 : N + 1],
             indices[:, :N].to(torch.int32),
         )
         assert torch.allclose(
-            result.logprobs[:, 1:N + 1],
+            result.logprobs[:, 1 : N + 1],
             logprobs[:, :N].to(torch.float32),
             atol=1e-6,
         )
@@ -137,9 +131,9 @@ class TestBuildLogprobsFromTopk:
         logprobs, indices = self._make_sorted_topk(sz)
         # User 0 sampled rank 0, user 1 rank 5, user 2 rank 31, user 3 rank 2
         ranks = [0, 5, 31, 2]
-        sampled = torch.tensor([
-            indices[i, r].item() for i, r in enumerate(ranks)
-        ], dtype=torch.int32)
+        sampled = torch.tensor(
+            [indices[i, r].item() for i, r in enumerate(ranks)], dtype=torch.int32
+        )
 
         result = _build_logprobs_from_topk(logprobs, indices, sampled, 10)
 

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -239,6 +239,22 @@ class TTPlatform(Platform):
         ), "TT backend does not support distributed execution"
         assert not vllm_config.lora_config, "LoRA is not supported for TT backend"
 
+        # Device computes top-32 logprobs but the OpenAI API limits to 20
+        # (ModelConfig.max_logprobs default). Clamp max_logprobs so that
+        # processor._validate_logprobs rejects requests exceeding this limit.
+        from vllm.config import ModelConfig
+
+        tt_max_logprobs = ModelConfig.max_logprobs  # default 20
+        model_config = vllm_config.model_config
+        if model_config.max_logprobs > tt_max_logprobs:
+            logger.warning(
+                "max_logprobs=%d exceeds TT device limit of %d, clamping to %d",
+                model_config.max_logprobs,
+                tt_max_logprobs,
+                tt_max_logprobs,
+            )
+            model_config.max_logprobs = tt_max_logprobs
+
         # Import and register models from tt-metal.
         #
         # NOTE: We also register TT models early in `vllm/v1/worker/tt_worker.py`

--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -240,20 +240,17 @@ class TTPlatform(Platform):
         assert not vllm_config.lora_config, "LoRA is not supported for TT backend"
 
         # Device computes top-32 logprobs but the OpenAI API limits to 20
-        # (ModelConfig.max_logprobs default). Clamp max_logprobs so that
-        # processor._validate_logprobs rejects requests exceeding this limit.
-        from vllm.config import ModelConfig
+        MAX_TOP_K = 20
 
-        tt_max_logprobs = ModelConfig.max_logprobs  # default 20
         model_config = vllm_config.model_config
-        if model_config.max_logprobs > tt_max_logprobs:
+        if model_config.max_logprobs > MAX_TOP_K:
             logger.warning(
                 "max_logprobs=%d exceeds TT device limit of %d, clamping to %d",
                 model_config.max_logprobs,
-                tt_max_logprobs,
-                tt_max_logprobs,
+                MAX_TOP_K,
+                MAX_TOP_K,
             )
-            model_config.max_logprobs = tt_max_logprobs
+            model_config.max_logprobs = MAX_TOP_K
 
         # Import and register models from tt-metal.
         #

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -44,6 +44,8 @@ logger = init_logger(__name__)
 
 # Maximum top_k value for on-device sampling
 MAX_K = 32
+# OpenAI API limit, matches vllm ModelConfig.max_logprobs
+MAX_LOGPROBS = 20
 
 
 def _build_logprobs_from_topk(
@@ -54,22 +56,23 @@ def _build_logprobs_from_topk(
 ) -> LogprobsTensors:
     """Build LogprobsTensors from device top-K logprobs.
 
-    Device returns top-32 logprobs already sorted descending.
-    This function packs them into the LogprobsTensors format expected
-    by the downstream vLLM pipeline.
+    Device always computes top-32 (MAX_K) logprobs sorted descending.
+    This function trims to min(max_num_logprobs, MAX_LOGPROBS=20) to
+    match the OpenAI API limit, then packs into LogprobsTensors format
+    expected by the downstream vLLM pipeline.
 
     Args:
         top_k_logprobs: [sz, 32] sorted descending logprobs from device.
         top_k_indices: [sz, 32] corresponding token IDs, same order.
         sampled_token_ids: [sz, 1] or [sz] sampled token IDs.
-        max_num_logprobs: max top_logprobs requested across batch.
+        max_num_logprobs: max top_logprobs requested across batch (clamped to 20).
 
     Returns:
-        LogprobsTensors with shape [sz, N+1] where N = min(max_num_logprobs, 32).
+        LogprobsTensors with shape [sz, N+1] where N = min(max_num_logprobs, 20).
         Column 0 = sampled token, columns 1..N = top-N from sorted list.
     """
     sz = top_k_logprobs.shape[0]
-    N = min(max_num_logprobs, MAX_K)
+    N = min(max_num_logprobs, MAX_LOGPROBS)
 
     # Find sampled token rank in the already-sorted top-32
     # Cast both to int64 to avoid uint32/int32 promotion error

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -78,10 +78,11 @@ def _build_logprobs_from_topk(
     if sampled_token_ids.dim() == 1:
         sampled_token_ids = sampled_token_ids.unsqueeze(-1)
     sampled_expanded = sampled_token_ids.to(torch.int64)
-    # The sampled token is guaranteed to be in top-32 because ttnn.sampling
-    # selects from the same top-K candidates returned here. If this constraint
-    # changes (e.g., top-K is reduced), match_mask may be all-False and
-    # argmax will return 0, giving an incorrect rank and logprob.
+    # The sampled token is guaranteed to be in top-32 because ttnn.sampling selects
+    # from the same top-32 (hardcoded in ttnn.sampling no matter the value of k)
+    # candidates returned here. If this constraint changes in ttnn.sampling to
+    # more than 32 candidates, match_mask may be all-False and argmax
+    # will return 0, giving an incorrect rank and logprob.
     match_mask = top_k_indices.to(torch.int64) == sampled_expanded
     # Convert mask to int since older versions of PyTorch don't support bool argmax.
     ranks = match_mask.int().argmax(dim=-1)
@@ -877,7 +878,7 @@ class TTModelRunner:
             seed = sampling_default_tensors["seed"]
             # enable_log_probs: convert num_logprobs >= 0
             enable_log_probs = sampling_default_tensors["num_logprobs"] >= 0
-            max_num_logprobs_val = 0
+            max_num_logprobs_val = -2  # -2 means no logprobs
         else:
             tokens = model_input.input_tokens
             positions = model_input.input_positions
@@ -906,7 +907,9 @@ class TTModelRunner:
             repetition_penalty = sampling_params.repetition_penalty
             seed = sampling_params.seed
             enable_log_probs = sampling_params.enable_log_probs
-            max_num_logprobs_val = model_input.max_num_logprobs[0] or 0
+            max_num_logprobs_val = (
+                model_input.max_num_logprobs[0] or -2
+            )  # -2 means no logprobs
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
         int_inputs = torch.cat(

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -61,7 +61,7 @@ def _build_logprobs_from_topk(
     Args:
         top_k_logprobs: [sz, 32] sorted descending logprobs from device.
         top_k_indices: [sz, 32] corresponding token IDs, same order.
-        sampled_token_ids: [sz] sampled token IDs.
+        sampled_token_ids: [sz, 1] or [sz] sampled token IDs.
         max_num_logprobs: max top_logprobs requested across batch.
 
     Returns:
@@ -72,25 +72,30 @@ def _build_logprobs_from_topk(
     N = min(max_num_logprobs, MAX_K)
 
     # Find sampled token rank in the already-sorted top-32
-    sampled_expanded = sampled_token_ids.unsqueeze(-1)
-    match_mask = (top_k_indices == sampled_expanded)
+    # Cast both to int64 to avoid uint32/int32 promotion error
+    # sampled_token_ids is [sz, 1], top_k_indices is [sz, 32] — broadcasts directly
+    if sampled_token_ids.dim() == 1:
+        sampled_token_ids = sampled_token_ids.unsqueeze(-1)
+    sampled_expanded = sampled_token_ids.to(torch.int64)
+    match_mask = (top_k_indices.to(torch.int64) == sampled_expanded)
     ranks = match_mask.float().argmax(dim=-1)
 
+    if ranks.dim() < top_k_logprobs.dim():
+        ranks = ranks.unsqueeze(-1)
     # Extract sampled token logprob
     sampled_logprob = top_k_logprobs.gather(
-        1, ranks.unsqueeze(-1).long()
+        1, ranks.long()
     )
-
     # Build output: col 0 = sampled, cols 1..N = top-N from sorted
     logprob_token_ids = torch.zeros(sz, N + 1, dtype=torch.int32)
     logprobs_values = torch.zeros(sz, N + 1, dtype=torch.float32)
 
-    logprob_token_ids[:, 0] = sampled_token_ids
+    logprob_token_ids[:, 0] = sampled_token_ids.squeeze(-1)
     logprobs_values[:, 0] = sampled_logprob.squeeze(-1)
     logprob_token_ids[:, 1:N + 1] = top_k_indices[:, :N].to(torch.int32)
     logprobs_values[:, 1:N + 1] = top_k_logprobs[:, :N].to(torch.float32)
 
-    selected_token_ranks = ranks.to(torch.int32)
+    selected_token_ranks = ranks.squeeze(-1).to(torch.int32)
 
     return LogprobsTensors(logprob_token_ids, logprobs_values,
                            selected_token_ranks)
@@ -111,6 +116,7 @@ class TTSamplingParams:
     repetition_penalty: torch.Tensor | list[float] | float = 1.0
     seed: torch.Tensor | list[int | None] | int = 0
     enable_log_probs: torch.Tensor | list[bool] | None = None
+    num_logprobs: torch.Tensor | list[int] | int = None
 
 
 @dataclass(frozen=True)
@@ -1469,14 +1475,15 @@ class TTModelRunner:
         if perform_device_sampling:
             # On-device sampling currently needs sampling param attributes to
             # be lists instead of tensors.
-            sampling_param_dict = {
-                field.name: (
-                    getattr(sampling_params, field.name).tolist()
-                    if getattr(sampling_params, field.name) is not None
-                    else None
-                )
-                for field in fields(sampling_params)
-            }
+            sampling_param_dict = {}
+            for field in fields(sampling_params):
+                val = getattr(sampling_params, field.name)
+                if val is None:
+                    sampling_param_dict[field.name] = None
+                elif hasattr(val, "tolist"):
+                    sampling_param_dict[field.name] = val.tolist()
+                else:
+                    sampling_param_dict[field.name] = val
             # Convert seed sentinel value back to None
             # (vLLM treats -1 as equivalent to None for seeds)
             sampling_param_dict["seed"] = [
@@ -1724,7 +1731,7 @@ class TTModelRunner:
                 logprobs_per_dp.append(sampler_output.logprobs_tensors)
             else:  # sample on device
                 next_token_ids = tt_out[start : start + sz]
-
+                rank_max_num_logprobs = model_input.max_num_logprobs[dp_rank]
                 # Extract logprobs if available from device sampling
                 # Always tensors - turned into lists only when passing to model
                 assert isinstance(sampling_params.enable_log_probs, torch.Tensor)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -46,6 +46,56 @@ logger = init_logger(__name__)
 MAX_K = 32
 
 
+def _build_logprobs_from_topk(
+    top_k_logprobs: torch.Tensor,
+    top_k_indices: torch.Tensor,
+    sampled_token_ids: torch.Tensor,
+    max_num_logprobs: int,
+) -> LogprobsTensors:
+    """Build LogprobsTensors from device top-K logprobs.
+
+    Device returns top-32 logprobs already sorted descending.
+    This function packs them into the LogprobsTensors format expected
+    by the downstream vLLM pipeline.
+
+    Args:
+        top_k_logprobs: [sz, 32] sorted descending logprobs from device.
+        top_k_indices: [sz, 32] corresponding token IDs, same order.
+        sampled_token_ids: [sz] sampled token IDs.
+        max_num_logprobs: max top_logprobs requested across batch.
+
+    Returns:
+        LogprobsTensors with shape [sz, N+1] where N = min(max_num_logprobs, 32).
+        Column 0 = sampled token, columns 1..N = top-N from sorted list.
+    """
+    sz = top_k_logprobs.shape[0]
+    N = min(max_num_logprobs, MAX_K)
+
+    # Find sampled token rank in the already-sorted top-32
+    sampled_expanded = sampled_token_ids.unsqueeze(-1)
+    match_mask = (top_k_indices == sampled_expanded)
+    ranks = match_mask.float().argmax(dim=-1)
+
+    # Extract sampled token logprob
+    sampled_logprob = top_k_logprobs.gather(
+        1, ranks.unsqueeze(-1).long()
+    )
+
+    # Build output: col 0 = sampled, cols 1..N = top-N from sorted
+    logprob_token_ids = torch.zeros(sz, N + 1, dtype=torch.int32)
+    logprobs_values = torch.zeros(sz, N + 1, dtype=torch.float32)
+
+    logprob_token_ids[:, 0] = sampled_token_ids
+    logprobs_values[:, 0] = sampled_logprob.squeeze(-1)
+    logprob_token_ids[:, 1:N + 1] = top_k_indices[:, :N].to(torch.int32)
+    logprobs_values[:, 1:N + 1] = top_k_logprobs[:, :N].to(torch.float32)
+
+    selected_token_ranks = ranks.to(torch.int32)
+
+    return LogprobsTensors(logprob_token_ids, logprobs_values,
+                           selected_token_ranks)
+
+
 @dataclass(frozen=True)
 class TTSamplingParams:
     """Sampling parameters for TT model execution.
@@ -1680,23 +1730,35 @@ class TTModelRunner:
                 assert isinstance(sampling_params.enable_log_probs, torch.Tensor)
                 rank_enable_lp = sampling_params.enable_log_probs[start : start + sz]
                 if rank_enable_lp.any() and tt_log_probs is not None:
-                    # TT device returns raw logprobs as [batch_size] tensor
-                    # containing log probability of the sampled token only.
-                    # Convert to LogprobsTensors format with minimal info.
-                    sampled_log_probs = tt_log_probs[start : start + sz]
-
-                    # Create LogprobsTensors with only sampled token info
-                    # Shape: [sz, 1] for token_ids and logprobs
-                    logprob_token_ids = next_token_ids.unsqueeze(-1).to(torch.int32)
-                    logprobs_values = sampled_log_probs.unsqueeze(-1).to(torch.float32)
-                    # Rank is unknown with device sampling, use -1 to indicate
-                    selected_token_ranks = torch.full((sz,), -1, dtype=torch.int32)
-
-                    logprobs_tensors = LogprobsTensors(
-                        logprob_token_ids=logprob_token_ids,
-                        logprobs=logprobs_values,
-                        selected_token_ranks=selected_token_ranks,
-                    )
+                    if isinstance(tt_log_probs, tuple):
+                        # New path: top-K logprobs from device
+                        # (gpt-oss-120b). Device returns already-sorted
+                        # (top_k_logprobs[B,32], top_k_indices[B,32]).
+                        top_k_logprobs, top_k_indices = tt_log_probs
+                        logprobs_tensors = _build_logprobs_from_topk(
+                            top_k_logprobs=top_k_logprobs[start:start + sz],
+                            top_k_indices=top_k_indices[start:start + sz],
+                            sampled_token_ids=next_token_ids,
+                            max_num_logprobs=rank_max_num_logprobs,
+                        )
+                    else:
+                        # Old path: single sampled-token logprob
+                        # (all other models). Device returns [B] tensor.
+                        sampled_log_probs = tt_log_probs[start : start + sz]
+                        logprob_token_ids = (
+                            next_token_ids.unsqueeze(-1).to(torch.int32)
+                        )
+                        logprobs_values = (
+                            sampled_log_probs.unsqueeze(-1).to(torch.float32)
+                        )
+                        selected_token_ranks = torch.full(
+                            (sz,), -1, dtype=torch.int32
+                        )
+                        logprobs_tensors = LogprobsTensors(
+                            logprob_token_ids=logprob_token_ids,
+                            logprobs=logprobs_values,
+                            selected_token_ranks=selected_token_ranks,
+                        )
                     logprobs_per_dp.append(logprobs_tensors)
                 else:
                     logprobs_per_dp.append(None)

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -81,7 +81,8 @@ def _build_logprobs_from_topk(
         sampled_token_ids = sampled_token_ids.unsqueeze(-1)
     sampled_expanded = sampled_token_ids.to(torch.int64)
     match_mask = (top_k_indices.to(torch.int64) == sampled_expanded)
-    ranks = match_mask.float().argmax(dim=-1)
+    # Convert mask to int since older versions of PyTorch don't support bool argmax.
+    ranks = match_mask.int().argmax(dim=-1)
 
     if ranks.dim() < top_k_logprobs.dim():
         ranks = ranks.unsqueeze(-1)
@@ -900,6 +901,7 @@ class TTModelRunner:
 
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
+        max_num_logprobs_val = model_input.max_num_logprobs[0] if model_input else 0
         int_inputs = torch.cat(
             [
                 tokens.contiguous().view(-1),  # B
@@ -911,6 +913,7 @@ class TTModelRunner:
                 enable_log_probs.contiguous()
                 .view(-1)
                 .to(torch.int32),  # B (bool->int32)
+                torch.tensor([max_num_logprobs_val], dtype=torch.int32),  # 1
             ],
             dim=0,
         ).contiguous()
@@ -953,7 +956,6 @@ class TTModelRunner:
             host_only_sample_params = {
                 "allowed_token_ids_mask": model_input.allowed_token_ids_mask_list[0],
                 "bad_words_token_ids": model_input.bad_words_token_ids_list[0],
-                "max_num_logprobs": model_input.max_num_logprobs[0],
                 "logitsprocs": model_input.logitsprocs_list[0],
                 "generators": model_input.generators_list[0],
             }
@@ -1076,6 +1078,12 @@ class TTModelRunner:
             # Convert back to bool tensor
             enable_log_probs = enable_log_probs_int > 0
 
+            # max_num_logprobs: one int per DP rank, always available
+            # (packed in int_inputs so it survives even when
+            # host_only_sample_params gather is skipped)
+            max_num_logprobs = stacked_int[:, off].tolist()
+            off += 1
+
             # Optional structured inputs: keep as list[Optional[tensor]]
             # per DP rank to match prefill behavior.
             grammar_bitmask_list = []
@@ -1107,21 +1115,20 @@ class TTModelRunner:
                             rank_params.get("bad_words_token_ids")
                         )
                         logitsprocs_list.append(rank_params.get("logitsprocs"))
-                        max_num_logprobs.append(rank_params.get("max_num_logprobs"))
                         generators_list.append(rank_params.get("generators", {}))
                     else:
                         allowed_token_ids_mask_list.append(None)
                         bad_words_token_ids_list.append({})
                         logitsprocs_list.append(None)
-                        max_num_logprobs.append(None)
                         generators_list.append({})
             else:
                 # No host-only sampling params - create empty lists
-                # Happens if we skipped gather (when device sampling)
+                # Happens when host_only_sample_params gather is skipped
+                # (device sampling). max_num_logprobs is already unpacked
+                # from int_inputs above.
                 allowed_token_ids_mask_list = [None] * world
                 bad_words_token_ids_list = [{}] * world
                 logitsprocs_list = [None] * world
-                max_num_logprobs = [None] * world
                 generators_list = [{}] * world
 
             off_f = 0

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1679,12 +1679,7 @@ class TTModelRunner:
                 # Always tensors - turned into lists only when passing to model
                 assert isinstance(sampling_params.enable_log_probs, torch.Tensor)
                 rank_enable_lp = sampling_params.enable_log_probs[start : start + sz]
-                if rank_enable_lp.any():
-                    # Sanity check for if we correctly detect
-                    # when logprobs are supported.
-                    assert tt_log_probs is not None, (
-                        "model should return logprobs when requested"
-                    )
+                if rank_enable_lp.any() and tt_log_probs is not None:
                     # TT device returns raw logprobs as [batch_size] tensor
                     # containing log probability of the sampled token only.
                     # Convert to LogprobsTensors format with minimal info.

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -44,8 +44,6 @@ logger = init_logger(__name__)
 
 # Maximum top_k value for on-device sampling
 MAX_K = 32
-# OpenAI API limit, matches vllm ModelConfig.max_logprobs
-MAX_LOGPROBS = 20
 
 
 def _build_logprobs_from_topk(
@@ -57,7 +55,7 @@ def _build_logprobs_from_topk(
     """Build LogprobsTensors from device top-K logprobs.
 
     Device always computes top-32 (MAX_K) logprobs sorted descending.
-    This function trims to min(max_num_logprobs, MAX_LOGPROBS=20) to
+    This function trims to max_num_logprobs which is in range (0-20) to
     match the OpenAI API limit, then packs into LogprobsTensors format
     expected by the downstream vLLM pipeline.
 
@@ -72,7 +70,7 @@ def _build_logprobs_from_topk(
         Column 0 = sampled token, columns 1..N = top-N from sorted list.
     """
     sz = top_k_logprobs.shape[0]
-    N = min(max_num_logprobs, MAX_LOGPROBS)
+    N = max_num_logprobs
 
     # Find sampled token rank in the already-sorted top-32
     # Cast both to int64 to avoid uint32/int32 promotion error

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -901,7 +901,7 @@ class TTModelRunner:
 
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
-        max_num_logprobs_val = model_input.max_num_logprobs[0] if model_input else 0
+        max_num_logprobs_val = (model_input.max_num_logprobs[0] or 0) if model_input else 0
         int_inputs = torch.cat(
             [
                 tokens.contiguous().view(-1),  # B

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -1729,7 +1729,12 @@ class TTModelRunner:
                 # Always tensors - turned into lists only when passing to model
                 assert isinstance(sampling_params.enable_log_probs, torch.Tensor)
                 rank_enable_lp = sampling_params.enable_log_probs[start : start + sz]
-                if rank_enable_lp.any() and tt_log_probs is not None:
+                if rank_enable_lp.any():
+                    # Sanity check for if we correctly detect
+                    # when logprobs are supported.
+                    assert tt_log_probs is not None, (
+                        "model should return logprobs when requested"
+                    )
                     if isinstance(tt_log_probs, tuple):
                         # New path: top-K logprobs from device
                         # (gpt-oss-120b). Device returns already-sorted

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -78,6 +78,10 @@ def _build_logprobs_from_topk(
     if sampled_token_ids.dim() == 1:
         sampled_token_ids = sampled_token_ids.unsqueeze(-1)
     sampled_expanded = sampled_token_ids.to(torch.int64)
+    # The sampled token is guaranteed to be in top-32 because ttnn.sampling
+    # selects from the same top-K candidates returned here. If this constraint
+    # changes (e.g., top-K is reduced), match_mask may be all-False and
+    # argmax will return 0, giving an incorrect rank and logprob.
     match_mask = top_k_indices.to(torch.int64) == sampled_expanded
     # Convert mask to int since older versions of PyTorch don't support bool argmax.
     ranks = match_mask.int().argmax(dim=-1)
@@ -115,7 +119,6 @@ class TTSamplingParams:
     repetition_penalty: torch.Tensor | list[float] | float = 1.0
     seed: torch.Tensor | list[int | None] | int = 0
     enable_log_probs: torch.Tensor | list[bool] | None = None
-    num_logprobs: torch.Tensor | list[int] | int = None
 
 
 @dataclass(frozen=True)
@@ -195,6 +198,15 @@ class TTModelRunner:
         self.enable_model_warmup = enable_model_warmup
         # Whether to sample on device
         self.sample_on_device_mode = TTPlatform.sample_on_device_mode
+        # Whether the model supports top-K logprobs on device.
+        # Detected from model_type (available to all DP ranks without
+        # requiring the model to be loaded). Models like gpt-oss-120b
+        # set use_topk_logprobs=True and return top-32 logprobs from device.
+        # TODO: Update this check as more models add top-K logprobs support.
+        # https://github.com/tenstorrent/tt-metal/issues/40810
+        self.supports_topk_logprobs = (
+            self.model_config.hf_config.model_type == "gpt_oss"
+        )
 
         logger.info(
             "TTModelRunner: trace_mode=%s, "
@@ -865,6 +877,7 @@ class TTModelRunner:
             seed = sampling_default_tensors["seed"]
             # enable_log_probs: convert num_logprobs >= 0
             enable_log_probs = sampling_default_tensors["num_logprobs"] >= 0
+            max_num_logprobs_val = 0
         else:
             tokens = model_input.input_tokens
             positions = model_input.input_positions
@@ -893,12 +906,9 @@ class TTModelRunner:
             repetition_penalty = sampling_params.repetition_penalty
             seed = sampling_params.seed
             enable_log_probs = sampling_params.enable_log_probs
-
+            max_num_logprobs_val = model_input.max_num_logprobs[0] or 0
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
-        max_num_logprobs_val = (
-            (model_input.max_num_logprobs[0] or 0) if model_input else 0
-        )
         int_inputs = torch.cat(
             [
                 tokens.contiguous().view(-1),  # B
@@ -1121,8 +1131,6 @@ class TTModelRunner:
             else:
                 # No host-only sampling params - create empty lists
                 # Happens when host_only_sample_params gather is skipped
-                # (device sampling). max_num_logprobs is already unpacked
-                # from int_inputs above.
                 allowed_token_ids_mask_list = [None] * world
                 bad_words_token_ids_list = [{}] * world
                 logitsprocs_list = [None] * world
@@ -1413,15 +1421,21 @@ class TTModelRunner:
         if has_structured_outputs:
             return False
 
-        # Logprobs on device are only supported on multi-device setups
-        # (num_devices in {8,32})
-        # Also, only the sampled token's logprob is returned on device,
-        # not the top-k alternatives.
-        # On single device, logprobs require host sampling.
+        # Logprobs on device require multi-device setups (num_devices in {8,32}).
+        # On single device, all logprobs require host sampling.
         # https://github.com/tenstorrent/tt-metal/issues/34077
+        #
+        # Top-K logprobs (max_lp > 0) are only supported on device by models
+        # that set use_topk_logprobs=True (e.g. gpt-oss-120b), which return
+        # top-32 logprobs as a (logprobs, indices) tuple. Other models only
+        # return the sampled token's logprob, so max_lp > 0 falls back to
+        # host sampling to compute full top-N from logits.
         max_lp = input_batch.max_num_logprobs
-        if max_lp is not None and (max_lp > 0 or num_devices not in (8, 32)):
-            return False
+        if max_lp is not None:
+            if num_devices not in (8, 32):
+                return False
+            if max_lp > 0 and not self.supports_topk_logprobs:
+                return False
 
         # TTPlatform.non_greedy_decoding_on_device must be True
         # for random sampling,

--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -80,29 +80,26 @@ def _build_logprobs_from_topk(
     if sampled_token_ids.dim() == 1:
         sampled_token_ids = sampled_token_ids.unsqueeze(-1)
     sampled_expanded = sampled_token_ids.to(torch.int64)
-    match_mask = (top_k_indices.to(torch.int64) == sampled_expanded)
+    match_mask = top_k_indices.to(torch.int64) == sampled_expanded
     # Convert mask to int since older versions of PyTorch don't support bool argmax.
     ranks = match_mask.int().argmax(dim=-1)
 
     if ranks.dim() < top_k_logprobs.dim():
         ranks = ranks.unsqueeze(-1)
     # Extract sampled token logprob
-    sampled_logprob = top_k_logprobs.gather(
-        1, ranks.long()
-    )
+    sampled_logprob = top_k_logprobs.gather(1, ranks.long())
     # Build output: col 0 = sampled, cols 1..N = top-N from sorted
     logprob_token_ids = torch.zeros(sz, N + 1, dtype=torch.int32)
     logprobs_values = torch.zeros(sz, N + 1, dtype=torch.float32)
 
     logprob_token_ids[:, 0] = sampled_token_ids.squeeze(-1)
     logprobs_values[:, 0] = sampled_logprob.squeeze(-1)
-    logprob_token_ids[:, 1:N + 1] = top_k_indices[:, :N].to(torch.int32)
-    logprobs_values[:, 1:N + 1] = top_k_logprobs[:, :N].to(torch.float32)
+    logprob_token_ids[:, 1 : N + 1] = top_k_indices[:, :N].to(torch.int32)
+    logprobs_values[:, 1 : N + 1] = top_k_logprobs[:, :N].to(torch.float32)
 
     selected_token_ranks = ranks.squeeze(-1).to(torch.int32)
 
-    return LogprobsTensors(logprob_token_ids, logprobs_values,
-                           selected_token_ranks)
+    return LogprobsTensors(logprob_token_ids, logprobs_values, selected_token_ranks)
 
 
 @dataclass(frozen=True)
@@ -901,7 +898,9 @@ class TTModelRunner:
 
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.
-        max_num_logprobs_val = (model_input.max_num_logprobs[0] or 0) if model_input else 0
+        max_num_logprobs_val = (
+            (model_input.max_num_logprobs[0] or 0) if model_input else 0
+        )
         int_inputs = torch.cat(
             [
                 tokens.contiguous().view(-1),  # B
@@ -1485,7 +1484,7 @@ class TTModelRunner:
         if perform_device_sampling:
             # On-device sampling currently needs sampling param attributes to
             # be lists instead of tensors.
-            sampling_param_dict = {}
+            sampling_param_dict: dict[str, Any] = {}
             for field in fields(sampling_params):
                 val = getattr(sampling_params, field.name)
                 if val is None:
@@ -1758,24 +1757,22 @@ class TTModelRunner:
                         # (top_k_logprobs[B,32], top_k_indices[B,32]).
                         top_k_logprobs, top_k_indices = tt_log_probs
                         logprobs_tensors = _build_logprobs_from_topk(
-                            top_k_logprobs=top_k_logprobs[start:start + sz],
-                            top_k_indices=top_k_indices[start:start + sz],
+                            top_k_logprobs=top_k_logprobs[start : start + sz],
+                            top_k_indices=top_k_indices[start : start + sz],
                             sampled_token_ids=next_token_ids,
-                            max_num_logprobs=rank_max_num_logprobs,
+                            max_num_logprobs=rank_max_num_logprobs
+                            if rank_max_num_logprobs is not None
+                            else 0,
                         )
                     else:
                         # Old path: single sampled-token logprob
                         # (all other models). Device returns [B] tensor.
                         sampled_log_probs = tt_log_probs[start : start + sz]
-                        logprob_token_ids = (
-                            next_token_ids.unsqueeze(-1).to(torch.int32)
+                        logprob_token_ids = next_token_ids.unsqueeze(-1).to(torch.int32)
+                        logprobs_values = sampled_log_probs.unsqueeze(-1).to(
+                            torch.float32
                         )
-                        logprobs_values = (
-                            sampled_log_probs.unsqueeze(-1).to(torch.float32)
-                        )
-                        selected_token_ranks = torch.full(
-                            (sz,), -1, dtype=torch.int32
-                        )
+                        selected_token_ranks = torch.full((sz,), -1, dtype=torch.int32)
                         logprobs_tensors = LogprobsTensors(
                             logprob_token_ids=logprob_token_ids,
                             logprobs=logprobs_values,


### PR DESCRIPTION
### Description
- Add top-K logprobs support through vllm and ensure backward compatibility. Currently there is request for gpt-oss-120b to support top-K logprobs (K in (0,20)).
- Issue link: https://github.com/tenstorrent/tt-metal/issues/34080
## Test Plan
- There is several tests added in test_build_logprobs_from_topk.py
- Run vllm nightly for all the models to verify nothing is broken since it's meant to be backward compatible with logprobs=1 implementation.
## Test Result
- Will add before and after execution pipelines. No need for approval before it's there, just for early review. 