### PR TITLE
Wire HMA tensor sharing through TT plugin (follow-up to #381)

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -417,13 +417,12 @@ class TTAsyncDecodeController:
             "kv_cache": runner.kv_caches,
             "start_pos": model_input.input_positions,
         }
-        # Hybrid attention models route per-layer block tables; they opt
-        # in by exposing ``get_kv_cache_spec`` (same marker the worker
-        # uses to pick the hybrid kv cache spec path). The runner cached
-        # the layer→group index mapping at ``initialize_kv_cache`` and
-        # populated ``block_tables_per_layer`` per submission so bridges
-        # don't have to re-derive vLLM's group construction order.
-        if hasattr(type(runner.model), "get_kv_cache_spec"):
+        # Hybrid attention models route per-layer block tables; the
+        # runner already populated ``block_tables_per_layer`` at
+        # submission time when the kv_cache_config has multiple groups.
+        # Legacy/uniform models leave it as ``None`` and never see the
+        # kwarg.
+        if model_input.block_tables_per_layer is not None:
             kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
         if perform_device_sampling:
             sampling_param_dict = {

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -417,12 +417,14 @@ class TTAsyncDecodeController:
             "kv_cache": runner.kv_caches,
             "start_pos": model_input.input_positions,
         }
-        # Hybrid attention models route per-layer to per-group block tables;
-        # they opt in by exposing ``get_kv_cache_spec`` (same marker the
-        # worker uses to pick the hybrid kv cache spec path). Legacy models
-        # never see the kwarg and don't need to strip it.
+        # Hybrid attention models route per-layer block tables; they opt
+        # in by exposing ``get_kv_cache_spec`` (same marker the worker
+        # uses to pick the hybrid kv cache spec path). The runner cached
+        # the layer→group index mapping at ``initialize_kv_cache`` and
+        # populated ``block_tables_per_layer`` per submission so bridges
+        # don't have to re-derive vLLM's group construction order.
         if hasattr(type(runner.model), "get_kv_cache_spec"):
-            kwargs["page_tables_per_group"] = model_input.block_tables_per_group
+            kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
         if perform_device_sampling:
             sampling_param_dict = {
                 field.name: (

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -169,9 +169,17 @@ class TTModelInput:
     # Per-group block tables in upstream's KVCacheConfig group order; one
     # entry for uniform models, ``len(kv_cache_groups)`` entries for
     # hybrid attention. Group g's tensor maps the model's layer-→group
-    # routing onto the right paged pool, consumed by hybrid models'
-    # prefill/decode forward via the ``page_tables_per_group`` kwarg.
+    # routing onto the right paged pool. We expand this into
+    # ``block_tables_per_layer`` (one entry per decoder layer) before
+    # handing it to hybrid models so they don't have to re-derive vLLM's
+    # group construction order.
     block_tables_per_group: list[torch.Tensor]
+    # Per-layer block tables, one entry per decoder layer in model
+    # layer-index order. ``None`` for non-hybrid models (the runner only
+    # populates this when ``self._layer_to_group_idx`` was set at
+    # ``initialize_kv_cache`` time, which itself only fires when the
+    # model class exposes ``get_kv_cache_spec``).
+    block_tables_per_layer: list[torch.Tensor] | None
     unpadded_batch_size: int | list[int]  # List is used for DP
     tt_sampling_params: TTSamplingParams
     multi_modal_kwargs: dict[str, Any]
@@ -396,6 +404,29 @@ class TTModelRunner:
             kv_cache_config.num_blocks,
         )
 
+        # Cache layer→group index mapping for hybrid models so submit_*
+        # can expand ``block_tables_per_group`` into ``block_tables_per_layer``
+        # without re-deriving vLLM's group construction order. Non-hybrid
+        # models skip the expansion entirely (mapping stays None).
+        self._layer_to_group_idx: list[int] | None = None
+        if hasattr(type(self.model), "get_kv_cache_spec"):
+            num_layers = self.model_config.get_num_layers_by_block_type(
+                self.parallel_config, "attention"
+            )
+            mapping: list[int | None] = [None] * num_layers
+            for g_idx, group in enumerate(kv_cache_groups):
+                for layer_name in group.layer_names:
+                    idx = _parse_layer_index(layer_name)
+                    mapping[idx] = g_idx
+            missing = [i for i, g in enumerate(mapping) if g is None]
+            if missing:
+                raise ValueError(
+                    f"No KVCacheGroupSpec covers layer indices {missing} "
+                    f"on hybrid model {type(self.model).__name__}; every "
+                    "attention layer must appear in some group's layer_names."
+                )
+            self._layer_to_group_idx = mapping  # type: ignore[assignment]
+
         # Only DP rank 0 allocates KV cache.
         if self.parallel_config.data_parallel_rank_local != 0:
             return
@@ -457,6 +488,23 @@ class TTModelRunner:
                 )
         shape, dtype = first
         return self.model.allocate_kv_cache(shape, dtype, len(per_layer_specs))
