### PR TITLE
gpt-oss AIME fixes: harmony parser + DP barrier (#386, #387)

### DIFF
--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -8,6 +8,7 @@ from typing import Literal
 from openai.types.responses.tool import Tool
 from openai_harmony import (
     Author,
+    ChannelConfig,
     Conversation,
     DeveloperContent,
     HarmonyEncodingName,
@@ -100,6 +101,17 @@ def get_system_message(
         sys_msg_content = sys_msg_content.with_tools(python_description)
     if container_description is not None:
         sys_msg_content = sys_msg_content.with_tools(container_description)
+    if not with_custom_tools:
+        # Restrict valid channels to {analysis, final} when there are no
+        # custom tools so the model does not emit commentary-channel
+        # transitions whose boundary tokens the parser is not robust to.
+        # See tenstorrent/vllm#386.
+        channel_config = sys_msg_content.channel_config
+        invalid_channel = "commentary"
+        new_config = ChannelConfig.require_channels(
+            [c for c in channel_config.valid_channels if c != invalid_channel]
+        )
+        sys_msg_content = sys_msg_content.with_channel_config(new_config)
     sys_msg = Message.from_role_and_content(Role.SYSTEM, sys_msg_content)
     return sys_msg
 
@@ -334,8 +346,26 @@ def get_streamable_parser_for_assistant() -> StreamableParser:
 
 def parse_output_into_messages(token_ids: Iterable[int]) -> StreamableParser:
     parser = get_streamable_parser_for_assistant()
+    stop_tokens = set(get_stop_tokens_for_assistant_actions())
     for token_id in token_ids:
-        parser.process(token_id)
+        try:
+            parser.process(token_id)
+        except Exception as e:
+            # Tolerate mid-stream harmony parse errors caused by stray
+            # tokens between messages. The model can occasionally emit
+            # corrupt control-token sequences at message boundaries
+            # (e.g. doubled <|start|>, content tokens before <|start|>);
+            # return whatever was successfully parsed before the bad token
+            # rather than letting the openai_harmony Rust binding raise out
+            # to the route handler. See tenstorrent/vllm#386.
+            logger.warning(
+                "Harmony parser error at token %d, returning partial parse: %r",
+                token_id,
+                e,
+            )
+            break
+        if token_id in stop_tokens:
+            break
     return parser
 
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1603,6 +1603,18 @@ class DPEngineCoreProc(EngineCoreProc):
 
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
+            # Rendezvous all DP ranks at iteration start to prevent
+            # FIFO-collective skew accumulation across iterations.
+            # gloo collectives are matched in call order per group, so
+            # once ranks drift apart in iteration count every subsequent
+            # collective deadlocks. See tenstorrent/vllm#387.
+            if self.requires_gather:
+                try:
+                    dist.barrier(group=self.dp_group)
+                except RuntimeError as e:
+                    if "Connection closed by peer" in str(e):
+                        raise SystemExit() from e
+                    raise
             # 1) Poll the input queue until there is work to do.
             self._process_input_queue()
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1546,15 +1546,27 @@ class DPEngineCoreProc(EngineCoreProc):
                 stateless_destroy_torch_distributed_process_group(dp_group)
 
     def add_request(self, request: Request, request_wave: int = 0):
+        start_wave = False
         if self.has_coordinator and request_wave != self.current_wave:
             if request_wave > self.current_wave:
                 self.current_wave = request_wave
             elif not self.engines_running:
                 # Request received for an already-completed wave, notify
                 # front-end that we need to start the next one.
-                self.output_queue.put_nowait(
-                    (-1, EngineCoreOutputs(start_wave=self.current_wave))
-                )
+                start_wave = True
+
+        if self.has_coordinator and not self.engines_running:
+            # The front-end normally notifies the coordinator before sending
+            # the first request in a new wave. If that notification races with
+            # wave completion state, the engine receiving the request must still
+            # wake its peers before entering gathered-DP collectives.
+            self.engines_running = True
+            start_wave = True
+
+        if start_wave:
+            self.output_queue.put_nowait(
+                (-1, EngineCoreOutputs(start_wave=self.current_wave))
+            )
 
         super().add_request(request, request_wave)
 


### PR DESCRIPTION
## Summary

- **#386 fix**: gpt-oss harmony parser regression from the v0.16 merge (`3325e5892`). Restores the v0.12 channel restriction in `get_system_message` and makes `parse_output_into_messages` tolerant of mid-stream parse errors so a transient harmony error returns the partial parse instead of surfacing as a 200-OK-with-error-body to the client.
- **#387 partial workaround**: cherry-picks Viktor's `add_request` wave-state fix and adds a `dist.barrier()` rendezvous at the top of `DPEngineCoreProc.run_busy_loop`. Prevents FIFO-collective drift across iterations. This is a partial workaround — the full fix for the async-scheduling × DP coordination deadlock requires structural changes to `tt_engine_step.py`'s `_finalize_previous` path (see #387). Until that lands, the documented stable configuration is this branch + `--no-async-scheduling` + `lm_eval ... num_concurrent=4`.

## Test plan

- AIME25 end-to-end on gpt-oss-120b, Galaxy 4x8, `data_parallel_size=4`, `--no-async-scheduling`, `num_concurrent=4` — completed 30/30 over two reproducible runs:
  - Run 1: `exact_match 0.8333 ± 0.0692` in 3:15:45
  - Run 2: `exact_match 0.8667 ± 0.0631` in 2:54:44
- Both within stderr; no `BadRequestError 400` from the client; no engine hangs or 0.0 tok/s stalls.

## Notes

- The harmony fix is independent and self-contained — it can be merged on its own if the DP barrier piece needs more review.
- The DP barrier change is gated on `self.requires_gather` so non-DP code paths are untouched.
- Closes #386. Partial fix toward #387.
