### PR TITLE
set max_tokens_all_users for DeepSeek based on cmd line params

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -423,7 +423,7 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
         # Qwen2.5-VL-72B on WH T3K
         max_tokens_all_users = 65536
     elif "DeepSeek-R1-0528" in model_config.model and is_wormhole:
-        max_tokens_all_users = 32768
+        max_tokens_all_users = model_config.max_model_len * scheduler_config.max_num_seqs
     else:
         # Note: includes num vision tokens for multi-modal
         max_tokens_all_users = 131072


### PR DESCRIPTION

Set max_tokens_all_users based in params (max_model_len and max_num_seqs) used to launch the vllm server. 
Signed-off-by: Pratikkumar Prajapati <pprajapati@tenstorrent.com>
