### PR TITLE
set non_greedy_decoding_on_device for DeepSeek

### DIFF
--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -362,6 +362,11 @@ class TTPlatform(Platform):
         ):
             cls.non_greedy_decoding_on_device = True  # type: ignore[attr-defined]
 
+        if model_class.__module__.startswith(
+            "models.demos.deepseek_v3.tt.generator_vllm"
+        ):
+            cls.non_greedy_decoding_on_device = True  # type: ignore[attr-defined]
+
         # Get model capabilities from the class
         model_capabilities: dict | None = getattr(
             model_class, "model_capabilities", None


### PR DESCRIPTION
This PR sets cls.non_greedy_decoding_on_device for deepseek model as it would support non-greedy sampling on device 


## Test Plan and Results
checking offline and online server mode with deepseek, it's working as expected.
related tt-metal PR: https://github.com/tenstorrent/tt-metal/pull/40788


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

