### PR TITLE
Fix num_logprobs=0 handling

### DIFF
--- a/vllm/v1/worker/tt_model_runner.py
+++ b/vllm/v1/worker/tt_model_runner.py
@@ -909,7 +909,9 @@ class TTModelRunner:
             seed = sampling_params.seed
             enable_log_probs = sampling_params.enable_log_probs
             max_num_logprobs_val = (
-                model_input.max_num_logprobs[0] or LOGPROBS_NONE_SENTINEL
+                model_input.max_num_logprobs[0]
+                if model_input.max_num_logprobs[0] is not None
+                else LOGPROBS_NONE_SENTINEL
             )
         # Pack into flattened tensors to reduce number of collectives.
         # B = max batch size, W = max_num_blocks_per_req.


### PR DESCRIPTION
### Description
Incorrect handling num_logprobs=0. When 0 is passed it's converted to SENTINEL 

## Purpose
Fix logic when num_logprobs=0, then sampled token logprobs should be returned but in condition max_num_logprobs_val becomes -2 when (0 or -2) is evaluated. Being that said, statement is modified to set SENTINEL only when value is None otherwise keep passed value.
## Test Plan
- run vllm nightly
## Test Result
- bug in logprobs before commit: https://github.com/tenstorrent/tt-metal/actions/runs/23761695990/job/69232451177#step:15:40
- fix after: https://github.com/tenstorrent/tt-metal/actions/runs/23762728179/job/69310937368#step:15:40

Model is still failing for test previously failing.