### PR TITLE
[Bench] Count reasoning_content tokens; declare VLLM_SYSTEM_START_DATE

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -345,7 +345,13 @@ async def async_request_openai_chat_completions(
                             data = json.loads(chunk)
 
                             if choices := data.get("choices"):
-                                content = choices[0]["delta"].get("content")
+                                delta = choices[0]["delta"]
+                                # Count reasoning_content tokens (e.g. GPT-OSS
+                                # harmony reasoning channel) the same as
+                                # regular content; both are produced tokens.
+                                content = delta.get("content") or delta.get(
+                                    "reasoning_content"
+                                )
                                 # First token
                                 if ttft == 0.0:
                                     ttft = timestamp - st
@@ -453,7 +459,10 @@ async def async_request_openai_audio(
                                 data = json.loads(chunk)
 
                                 if choices := data.get("choices"):
-                                    content = choices[0]["delta"].get("content")
+                                    delta = choices[0]["delta"]
+                                    content = delta.get("content") or delta.get(
+                                        "reasoning_content"
+                                    )
                                     # First token
                                     if ttft == 0.0:
                                         ttft = timestamp - st

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     VLLM_HOST_IP: str = ""
+    VLLM_SYSTEM_START_DATE: str | None = None
     VLLM_PORT: int | None = None
     VLLM_RPC_BASE_PATH: str = tempfile.gettempdir()
     VLLM_USE_MODELSCOPE: bool = False
@@ -458,6 +459,9 @@ def get_env_or_set_default(
 logger = logging.getLogger(__name__)
 
 environment_variables: dict[str, Callable[[], Any]] = {
+    # Optional ISO date used by the GPT-OSS harmony chat template to pin
+    # the conversation start date and remove time-based non-determinism.
+    "VLLM_SYSTEM_START_DATE": lambda: os.getenv("VLLM_SYSTEM_START_DATE", None),
     # ================== Installation Time Env Vars ==================
     # Target device of vLLM, supporting [cuda (by default),
     # rocm, cpu]


### PR DESCRIPTION
## 1. `endpoint_request_func.py`: count `delta.reasoning_content`

When the server runs with `reasoning_parser='openai_gptoss'`, harmony reasoning-channel tokens arrive in `delta.reasoning_content` rather than `delta.content`. The streaming benchmark client only inspected `delta.content` — so any run where the model finishes within the reasoning channel (very common for short `max_tokens` benchmarks) reported `total_output_tokens=0`, `mean_ttft_ms=0`, empty `generated_text`. Downstream report-gen then divides by zero on throughput math.

Treat `delta.reasoning_content` as content for benchmark purposes; both are real tokens emitted by the model. Same fix applied to the audio chat handler.

## 2. `envs.py`: declare `VLLM_SYSTEM_START_DATE`

`vllm/entrypoints/openai/parser/harmony_utils.py` reads `envs.VLLM_SYSTEM_START_DATE` to optionally pin the harmony chat template start date and remove time-based non-determinism. Upstream `vllm-project/main` has this declaration in `vllm/envs.py`, but it was lost during the last upstream sync into `dev`, so the first GPT-OSS chat completion request raises:

```
AttributeError: module 'vllm.envs' has no attribute 'VLLM_SYSTEM_START_DATE'
```

Re-add the type stub and the `environment_variables` registration to match upstream verbatim.

## Test plan
- [x] Offline mock SSE stream with `delta.reasoning_content` chunks → patched client reports `ttft>0`, correct `generated_text`, `output_tokens=5`
- [x] Re-run gpt-oss-120b benchmarks on TG with patched client; verify `output_lens > 0`, `mean_ttft_ms > 0`, no `AttributeError`
- [ ] Llama (no reasoning parser) regression check — `delta.content` path still wins