### PR TITLE
Fix token doubling in DP async-scheduling overlap path (#395)

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -563,11 +563,17 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 handle.scheduler_output, model_output
             )
 
-        finalize_before_submit = prev_handle is not None and (
-            not global_has_requests
-            or not prev_handle.overlap_ok
-            or not current_overlap_ok
-        )
+        # Always finalize the previous step before submitting the next one.
+        #
+        # The submit reads ``input_batch.token_ids_cpu`` to build the decode
+        # input for the next step; that table is only updated once
+        # ``apply_dp_execution_result`` runs inside ``_finalize_previous``. The
+        # original overlap path (submit-next then finalize-prev) therefore
+        # built the next step's input from stale token state, so the device
+        # re-sampled the previous step's near-deterministic position — most
+        # visibly as doubled ``<|end|>`` and ``<|start|>assistant`` tokens,
+        # which break harmony parsing and silently null out chat responses.
+        finalize_before_submit = prev_handle is not None
 
         engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
         if finalize_before_submit:

--- a/setup.py
+++ b/setup.py
@@ -817,6 +817,10 @@ def _is_xpu() -> bool:
     return VLLM_TARGET_DEVICE == "xpu"
 
 
+def _is_tt() -> bool:
+    return VLLM_TARGET_DEVICE == "tt"
+
+
 def _build_custom_ops() -> bool:
     return _is_cuda() or _is_hip() or _is_cpu()
 
@@ -906,6 +910,8 @@ def get_vllm_version() -> str:
             version += f"{sep}cpu"
     elif _is_xpu():
         version += f"{sep}xpu"
+    elif _is_tt():
+        version += f"{sep}tt"
     else:
         raise RuntimeError("Unknown runtime environment")
 
@@ -952,6 +958,8 @@ def get_requirements() -> list[str]:
         requirements = _read_requirements("cpu.txt")
     elif _is_xpu():
         requirements = _read_requirements("xpu.txt")
+    elif _is_tt():
+        requirements = _read_requirements("common.txt")
     else:
         raise ValueError("Unsupported platform, please use CUDA, ROCm, or CPU.")
     return requirements
@@ -959,7 +967,9 @@ def get_requirements() -> list[str]:
 
 ext_modules = []
 
-if _is_cuda() or _is_hip():
+if _is_tt():
+    ext_modules = []
+elif _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
     ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
     # Optional since this doesn't get built (produce an .so file). This is just

--- a/setup.py
+++ b/setup.py
@@ -817,10 +817,6 @@ def _is_xpu() -> bool:
     return VLLM_TARGET_DEVICE == "xpu"
 
 
-def _is_tt() -> bool:
-    return VLLM_TARGET_DEVICE == "tt"
-
-
 def _build_custom_ops() -> bool:
     return _is_cuda() or _is_hip() or _is_cpu()
 
@@ -910,8 +906,6 @@ def get_vllm_version() -> str:
             version += f"{sep}cpu"
     elif _is_xpu():
         version += f"{sep}xpu"
-    elif _is_tt():
-        version += f"{sep}tt"
     else:
         raise RuntimeError("Unknown runtime environment")
 
@@ -958,8 +952,6 @@ def get_requirements() -> list[str]:
         requirements = _read_requirements("cpu.txt")
     elif _is_xpu():
         requirements = _read_requirements("xpu.txt")
-    elif _is_tt():
-        requirements = _read_requirements("common.txt")
     else:
         raise ValueError("Unsupported platform, please use CUDA, ROCm, or CPU.")
     return requirements
@@ -967,9 +959,7 @@ def get_requirements() -> list[str]:
 
 ext_modules = []
 
-if _is_tt():
-    ext_modules = []
-elif _is_cuda() or _is_hip():
+if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
     ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
     # Optional since this doesn't get built (produce an .so file). This is just


### PR DESCRIPTION
## Summary

Fixes #395 — silent token duplication under async-scheduling + DP overlap. With async-scheduling on (default on tt platform) and `data_parallel_size > 1`, `step_dp_with_batch_queue`'s overlap path submitted the next step before applying the previous step's sampled tokens to `input_batch`. The next step's `build_model_input` then pulled stale input tokens, the device re-sampled the previous near-deterministic position, and chat completions silently returned `content=null` from harmony parse failures.

This PR forces `finalize_before_submit = prev_handle is not None` every iteration, restoring apply-then-submit ordering.

Root-cause walkthrough and token-level evidence are in #395.

## Test plan

Measured on `gpt-oss-120b`, DP=4 on a Wormhole 4x8 galaxy, `vllm + viktorpus/fix-dp-zero-schedule` base (PR #394 applied) + this PR. `lm_eval --tasks aime25 --num_concurrent 16 --gen_kwargs reasoning_effort=high,do_sample=true,temperature=1.0,max_gen_toks=65536 --seed 42`:

| Config | Wall time | NULL content | Harmony parse errors | AIME25 score |
|---|---|---|---|---|
| `--no-async-scheduling` baseline | 35:18 | 0/30 | 0 | 0.7667 |
| async ON, before this PR (PR #394 only) | 51:21 | 18/30 | 12 | 0.1333 |
| async ON, after this PR | **37:29** | **0/30** | **0** | **0.80** |

Also ran a 16-request concurrent probe of mixed reasoning prompts directly against the chat endpoint:

| Config | NULL content | Harmony parse errors |
|---|---|---|
| async ON, before this PR (PR #394 only) | 4/16 | 4 |
| async ON, after this PR | 0/16 | 0 |

- [x] AIME25 30/30, async ON, no NULL responses, no harmony errors
- [x] AIME25 score within noise of `--no-async-scheduling` baseline
- [x] No regression on sync path (`step` is unaffected — only the async `step_dp_with_batch_queue` path changes)
- [x] Hang from #387 still does not reproduce on top of #394 (`tt-metal sraizada/gpt-oss-aime-release` @ `f7e2f8b499a`, 4x8 Galaxy, GWH01)

## Performance note

The host-side finalize work (`apply_dp_execution_result` + `update_from_output`) is no longer hidden behind the next device kick-off. Cost vs the sync path on the AIME25 workload above is ~6%. The async path is still 27% faster than its broken-overlap predecessor because rejected null responses no longer waste decode time.

A structural fix that preserves overlap is possible by splitting `apply_and_build_runner_output` into a fast "apply tokens to `input_batch`" half (run before submit) and a slower "build runner output" half (run after submit). That diff is non-trivial and touches the worker / model_runner / engine layers, so I'd suggest landing this minimal fix first and doing the structural one as a follow-up if the ~6% perf delta is felt.
