### PR TITLE
Fix max_num_logprobs propagation in model runner

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1094,10 +1094,6 @@ class TTModelRunner:
             # This means sampling is not perfectly deterministic
             # whenever device sampling is enabled.
 
-        max_num_logprobs = input_batch.max_num_logprobs
-        if max_num_logprobs is None:
-            max_num_logprobs = 0
-
         return TTModelInput(
             input_tokens=input_tokens,
             input_positions=input_positions,
@@ -1117,7 +1113,7 @@ class TTModelRunner:
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
             bad_words_token_ids_list=[input_batch.sampling.bad_words_token_ids],
-            max_num_logprobs=[max_num_logprobs],
+            max_num_logprobs=[input_batch.max_num_logprobs],
             logitsprocs_list=[input_batch.sampling.logitsprocs],
             generators_list=[generators],
         )


### PR DESCRIPTION
## Purpose

This bug only manifested in reduced performance, since `max_num_logprobs=0` disabled steady async decode overlap. Mean TPOT on Llama 1B N150 was around 84.5 ms with and without async scheduling. With this fix, async scheduling is back to around 82.5 ms, same as the original async implementation. This bug was likely introduced by the recent plugin separation, or perhaps other changes in logprobs propagation.

## Test Result

CI: https://github.com/tenstorrent/tt-metal/actions/runs/25857823736
