### PR TITLE
[Bench] Count reasoning_content tokens in openai-chat backend

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -349,7 +349,13 @@ async def async_request_openai_chat_completions(
                             data = json.loads(chunk)
 
                             if choices := data.get("choices"):
-                                content = choices[0]["delta"].get("content")
+                                delta = choices[0]["delta"]
+                                # Count reasoning_content tokens (e.g. GPT-OSS
+                                # harmony reasoning channel) the same as
+                                # regular content; both are produced tokens.
+                                content = delta.get("content") or delta.get(
+                                    "reasoning_content"
+                                )
                                 # First token
                                 if ttft == 0.0:
                                     ttft = timestamp - st
@@ -459,7 +465,10 @@ async def async_request_openai_audio(
                                 data = json.loads(chunk)
 
                                 if choices := data.get("choices"):
-                                    content = choices[0]["delta"].get("content")
+                                    delta = choices[0]["delta"]
+                                    content = delta.get("content") or delta.get(
+                                        "reasoning_content"
+                                    )
                                     # First token
                                     if ttft == 0.0:
                                         ttft = timestamp - st


### PR DESCRIPTION
## Problem

In tt-shield CI, the gpt-oss-120b release benchmark consistently reports `Total generated tokens: 0` for every request even though the model is generating tokens. The downstream report generator then crashes with `ZeroDivisionError: float division by zero` on `output_throughput = total_generated / duration`. Example: tt-shield run #621 / job 73089333672.

## Root Cause

The server is launched with `reasoning_parser='openai_gptoss'`, which routes the model's harmony reasoning-channel tokens to `delta.reasoning_content` instead of `delta.content`. The benchmark client (`endpoint_request_func.py async_request_openai_chat_completions`) only inspects `delta.content`, so it sees no tokens — even though the streaming response is delivering them. Short prompts (random isl=128) hit the `max_completion_tokens` budget while still inside the reasoning channel and never reach the final-content channel, so `delta.content` is empty for every chunk.

Result: `ttft=0`, `output_lens=0`, `generated_text=""`, `total_output_tokens=0` — and the report-generation step divides by zero.

## Fix

Read `delta.reasoning_content` as a fallback when `delta.content` is empty/missing. Both are real tokens the model produced; for benchmark TTFT/throughput purposes they should be counted identically. Same fix applied to the audio chat handler.

## Test plan
- [x] Patch builds and imports cleanly
- [ ] Re-run gpt-oss-120b benchmarks on TG; verify `output_lens > 0` and `mean_ttft_ms > 0`
- [ ] Run a non-reasoning model (e.g. Llama) to confirm no regression — `delta.content` path still wins