+
+    def _block_tables_per_layer(
+        self, block_tables_per_group: list[torch.Tensor]
+    ) -> list[torch.Tensor] | None:
+        """Expand per-group block tables to per-layer using the cached mapping.
+
+        Returns None for non-hybrid models (the mapping is only populated
+        when the model class exposes ``get_kv_cache_spec``). The output is
+        a list of ``num_layers`` tensors, where entry ``i`` is the block
+        table for layer ``i``'s containing kv_cache_group — what hybrid
+        bridges hand to the underlying TT model so attention layer ``i``
+        can index its own paged pool (full vs. sliding-window) without
+        knowing how vLLM ordered the groups.
+        """
+        if self._layer_to_group_idx is None:
+            return None
+        return [block_tables_per_group[g] for g in self._layer_to_group_idx]
 
     def _build_per_layer_specs(
         self, kv_cache_config: KVCacheConfig, num_layers: int
@@ -992,6 +1040,7 @@ class TTModelRunner:
             prompt_lens=prompt_lens,
             block_tables=block_tables,
             block_tables_per_group=block_tables_per_group,
+            block_tables_per_layer=self._block_tables_per_layer(block_tables_per_group),
             unpadded_batch_size=num_reqs,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
@@ -1599,8 +1648,11 @@ class TTModelRunner:
             # DP merged path collapses to group-0 only for now; full
             # per-group DP gather is not yet implemented. Hybrid models on
             # DP > 1 are gated by ``TTWorker.get_kv_cache_spec`` until
-            # then.
+            # then. ``block_tables_per_layer`` stays None on this path —
+            # if a hybrid model ever runs DP > 1 the gate above will fire
+            # before we get here.
             block_tables_per_group=[block_tables],
+            block_tables_per_layer=None,
             unpadded_batch_size=batch_size_per_dp,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
@@ -1789,12 +1841,16 @@ class TTModelRunner:
             "prompt_lens": model_input.prompt_lens,
             "start_pos": model_input.input_positions,
         }
-        # Hybrid attention models route per-layer to per-group block tables;
-        # they opt in by exposing ``get_kv_cache_spec`` (same marker the
-        # worker uses to pick the hybrid kv cache spec path). Legacy models
-        # never see the kwarg and don't need to strip it.
+        # Hybrid attention models route per-layer block tables; they opt
+        # in by exposing ``get_kv_cache_spec`` (same marker the worker
+        # uses to pick the hybrid kv cache spec path). The runner cached
+        # the layer→group index mapping at ``initialize_kv_cache`` and
+        # ``_block_tables_per_layer`` already expanded the per-group list
+        # into a per-layer list aligned with the model's ``self.layers``
+        # — bridges just pass it straight through. Legacy models never
+        # see the kwarg.
         if hasattr(type(self.model), "get_kv_cache_spec"):
-            kwargs["page_tables_per_group"] = model_input.block_tables_per_group
+            kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
         kwargs.update(model_input.multi_modal_kwargs)
         if model_input.perform_device_sampling:
             sampling_params = model_input.tt_sampling_params

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1192,7 +1192,6 @@ class TTModelRunner:
                 torch.zeros((max_batch, max_blocks_decode_batch), dtype=torch.int32)
                 for _ in range(num_groups)
             ]
-            block_tables = block_tables_per_group[0]
             unpadded_batch_size = torch.tensor([0], dtype=torch.int32)
             # Create default sampling parameter tensors (max_batch sized)
             sampling_default_tensors = (
@@ -1231,7 +1230,6 @@ class TTModelRunner:
                 f"build_dp_decode_gather_input: expected {num_groups} "
                 f"per-group block tables, got {len(block_tables_per_group)}"
             )
-            block_tables = block_tables_per_group[0]
             unpadded_batch_size = torch.tensor(
                 [cast(int, model_input.unpadded_batch_size)], dtype=torch.int32
             )
