### PR TITLE
Fix ignore_eos not respecting stop_token_ids

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -587,6 +587,32 @@ def test_check_stop_min_tokens():
     assert request_stop.stop_reason == 42
 
 
+def test_check_stop_ignore_eos_with_stop_token_ids():
+    """Test that ignore_eos also skips stop_token_ids checking."""
+    from vllm.v1.core.sched.utils import check_stop
+
+    # When ignore_eos=True, stop_token_ids should also be ignored
+    sampling_params = SamplingParams(
+        ignore_eos=True,
+        max_tokens=20,
+        stop_token_ids=[42, 43],
+    )
+    request = Request(
+        request_id="0",
+        prompt_token_ids=[0, 1, 2],
+        sampling_params=sampling_params,
+        pooling_params=None,
+        eos_token_id=EOS_TOKEN_ID,
+    )
+    # Generate tokens including a stop token and EOS
+    request.append_output_token_ids([10, 42, 11, EOS_TOKEN_ID, 43])
+
+    result = check_stop(request, max_model_len=100)
+    assert result is False, (
+        "Should not stop on stop_token_ids or EOS when ignore_eos=True"
+    )
+
+
 @pytest.mark.parametrize(
     "enable_prefix_caching, prompt_logprobs",
     [

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -59,7 +59,9 @@ def check_stop(
         request.status = RequestStatus.FINISHED_STOPPED
         return True
 
-    if last_token_id in (sampling_params.stop_token_ids or ()):
+    if not sampling_params.ignore_eos and last_token_id in (
+        sampling_params.stop_token_ids or ()
+    ):
         request.status = RequestStatus.FINISHED_STOPPED
         request.stop_reason = last_token_id
         return True


### PR DESCRIPTION
## Summary
- check_stop() correctly gated the primary eos_token_id check with ignore_eos, but the stop_token_ids check fired unconditionally
- GPT-OSS injects harmony stop tokens into stop_token_ids, so benchmarks with ignore_eos=True still terminated early
- Gate the stop_token_ids check with ignore_eos to match the EOS token behavior

Closes #344

## Test plan
- [x] Added test_check_stop_ignore_eos_with_stop_token_ids to tests/v1/core/test_scheduler.py
- [ ] Run GPT-OSS benchmark with --random-output-len 128 and verify outputs reach 128 tokens