### PR TITLE
Add rejection of custom logits processors.

### DIFF
--- a/vllm/platforms/tt.py
+++ b/vllm/platforms/tt.py
@@ -254,6 +254,10 @@ class TTPlatform(Platform):
         MAX_TOP_K = 20
 
         model_config = vllm_config.model_config
+        if model_config.logits_processors:
+            raise ValueError(
+                f"Custom logits_processors not supported on {cls.device_name} in V1"
+            )
         if model_config.max_logprobs > MAX_TOP_K:
             logger.warning(
                 "max_logprobs=%d exceeds TT device limit of %d, clamping to %d",


### PR DESCRIPTION
## Purpose

Add rejection of custom logits processors which was accidentally removed in the recent upstream pull. 

SamplingParams no longer has a logits_processors field of its own. The custom processors are now configured at engine/model initialization time via logits_processors=... on LLM / ModelConfig, not attached directly to each request’s SamplingParams.

## Test Result

https://github.com/tenstorrent/tt-metal/actions/runs/24822901197

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