@@ -1598,8 +1596,7 @@ class TTModelRunner:
                     prompt_lens_list.append(mi.prompt_lens)
                     block_tables_list.append(pad_block_tables(mi.block_tables))
                     assert (
-                        len(mi.block_tables_per_group)
-                        == self._num_kv_cache_groups
+                        len(mi.block_tables_per_group) == self._num_kv_cache_groups
                     ), (
                         f"DP merge: rank input has "
                         f"{len(mi.block_tables_per_group)} block_tables_per_group "
@@ -1652,8 +1649,7 @@ class TTModelRunner:
             # Build the per-group merged view here so the prefill branch
             # exits with the same shape contract as the decode branch.
             block_tables_per_group = [
-                torch.cat(per_rank, dim=0)
-                for per_rank in block_tables_per_group_list
+                torch.cat(per_rank, dim=0) for per_rank in block_tables_per_group_list
             ]
 
             # Concatenate sampling parameter tensors across DP ranks
@@ -1762,9 +1758,7 @@ class TTModelRunner:
             # ``_block_tables_per_layer`` then expands the per-group view
             # into the per-layer list the hybrid bridge consumes.
             block_tables_per_group=block_tables_per_group,
-            block_tables_per_layer=self._block_tables_per_layer(
-                block_tables_per_group
-            ),
+            block_tables_per_layer=self._block_tables_per_layer(block_tables_per_group),
             unpadded_batch_size=batch_size_per_dp,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -478,15 +478,18 @@ class TTModelRunner:
         if hasattr(self.model, "allocate_kv_cache_per_layer"):
             return self.model.allocate_kv_cache_per_layer(per_layer_specs)
 
-        first = per_layer_specs[0]
-        for entry in per_layer_specs[1:]:
-            if entry != first:
+        # Legacy ``allocate_kv_cache(shape, dtype, num_layers)`` API: every
+        # layer must have the same shape/dtype. The third tuple element is
+        # the tensor index, which is irrelevant for the legacy uniform
+        # path (each layer gets its own buffer there).
+        shape, dtype, _ = per_layer_specs[0]
+        for entry_shape, entry_dtype, _ in per_layer_specs[1:]:
+            if (entry_shape, entry_dtype) != (shape, dtype):
                 raise NotImplementedError(
                     f"{type(self.model).__name__} only implements legacy "
                     "allocate_kv_cache; hybrid attention models must "
                     "override allocate_kv_cache_per_layer."
                 )
-        shape, dtype = first
         return self.model.allocate_kv_cache(shape, dtype, len(per_layer_specs))
 
     def _block_tables_per_layer(
@@ -508,17 +511,23 @@ class TTModelRunner:
 
     def _build_per_layer_specs(
         self, kv_cache_config: KVCacheConfig, num_layers: int
-    ) -> list[tuple[tuple[int, int, int, int], Any]]:
-        """Resolve ``KVCacheConfig`` → list of ``(shape, dtype)`` per layer.
+    ) -> list[tuple[tuple[int, int, int, int], Any, int]]:
+        """Resolve ``KVCacheConfig`` → list of ``(shape, dtype, tensor_idx)``
+        per layer in model layer-index order.
 
-        Single-group: every layer gets the same shape/dtype.
+        ``tensor_idx`` identifies the unique DRAM buffer that each layer's
+        KV cache lives in. Multiple layers from different
+        ``KVCacheGroupSpec``\\ s can carry the same ``tensor_idx`` — this
+        is upstream's tensor-sharing model: with a 5:1 sliding/full split,
+        a full-attention layer and several sliding-window layers all share
+        one buffer, and they index disjoint slots within it via per-group
+        block tables (vLLM's ``BlockPool`` allocates disjoint block IDs
+        across groups, so the shared tensor is sized for the worst-case
+        full-attention demand and the sliding-window layers fit within
+        their window's worth of slots).
 
-        Multi-group: each layer's spec comes from its containing
-        ``KVCacheGroupSpec`` and shape is derived per group (sliding-window
-        layers can therefore receive a smaller paged pool than full
-        attention). Layer index is parsed from the layer name; the hook
-        author is expected to follow the ``...layers.<idx>...`` convention
-        used by upstream attention layer naming.
+        Single-group (uniform-attention) models keep the previous behavior:
+        every layer gets a unique buffer and ``tensor_idx == layer_idx``.
         """
         kv_cache_groups = kv_cache_config.kv_cache_groups
 
@@ -528,19 +537,28 @@ class TTModelRunner:
             # top of ``initialize_kv_cache``; assert for mypy.
             assert isinstance(spec, AttentionSpec)
             shape = self._kv_cache_shape(spec, kv_cache_config.num_blocks)
-            return [(shape, spec.dtype)] * num_layers
+            return [(shape, spec.dtype, i) for i in range(num_layers)]
 
-        # Multi-group: walk groups, parse layer index from each layer name,
-        # and slot each layer's (shape, dtype) into the per-layer list.
-        per_layer: list[tuple[tuple[int, int, int, int], Any] | None] = [
+        # Multi-group: walk ``kv_cache_tensors`` (one entry per unique DRAM
+        # buffer) and assign every layer in ``shared_by`` the same
+        # ``tensor_idx``. Shape/dtype come from the layer's own group spec.
+        spec_by_layer_name: dict[str, AttentionSpec] = {}
+        for group in kv_cache_groups:
+            assert isinstance(group.kv_cache_spec, AttentionSpec)
+            for layer_name in group.layer_names:
+                spec_by_layer_name[layer_name] = group.kv_cache_spec
+
+        per_layer: list[tuple[tuple[int, int, int, int], Any, int] | None] = [
             None
         ] * num_layers
-        for group in kv_cache_groups:
-            spec = group.kv_cache_spec
-            assert isinstance(spec, AttentionSpec)
-            shape = self._kv_cache_shape(spec, kv_cache_config.num_blocks)
-            entry = (shape, spec.dtype)
-            for layer_name in group.layer_names:
+        for tensor_idx, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+            for layer_name in kv_cache_tensor.shared_by:
+                spec = spec_by_layer_name.get(layer_name)
+                if spec is None:
+                    raise ValueError(
+                        f"KVCacheTensor.shared_by names layer '{layer_name}' "
+                        "but it doesn't appear in any kv_cache_group"
+                    )
                 idx = _parse_layer_index(layer_name)
                 if not 0 <= idx < num_layers:
                     raise ValueError(
@@ -549,17 +567,19 @@ class TTModelRunner:
                     )
                 if per_layer[idx] is not None:
                     raise ValueError(
-                        f"Layer index {idx} (from '{layer_name}') already "
-                        "assigned to another group; layer names must be unique"
+                        f"Layer index {idx} (from '{layer_name}') is named "
+                        "by more than one KVCacheTensor.shared_by; each "
+                        "layer must map to exactly one DRAM buffer"
                     )
-                per_layer[idx] = entry
+                shape = self._kv_cache_shape(spec, kv_cache_config.num_blocks)
+                per_layer[idx] = (shape, spec.dtype, tensor_idx)
 
         missing = [i for i, e in enumerate(per_layer) if e is None]
         if missing:
             raise ValueError(
-                f"No KVCacheGroupSpec covers layer indices {missing}; "
-                "the model's get_kv_cache_spec hook must return a spec "
-                f"for every attention layer (expected {num_layers})"
+                f"No KVCacheTensor covers layer indices {missing}; "
+                "every attention layer must appear in some "
+                "kv_cache_tensors[i].shared_by"
             )
         return per_layer  # type: ignore[return-value]
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -404,12 +404,18 @@ class TTModelRunner:
             kv_cache_config.num_blocks,
         )
 
+        # Number of kv_cache_groups; needed by DP gather/merge to pack
+        # per-group block tables into the gather payload.
+        self._num_kv_cache_groups = len(kv_cache_groups)
         # Cache layer→group index mapping for hybrid models so submit_*
         # can expand ``block_tables_per_group`` into ``block_tables_per_layer``
         # without re-deriving vLLM's group construction order. Non-hybrid
-        # models skip the expansion entirely (mapping stays None).
+        # configurations (single group) skip the expansion entirely. The
+        # check is on ``len(kv_cache_groups)`` rather than the model class
+        # so it works on every DP rank — only ``data_parallel_rank_local
+        # == 0`` actually loads ``self.model``.
         self._layer_to_group_idx: list[int] | None = None
-        if hasattr(type(self.model), "get_kv_cache_spec"):
+        if len(kv_cache_groups) > 1:
             num_layers = self.model_config.get_num_layers_by_block_type(
                 self.parallel_config, "attention"
             )
@@ -422,8 +428,8 @@ class TTModelRunner:
             if missing:
                 raise ValueError(
                     f"No KVCacheGroupSpec covers layer indices {missing} "
-                    f"on hybrid model {type(self.model).__name__}; every "
-                    "attention layer must appear in some group's layer_names."
+                    f"on hybrid model; every attention layer must appear "
+                    "in some group's layer_names."
                 )
             self._layer_to_group_idx = mapping  # type: ignore[assignment]
 
@@ -1170,12 +1176,18 @@ class TTModelRunner:
         """
 
         max_batch = int(self.scheduler_config.max_num_seqs)
+        num_groups = self._num_kv_cache_groups
         if model_input is None:
             tokens = torch.zeros((max_batch, 1), dtype=torch.int32)
             positions = torch.full((max_batch,), -1, dtype=torch.int32)
-            block_tables = torch.zeros(
-                (max_batch, max_blocks_decode_batch), dtype=torch.int32
-            )
+            # One zero-filled block table per kv_cache_group so the gather
+            # payload always carries G * B * W block_table ints regardless
+            # of whether this rank has local work.
+            block_tables_per_group = [
+                torch.zeros((max_batch, max_blocks_decode_batch), dtype=torch.int32)
+                for _ in range(num_groups)
+            ]
+            block_tables = block_tables_per_group[0]
             unpadded_batch_size = torch.tensor([0], dtype=torch.int32)
             # Create default sampling parameter tensors (max_batch sized)
             sampling_default_tensors = (
@@ -1195,19 +1207,26 @@ class TTModelRunner:
         else:
             tokens = model_input.input_tokens
             positions = model_input.input_positions
-            block_tables = model_input.block_tables
-            # Pad block tables to max_blocks_decode_batch
-            if block_tables.shape[1] < max_blocks_decode_batch:
-                pad_w = max_blocks_decode_batch - block_tables.shape[1]
-                block_tables = torch.cat(
-                    [
-                        block_tables,
-                        torch.zeros(
-                            (block_tables.shape[0], pad_w), dtype=block_tables.dtype
-                        ),
-                    ],
-                    dim=1,
-                )
+            # Pad each group's block_table out to ``max_blocks_decode_batch``
+            # so the gather payload has a fixed shape regardless of which
+            # group carries the most blocks for this rank.
+            block_tables_per_group = []
+            for bt in model_input.block_tables_per_group:
+                if bt.shape[1] < max_blocks_decode_batch:
+                    pad_w = max_blocks_decode_batch - bt.shape[1]
+                    bt = torch.cat(
+                        [
+                            bt,
+                            torch.zeros((bt.shape[0], pad_w), dtype=bt.dtype),
+                        ],
+                        dim=1,
+                    )
+                block_tables_per_group.append(bt)
+            assert len(block_tables_per_group) == num_groups, (
+                f"build_dp_decode_gather_input: expected {num_groups} "
+                f"per-group block tables, got {len(block_tables_per_group)}"
+            )
+            block_tables = block_tables_per_group[0]
             unpadded_batch_size = torch.tensor(
                 [cast(int, model_input.unpadded_batch_size)], dtype=torch.int32
             )
@@ -1233,12 +1252,20 @@ class TTModelRunner:
             else torch.arange(max_batch, dtype=torch.int32)
         )
         # Pack into flattened tensors to reduce number of collectives.
-        # B = max batch size, W = max_num_blocks_per_req.
+        # B = max batch size, W = max_num_blocks_per_req, G = num kv_cache_groups.
+        # Layout includes one block_table block per group (G*B*W ints) so
+        # hybrid models can carry per-group routing through DP gather; for
+        # the legacy single-group case G == 1 and the layout is byte-
+        # identical to the pre-hybrid format.
+        block_tables_packed = torch.cat(
+            [bt.contiguous().view(-1) for bt in block_tables_per_group],
+            dim=0,
+        )
         int_inputs = torch.cat(
             [
                 tokens.contiguous().view(-1),  # B
                 positions.contiguous().view(-1),  # B
-                block_tables.contiguous().view(-1),  # B*W
+                block_tables_packed,  # G*B*W
                 unpadded_batch_size.contiguous().view(-1),  # 1
                 top_k.contiguous().view(-1),  # B
                 seed.contiguous().view(-1),  # B
@@ -1391,15 +1418,24 @@ class TTModelRunner:
                     f"max_blocks_decode_batch={W} exceeds "
                     f"max_num_blocks_per_req={max_bt_width}"
                 )
-            block_tables_raw = stacked_int[:, off : off + B * W].reshape(total_B, W)
-            off += B * W
-            if max_bt_width == W:
-                block_tables = block_tables_raw
-            else:
-                # Pad to constant width expected by TT backend.
-                # Use new_zeros to match dtype/device of gathered tensors.
-                block_tables = block_tables_raw.new_zeros((total_B, max_bt_width))
-                block_tables[:, :W] = block_tables_raw
+            num_groups = self._num_kv_cache_groups
+            # Layout: ``[world, G, B, W]`` because every rank packs its
+            # block tables in kv_cache_group order and the gather stacks
+            # ranks. Reshape per-group and reassemble each group's table
+            # as ``[total_B, W]`` then pad to the kernel-expected width.
+            block_tables_raw_per_group = stacked_int[
+                :, off : off + num_groups * B * W
+            ].reshape(world, num_groups, B, W)
+            off += num_groups * B * W
+            block_tables_per_group: list[torch.Tensor] = []
+            for g in range(num_groups):
+                bt_g = block_tables_raw_per_group[:, g, :, :].reshape(total_B, W)
+                if max_bt_width != W:
+                    padded = bt_g.new_zeros((total_B, max_bt_width))
+                    padded[:, :W] = bt_g
+                    bt_g = padded
+                block_tables_per_group.append(bt_g)
+            block_tables = block_tables_per_group[0]
 
             bs_tensor = stacked_int[:, off]
             off += 1
@@ -1495,6 +1531,13 @@ class TTModelRunner:
         else:
             input_tokens_list: list[torch.Tensor] = []
             block_tables_list: list[torch.Tensor] = []
+            # ``block_tables_per_group_list[g]`` holds one entry per active
+            # rank (the rank's group-``g`` block table padded to a common
+            # width). Concatenated across ranks at the end so hybrid
+            # prefill carries per-group routing through the merged input.
+            block_tables_per_group_list: list[list[torch.Tensor]] = [
+                [] for _ in range(self._num_kv_cache_groups)
+            ]
             input_positions_list: list[
                 torch.Tensor
             ] = []  # (prefix cache positions for prefill)
@@ -1549,6 +1592,16 @@ class TTModelRunner:
                     assert mi.prompt_lens is not None
                     prompt_lens_list.append(mi.prompt_lens)
                     block_tables_list.append(pad_block_tables(mi.block_tables))
+                    assert (
+                        len(mi.block_tables_per_group)
+                        == self._num_kv_cache_groups
+                    ), (
+                        f"DP merge: rank input has "
+                        f"{len(mi.block_tables_per_group)} block_tables_per_group "
+                        f"entries, expected {self._num_kv_cache_groups}"
+                    )
+                    for g, bt_g in enumerate(mi.block_tables_per_group):
+                        block_tables_per_group_list[g].append(pad_block_tables(bt_g))
                     input_positions_list.append(mi.input_positions)
 
                     # Extract sampling parameter tensors from TTSamplingParams
@@ -1591,6 +1644,12 @@ class TTModelRunner:
             input_positions = np.concatenate(input_positions_list, axis=0)
             prompt_lens = np.concatenate(prompt_lens_list, axis=0)
             block_tables = torch.cat(block_tables_list, dim=0)
+            # Build the per-group merged view here so the prefill branch
+            # exits with the same shape contract as the decode branch.
+            block_tables_per_group = [
+                torch.cat(per_rank, dim=0)
+                for per_rank in block_tables_per_group_list
+            ]
 
             # Concatenate sampling parameter tensors across DP ranks
             temperature = torch.cat(temperature_list, dim=0)
@@ -1692,14 +1751,15 @@ class TTModelRunner:
             input_positions=input_positions,
             prompt_lens=prompt_lens,
             block_tables=block_tables,
-            # DP merged path collapses to group-0 only for now; full
-            # per-group DP gather is not yet implemented. Hybrid models on
-            # DP > 1 are gated by ``TTWorker.get_kv_cache_spec`` until
-            # then. ``block_tables_per_layer`` stays None on this path —
-            # if a hybrid model ever runs DP > 1 the gate above will fire
-            # before we get here.
-            block_tables_per_group=[block_tables],
-            block_tables_per_layer=None,
+            # ``block_tables_per_group`` carries each kv_cache_group's
+            # block table merged across DP ranks (decode unpacks them
+            # from ``int_inputs``; prefill concatenates rank-by-rank).
+            # ``_block_tables_per_layer`` then expands the per-group view
+            # into the per-layer list the hybrid bridge consumes.
+            block_tables_per_group=block_tables_per_group,
+            block_tables_per_layer=self._block_tables_per_layer(
+                block_tables_per_group
+            ),
             unpadded_batch_size=batch_size_per_dp,
             tt_sampling_params=tt_sampling_params,
             multi_modal_kwargs=multi_modal_kwargs,
@@ -1888,15 +1948,12 @@ class TTModelRunner:
             "prompt_lens": model_input.prompt_lens,
             "start_pos": model_input.input_positions,
         }
-        # Hybrid attention models route per-layer block tables; they opt
-        # in by exposing ``get_kv_cache_spec`` (same marker the worker
-        # uses to pick the hybrid kv cache spec path). The runner cached
-        # the layer→group index mapping at ``initialize_kv_cache`` and
-        # ``_block_tables_per_layer`` already expanded the per-group list
-        # into a per-layer list aligned with the model's ``self.layers``
-        # — bridges just pass it straight through. Legacy models never
-        # see the kwarg.
-        if hasattr(type(self.model), "get_kv_cache_spec"):
+        # Hybrid attention models route per-layer block tables; the
+        # runner already expanded ``block_tables_per_group`` into a
+        # per-layer list at submission time when the kv_cache_config has
+        # multiple groups. Legacy/uniform models leave it as ``None``
+        # and never see the kwarg.
+        if model_input.block_tables_per_layer is not None:
             kwargs["page_tables_per_layer"] = model_input.block_tables_per_layer
         kwargs.update(model_input.multi_modal_kwargs)
         if model_input.perform_device_sampling:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -507,7 +507,34 @@ class TTModelRunner:
         """
         if self._layer_to_group_idx is None:
             return None
-        return [block_tables_per_group[g] for g in self._layer_to_group_idx]
+        result = [block_tables_per_group[g] for g in self._layer_to_group_idx]
+        # Pad to the warmup shape ``[max_batch, max_num_blocks_per_req]``.
+        # The model side (``Transformer._page_tables_to_ttnn``) allocates
+        # *persistent* ttnn device tensors at this shape during warmup so
+        # captured traces can be replayed against stable device addresses;
+        # ``ttnn.copy_host_to_device_tensor`` then asserts
+        # ``host_shape == device_shape`` when the runtime per-layer block
+        # tables push their content into those buffers. Padding rows with
+        # zeros is harmless — the kernel only reads up to each layer's
+        # active block count.
+        max_batch = int(self.scheduler_config.max_num_seqs) * int(
+            self.parallel_config.data_parallel_size
+        )
+        target_shape = (max_batch, self.max_num_blocks_per_req)
+        padded = []
+        for bt in result:
+            if bt is None:
+                padded.append(None)
+                continue
+            if bt.shape == target_shape:
+                padded.append(bt)
+                continue
+            full = torch.zeros(target_shape, dtype=bt.dtype)
+            rows = min(bt.shape[0], target_shape[0])
+            cols = min(bt.shape[1], target_shape[1])
+            full[:rows, :cols] = bt[:rows, :cols]
+            padded.append(full)
+        return padded
 
     def _build_per_layer_specs(
         self, kv_cache_config: KVCacheConfig, num_layers: int

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -928,14 +928,19 @@ class TTModelRunner:
                 input_positions = torch.cat(
                     [input_positions, torch.ones(batch_pad, dtype=torch.int32) * -1]
                 )
-                block_tables = torch.cat(
-                    [
-                        block_tables,
-                        torch.zeros(
-                            batch_pad, block_tables.shape[1], dtype=torch.int32
-                        ),
-                    ]
-                )
+                # Pad each per-group block table to max_num_reqs so DP
+                # gather produces a fixed-shape payload regardless of how
+                # many users are active on this rank. Keep ``block_tables``
+                # aliased to the (now padded) group-0 view, matching the
+                # alias set up where ``block_tables_per_group`` is built.
+                block_tables_per_group = [
+                    torch.cat(
+                        [bt, torch.zeros(batch_pad, bt.shape[1], dtype=bt.dtype)],
+                        dim=0,
+                    )
+                    for bt in block_tables_per_group
+                ]
+                block_tables = block_tables_per_group[0]
                 # Pad sampling parameters with default values
                 sample_params.pad_with_defaults(num_reqs)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -211,6 +211,16 @@ class TTPlatform(Platform):
     simple_compile_backend: str = "eager"
 
     @classmethod
+    def support_hybrid_kv_cache(cls) -> bool:
+        # Hybrid models (Gemma3/4, GPT-OSS) opt in to upstream's HMA via
+        # ``HybridAttentionForCausalLM.get_kv_cache_spec`` so layers from
+        # different attention groups can share DRAM tensors. Without this
+        # override the base ``Platform`` returns ``False`` and HMA collapses
+        # every ``SlidingWindowSpec`` back to ``FullAttentionSpec`` in
+        # ``unify_hybrid_kv_cache_specs`` — defeating the entire point.
+        return True
+
+    @classmethod
     def pre_register_and_update(
         cls, parser: FlexibleArgumentParser | None = None
     ) -> None:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -147,30 +147,9 @@ class TTWorker(WorkerBase):
         """
         spec_from_hook = self._try_get_spec_from_model_hook()
         if spec_from_hook is not None:
-            self._guard_hybrid_under_dp(spec_from_hook)
             return spec_from_hook
 
         return self._build_default_kv_cache_spec()
-
-    def _guard_hybrid_under_dp(self, spec: dict[str, KVCacheSpec]) -> None:
-        """Reject hybrid (multi-spec) configurations when running with
-        ``data_parallel_size > 1``.
-
-        The DP merge path in :class:`TTModelRunner` currently collapses to
-        a single group-0 block table when concatenating per-rank inputs, so
-        running a hybrid model under DP would silently send only group 0
-        to the device and corrupt KV state for the sliding-window groups.
-        Per-group DP gather isn't implemented yet; fail fast at config
-        time until it is.
-        """
-        spec_types = {type(s) for s in spec.values()}
-        if len(spec_types) > 1 and self.parallel_config.data_parallel_size > 1:
-            raise NotImplementedError(
-                "Hybrid attention models with mixed kv cache types are not "
-                "yet supported with data_parallel_size > 1 on the TT backend. "
-                "Run with data_parallel_size=1, or use a uniform-attention "
-                "model under DP."
-            )
 
     def _try_get_spec_from_model_hook(self) -> dict[str, KVCacheSpec] | None:
         """If the resolved TT model class implements ``get_kv_cache_spec``,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -180,8 +180,25 @@ class TTWorker(WorkerBase):
         """
         from vllm.model_executor.models.registry import ModelRegistry
 
+        # ``ModelConfig.architecture`` (singular) is computed in
+        # ``ModelConfig.__post_init__`` from ``hf_config.architectures``
+        # *before* :meth:`TTPlatform.check_and_update_config` prepends ``"TT"``
+        # to the architectures list. As a result the cached property still
+        # holds the upstream (e.g. CUDA) name, and resolving it would find
+        # upstream's vLLM model class — which doesn't have our
+        # ``get_kv_cache_spec`` hook. Prefer the prefixed entry from the
+        # ``architectures`` list (which the platform modifies in-place) and
+        # fall back to prepending ``"TT"`` when neither is available.
+        arch = next(
+            (a for a in self.model_config.architectures if a.startswith("TT")),
+            None,
+        )
+        if arch is None:
+            arch = self.model_config.architecture
+            if not arch.startswith("TT"):
+                arch = "TT" + arch
         model_cls, _ = ModelRegistry.resolve_model_cls(
-            self.model_config.architecture, model_config=self.model_config
+            arch, model_config=self.model_config
         )
         hook = getattr(model_cls, "get_kv_cache_spec", None)
         if hook is None:

--- a/tests/v1/tt/test_initialize_kv_cache.py
+++ b/tests/v1/tt/test_initialize_kv_cache.py
@@ -133,7 +133,9 @@ def test_initialize_single_group_calls_model_allocate(runner):
     assert len(per_layer_specs) == 32
     # Each layer gets a unique ``tensor_idx`` in the single-group path so
     # legacy (uniform) callers retain one buffer per layer.
-    assert all(s == (expected_shape, torch.bfloat16, i) for i, s in enumerate(per_layer_specs))
+    assert all(
+        s == (expected_shape, torch.bfloat16, i) for i, s in enumerate(per_layer_specs)
+    )
     assert runner.kv_caches == "kv-caches-sentinel"
     assert runner.kv_cache_config is config
 

--- a/tests/v1/tt/test_initialize_kv_cache.py
+++ b/tests/v1/tt/test_initialize_kv_cache.py
@@ -131,7 +131,9 @@ def test_initialize_single_group_calls_model_allocate(runner):
     (per_layer_specs,), _ = runner.model.allocate_kv_cache_per_layer.call_args
     expected_shape = (2048, 8 // min(2, 8), 64, 128)
     assert len(per_layer_specs) == 32
-    assert all(s == (expected_shape, torch.bfloat16) for s in per_layer_specs)
+    # Each layer gets a unique ``tensor_idx`` in the single-group path so
+    # legacy (uniform) callers retain one buffer per layer.
+    assert all(s == (expected_shape, torch.bfloat16, i) for i, s in enumerate(per_layer_specs))
     assert runner.kv_caches == "kv-caches-sentinel"
     assert runner.kv_cache_config is config
 
@@ -139,7 +141,8 @@ def test_initialize_single_group_calls_model_allocate(runner):
 def test_initialize_multi_group_assigns_specs_per_layer(runner):
     """Hybrid configuration: 2 full-attention layers + 4 sliding-window
     layers should produce a per-layer spec list where each layer's shape
-    matches its group's spec.
+    matches its group's spec, and ``tensor_idx`` matches the
+    ``kv_cache_tensors`` sharing layout (one tensor per unique buffer).
     """
     runner.model_config.get_num_layers_by_block_type.return_value = 6
     runner.model.allocate_kv_cache_per_layer.return_value = "kv-caches-sentinel"
@@ -147,6 +150,27 @@ def test_initialize_multi_group_assigns_specs_per_layer(runner):
     sliding = _sliding_spec(
         num_kv_heads=4, head_size=128, block_size=64, sliding_window=1024
     )
+    # Two unique DRAM buffers, each shared by one full + two sliding
+    # layers — mirrors upstream's HMA tensor-sharing layout for n:1
+    # patterns.
+    tensors = [
+        KVCacheTensor(
+            size=1,
+            shared_by=[
+                "model.layers.0.self_attn",
+                "model.layers.1.self_attn",
+                "model.layers.2.self_attn",
+            ],
+        ),
+        KVCacheTensor(
+            size=1,
+            shared_by=[
+                "model.layers.5.self_attn",
+                "model.layers.3.self_attn",
+                "model.layers.4.self_attn",
+            ],
+        ),
+    ]
     config = _config(
         [
             KVCacheGroupSpec(
@@ -164,6 +188,7 @@ def test_initialize_multi_group_assigns_specs_per_layer(runner):
             ),
         ],
         num_blocks=512,
+        tensors=tensors,
     )
 
     runner.initialize_kv_cache(config)
@@ -173,13 +198,17 @@ def test_initialize_multi_group_assigns_specs_per_layer(runner):
     full_shape = (512, 4 // min(2, 4), 64, 128)
     sliding_shape = (512, 4 // min(2, 4), 64, 128)
     # Layer indices 0 and 5 are full attention; 1-4 are sliding window.
-    # (Shapes happen to match since both groups share kv-heads/head-size in
-    # this fixture; the spec types differ, which is the structural change
-    # that propagates downstream once forward routing lands.)
     assert per_layer_specs[0][0] == full_shape
     assert per_layer_specs[5][0] == full_shape
     assert per_layer_specs[1][0] == sliding_shape
     assert per_layer_specs[4][0] == sliding_shape
+    # Tensor index reflects sharing: layers 0, 1, 2 → buffer 0; 5, 3, 4 → buffer 1.
+    assert per_layer_specs[0][2] == 0
+    assert per_layer_specs[1][2] == 0
+    assert per_layer_specs[2][2] == 0
+    assert per_layer_specs[5][2] == 1
+    assert per_layer_specs[3][2] == 1
+    assert per_layer_specs[4][2] == 1
 
 
 def test_initialize_stores_config_even_when_not_dp_rank_zero(runner):
@@ -211,9 +240,8 @@ def test_build_per_layer_specs_rejects_unparseable_layer_name(runner):
 
 
 def test_build_per_layer_specs_rejects_missing_layers(runner):
-    """If the spec hook didn't return a spec for every attention layer,
-    we should fail loudly in the multi-group path rather than silently
-    allocating None for the missing layers."""
+    """If kv_cache_tensors doesn't cover every attention layer, fail
+    loudly rather than silently leaving holes in the per-layer list."""
     runner.model_config.get_num_layers_by_block_type.return_value = 4
     config = _config(
         [
@@ -230,17 +258,26 @@ def test_build_per_layer_specs_rejects_missing_layers(runner):
 
 
 def test_build_per_layer_specs_rejects_duplicate_layer(runner):
+    """A layer named in two different KVCacheTensors must error — every
+    layer must map to exactly one DRAM buffer."""
+    full = _full_spec()
+    sliding = _sliding_spec()
+    tensors = [
+        KVCacheTensor(size=1, shared_by=["model.layers.0.self_attn"]),
+        KVCacheTensor(size=1, shared_by=["model.layers.0.self_attn"]),
+    ]
     config = _config(
         [
             KVCacheGroupSpec(
-                layer_names=["model.layers.0.self_attn"], kv_cache_spec=_full_spec()
+                layer_names=["model.layers.0.self_attn"], kv_cache_spec=full
             ),
             KVCacheGroupSpec(
-                layer_names=["model.layers.0.self_attn"], kv_cache_spec=_sliding_spec()
+                layer_names=["model.layers.1.self_attn"], kv_cache_spec=sliding
             ),
-        ]
+        ],
+        tensors=tensors,
     )
-    with pytest.raises(ValueError, match="already.*assigned"):
+    with pytest.raises(ValueError, match="more than one KVCacheTensor"):
         runner._build_per_layer_specs(config, num_layers=2)
 
 

--- a/tests/v1/tt/test_kv_cache_spec.py
+++ b/tests/v1/tt/test_kv_cache_spec.py
@@ -141,16 +141,17 @@ def test_default_spec_passes_sliding_window(resolve, worker):
 
 
 @patch("vllm.model_executor.models.registry.ModelRegistry.resolve_model_cls")
-def test_hybrid_under_dp_rejected(resolve, worker):
-    """Hybrid spec (mixed FullAttention + SlidingWindow) under DP > 1 is
-    rejected at spec-resolution time. The DP merged path doesn't yet
-    gather per-group block tables, so silent group-0 collapse would
-    corrupt KV state for the sliding-window groups."""
+def test_hybrid_under_dp_returns_full_spec(resolve, worker):
+    """Hybrid spec (mixed FullAttention + SlidingWindow) under DP > 1
+    flows through unchanged: the DP gather/merge path now packs every
+    kv_cache_group's block table into the gather payload and rebuilds
+    them on the driver, so per-rank routing survives the merge."""
     resolve.return_value = (_ModelHookReturningSpecs, "TestArch")
     worker.parallel_config.data_parallel_size = 2
 
-    with pytest.raises(NotImplementedError, match="data_parallel_size"):
-        worker.get_kv_cache_spec()
+    spec = worker.get_kv_cache_spec()
+
+    assert {type(s) for s in spec.values()} == {FullAttentionSpec, SlidingWindowSpec}
 
 
 @patch("vllm.model_executor.models.registry.ModelRegistry.resolve_model_cls")


### PR DESCRIPTION
## Summary

Three follow-ups to PR #381 surfaced while wiring gemma-3 / gpt-oss into the kv-cache-groups path locally:

- **Enable HMA on TT.** `TTPlatform` inherits the base `Platform.support_hybrid_kv_cache() → False`, which makes vLLM set `scheduler_config.disable_hybrid_kv_cache_manager = True` and call `unify_hybrid_kv_cache_specs` to collapse every `SlidingWindowSpec` back to `FullAttentionSpec`. The hybrid spec hook returns the right thing, but the manager throws it away. Override the platform method to return `True` so HMA actually engages.

- **Honor upstream's tensor-sharing layout.** `_build_per_layer_specs` previously walked `kv_cache_groups` directly and emitted one tuple per layer; with HMA enabled, vLLM places layers from full and sliding-window groups at the same position-within-group so they can share one DRAM buffer (e.g. for a 5:1 sliding/full pattern, 34 layers collapse to ~6 unique tensors). Drive the per-layer list from `kv_cache_config.kv_cache_tensors.shared_by` instead, and emit `(shape, dtype, tensor_idx)` triples so the tt-metal allocator (companion PR) can dedupe. For Gemma3-4b on N150 this lets the model fit instead of OOMing at layer 9 of 34.

- **Resolve TT-prefixed arch when probing the spec hook.** `ModelConfig.architecture` (singular) is cached in `__post_init__` from `hf_config.architectures` *before* `TTPlatform.check_and_update_config` prepends `\"TT\"` to the architectures list. Resolving the cached architecture string therefore returned the upstream (e.g. CUDA) model class, which lacks our hybrid-spec hook — so hybrid models silently fell back to the single-spec default. Prefer the TT-prefixed entry from the architectures list and only fall back to prepending when none is present.

The companion tt-metal change is at https://github.com/tenstorrent/tt-metal/commit/317efab877f.

## Test plan
- [x] `tests/v1/tt/test_initialize_kv_cache.py` — covers the new `tensor_idx` contract, multi-group sharing layout, and updated error messages
- [x] End-to-end: `HF_MODEL=/proj_sw/user_dev/google/gemma-3-4b-it/ python3 examples/server_example_tt.py --model google/gemma-3-4b-it --async-scheduling` on N150 — KV alloc succeeds (5 unique buffers vs 34 layers), prefill warmup, decode warmup, and API server startup all complete
- [ ] CI: gpt-oss and gemma3 nightlies

🤖 Generated with [Claude Code](https://claude.com/claude-code)