### PR TITLE
Use --additional_config, prefer it over --plugin_config

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -178,7 +178,7 @@ LLAMA_DIR=<path-to-weights> \
 TT_LLAMA_TEXT_VER=llama3_70b_galaxy \
 python plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
   --model "meta-llama/Llama-3.1-70B-Instruct" \
-  --plugin-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
 ```
 
 To run GPT-OSS 20B on Galaxy:
@@ -188,7 +188,7 @@ MESH_DEVICE="(4,8)" \
 python plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
   --model "openai/gpt-oss-20b" \
   --max_seqs_in_batch 1 \
-  --plugin-config '{"tt": {"fabric_config": "FABRIC_1D_RING"}}'
+  --additional-config '{"tt": {"fabric_config": "FABRIC_1D_RING"}}'
 ```
 
 Run Llama 3.2 Vision on N300:
@@ -207,8 +207,8 @@ Useful vision-model variants:
 - Llama 3.2 11B Vision on QuietBox: set `MESH_DEVICE=T3K` and `--max_seqs_in_batch 32`.
 - Llama 3.2 90B Vision: set `MESH_DEVICE=T3K`, `--model "meta-llama/Llama-3.2-90B-Vision-Instruct"`, and `--max_seqs_in_batch 4`.
 - Qwen 2.5-VL 32B: set `MESH_DEVICE=T3K`, `--model "Qwen/Qwen2.5-VL-32B"`, and `--max_seqs_in_batch 32`.
-- Qwen 2.5-VL 72B: set `MESH_DEVICE=T3K`, `--model "Qwen/Qwen2.5-VL-72B"`, `--max_seqs_in_batch 32`, `--max_model_len 2048`, and `--plugin-config '{"tt": {"trace_region_size": 28467200}}'`.
-- Gemma 3 27B: set `MESH_DEVICE=T3K`, `--model "google/gemma-3-27b-it"`, `--max_seqs_in_batch 32`, `--plugin-config '{"tt": {"l1_small_size": 768, "fabric_config": "FABRIC_1D"}}'`, `--multi_modal`, `--multi_image`, and `--mm_processor_kwargs '{"use_fast": true, "do_convert_rgb": true}'`.
+- Qwen 2.5-VL 72B: set `MESH_DEVICE=T3K`, `--model "Qwen/Qwen2.5-VL-72B"`, `--max_seqs_in_batch 32`, `--max_model_len 2048`, and `--additional-config '{"tt": {"trace_region_size": 28467200}}'`.
+- Gemma 3 27B: set `MESH_DEVICE=T3K`, `--model "google/gemma-3-27b-it"`, `--max_seqs_in_batch 32`, `--additional-config '{"tt": {"l1_small_size": 768, "fabric_config": "FABRIC_1D"}}'`, `--multi_modal`, `--multi_image`, and `--mm_processor_kwargs '{"use_fast": true, "do_convert_rgb": true}'`.
 
 For debugging V1, set `VLLM_ENABLE_V1_MULTIPROCESSING=0` to disable
 multiprocessing. This is useful for stepping through code or making scheduling
@@ -249,15 +249,15 @@ base64 `data:image/...` URL or a real URL such as
 
 ## Configuration
 
-TT options are passed through vLLM's generic plugin namespace:
+TT options are passed through vLLM's generic additional config namespace:
 
 ```bash
---plugin-config '{"tt": {"sample_on_device_mode": "all"}}'
+--additional-config '{"tt": {"sample_on_device_mode": "all"}}'
 ```
 
 Plugin code reads this through `vllm_tt_plugin.config.get_tt_config()`, which
-returns `vllm_config.plugin_config["tt"]`. Do not add TT-specific options to the
-core vLLM CLI namespace.
+returns `vllm_config.additional_config["tt"]`. The deprecated
+`--plugin-config '{"tt": {...}}'` form is still accepted with a warning.
 
 Common options:
 
@@ -405,7 +405,7 @@ python -u plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
   --model <MODEL_NAME> \
   --data_parallel_size 2 \
   --async_engine \
-  --plugin-config '{
+  --additional-config '{
     "tt": {
       "rank_binding": "<TT_METAL>/tests/tt_metal/distributed/config/dual_galaxy_rank_bindings.yaml",
       "extra_ttrun_args": "--tcp-interface cnx1",
@@ -423,7 +423,7 @@ Notes:
 - The `rank_binding` YAML needs an absolute path for `mesh_graph_desc_path`.
 - `config_pkl_dir` must be shared by all hosts.
 - Environment variables can be propagated through `env_passthrough` in
-  `--plugin-config` or through `global_env` in the rank-binding file.
+  `--additional-config` or through `global_env` in the rank-binding file.
 - `extra_ttrun_args` passes raw flags to `tt-run`, such as
   `"--tcp-interface cnx1"`, `"--bare"`, or `"--debug-gdbserver"`.
 
@@ -469,8 +469,6 @@ will work against stock vLLM without any fork.
 
 The extensions needed are:
 
-- `VllmConfig.plugin_config`: a namespaced dict that lets any plugin pass
-  backend-specific configuration without touching the core CLI.
 - `ParallelConfig.engine_core_cls`: lets a platform plugin select an
   alternative `EngineCore` implementation.
 - `ParallelConfig.engine_core_proc_cls`: lets a platform plugin select an

--- a/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
+++ b/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
@@ -319,14 +319,10 @@ def run_inference(
             if not isinstance(parsed_plugin_config, dict):
                 raise ValueError("plugin_config must be a JSON object")
 
-        if (
-            parsed_additional_config is not None
-            and parsed_plugin_config is not None
-            and parsed_additional_config != parsed_plugin_config
-        ):
+        if parsed_additional_config is not None and parsed_plugin_config is not None:
             raise ValueError(
-                "additional_config and plugin_config must contain identical "
-                "{'tt': {...}} content when both are provided"
+                "Only one of additional_config or plugin_config may be provided. "
+                "Prefer additional_config."
             )
         if parsed_additional_config is not None or parsed_plugin_config is not None:
             engine_kw_args["additional_config"] = (
@@ -704,7 +700,7 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help=(
-            "Deprecated alias for --additional-config. "
+            "Deprecated alias; prefer --additional-config. "
             "Value must use the same '{\"tt\": {...}}' JSON shape."
         ),
     )

--- a/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
+++ b/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -248,6 +249,7 @@ def run_inference(
     mm_processor_kwargs=None,
     test_increasing_seq_lens=False,
     plugin_config=None,
+    additional_config=None,
     max_model_len=None,
     max_num_batched_tokens=None,
     data_parallel_size=1,
@@ -300,13 +302,40 @@ def run_inference(
     }
 
     try:
+        parsed_additional_config = None
+        if additional_config:
+            parsed_additional_config = json.loads(additional_config)
+            if not isinstance(parsed_additional_config, dict):
+                raise ValueError("additional_config must be a JSON object")
+
+        parsed_plugin_config = None
         if plugin_config:
+            print(
+                "WARNING: --plugin-config is deprecated. "
+                "Use --additional-config '{\"tt\": {...}}' instead.",
+                file=sys.stderr,
+            )
             parsed_plugin_config = json.loads(plugin_config)
             if not isinstance(parsed_plugin_config, dict):
                 raise ValueError("plugin_config must be a JSON object")
-            engine_kw_args["plugin_config"] = parsed_plugin_config
+
+        if (
+            parsed_additional_config is not None
+            and parsed_plugin_config is not None
+            and parsed_additional_config != parsed_plugin_config
+        ):
+            raise ValueError(
+                "additional_config and plugin_config must contain identical "
+                "{'tt': {...}} content when both are provided"
+            )
+        if parsed_additional_config is not None or parsed_plugin_config is not None:
+            engine_kw_args["additional_config"] = (
+                parsed_additional_config
+                if parsed_additional_config is not None
+                else parsed_plugin_config
+            )
     except json.JSONDecodeError as err:
-        raise ValueError(f"Invalid JSON string for plugin_config: {err}") from err
+        raise ValueError(f"Invalid JSON config string: {err}") from err
 
     try:
         if mm_processor_kwargs:
@@ -663,11 +692,21 @@ if __name__ == "__main__":
         help="Test generations of small to large sequences",
     )
     parser.add_argument(
+        "--additional-config",
+        dest="additional_config",
+        type=str,
+        default=None,
+        help="Additional vLLM options as JSON, for example '{\"tt\": {...}}'",
+    )
+    parser.add_argument(
         "--plugin-config",
         dest="plugin_config",
         type=str,
         default=None,
-        help="Plugin options as JSON, for example '{\"tt\": {...}}'",
+        help=(
+            "Deprecated alias for --additional-config. "
+            "Value must use the same '{\"tt\": {...}}' JSON shape."
+        ),
     )
     parser.add_argument("--max_model_len", type=int, default=None, help="Max model len")
     parser.add_argument(
@@ -727,6 +766,7 @@ if __name__ == "__main__":
         multi_image=args.multi_image,
         mm_processor_kwargs=args.mm_processor_kwargs,
         test_increasing_seq_lens=args.test_increasing_seq_lens,
+        additional_config=args.additional_config,
         plugin_config=args.plugin_config,
         max_model_len=args.max_model_len,
         max_num_batched_tokens=args.max_num_batched_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -3,10 +3,60 @@
 
 from typing import TYPE_CHECKING, Any
 
+from vllm.logger import init_logger
+
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
+logger = init_logger(__name__)
+
+_warned_plugin_config = False
+
+
+def _extract_tt_config(
+    config: dict[str, Any], config_name: str
+) -> tuple[dict[str, Any], bool]:
+    if not isinstance(config, dict):
+        raise ValueError(f"{config_name} must be a JSON object")
+    if "tt" not in config:
+        return {}, False
+    tt_config = config["tt"]
+    if not isinstance(tt_config, dict):
+        raise ValueError(f"{config_name}['tt'] must be a JSON object")
+    return tt_config, True
+
+
+def _warn_plugin_config() -> None:
+    global _warned_plugin_config
+    if _warned_plugin_config:
+        return
+    logger.warning(
+        "TT config passed through --plugin-config is deprecated. "
+        "Use --additional-config '{\"tt\": {...}}' instead."
+    )
+    _warned_plugin_config = True
+
 
 def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
-    """Return TT plugin config from the generic plugin namespace."""
-    return dict(vllm_config.plugin_config.get("tt", {}))
+    """Return TT config from vLLM's generic additional config namespace."""
+    additional_config, has_additional_config = _extract_tt_config(
+        getattr(vllm_config, "additional_config", {}) or {}, "additional_config"
+    )
+    plugin_config, has_plugin_config = _extract_tt_config(
+        getattr(vllm_config, "plugin_config", {}) or {}, "plugin_config"
+    )
+
+    if has_plugin_config:
+        _warn_plugin_config()
+
+    if (
+        has_additional_config
+        and has_plugin_config
+        and additional_config != plugin_config
+    ):
+        raise ValueError(
+            "TT config in additional_config and plugin_config differs. "
+            "Pass only additional_config. plugin_config is deprecated."
+        )
+
+    return dict(additional_config if has_additional_config else plugin_config)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -49,14 +49,10 @@ def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
     if has_plugin_config:
         _warn_plugin_config()
 
-    if (
-        has_additional_config
-        and has_plugin_config
-        and additional_config != plugin_config
-    ):
+    if has_additional_config and has_plugin_config:
         raise ValueError(
-            "TT config in additional_config and plugin_config differs. "
-            "Pass only additional_config. plugin_config is deprecated."
+            "Only one of additional_config or plugin_config may contain TT config. "
+            "Prefer additional_config. plugin_config is deprecated."
         )
 
     return dict(additional_config if has_additional_config else plugin_config)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -25,6 +25,18 @@ else:
 logger = init_logger(__name__)
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
+_warned_cli_plugin_config = False
+
+
+def _warn_cli_plugin_config() -> None:
+    global _warned_cli_plugin_config
+    if _warned_cli_plugin_config:
+        return
+    logger.warning(
+        "TT config passed through --plugin-config is deprecated. "
+        "Use --additional-config '{\"tt\": {...}}' instead."
+    )
+    _warned_cli_plugin_config = True
 
 
 def _register_model_if_missing(ModelRegistry, model_arch: str, model_path: str) -> None:
@@ -38,41 +50,48 @@ def _register_model_if_missing(ModelRegistry, model_arch: str, model_path: str) 
 
 
 def _should_pre_register_tt_test_models_from_cli() -> bool:
-    """Return True iff `--plugin-config` enables TT test models.
+    """Return True iff CLI TT config enables TT test models.
 
     `TTPlatform.pre_register_and_update()` runs before `VllmConfig` is
     constructed, but ModelConfig may inspect architectures early.
     """
     argv = list(sys.argv[1:])
 
-    def _parse_plugin_config(raw: str) -> dict | None:
+    def _parse_namespaced_config(raw: str) -> dict | None:
         try:
             parsed = json.loads(raw)
         except Exception:
             return None
         return parsed if isinstance(parsed, dict) else None
 
-    canonical_flag = "--plugin-config"
+    canonical_flags = {"--additional-config", "--plugin-config"}
+    parsed_configs: dict[str, dict] = {}
     for i, arg in enumerate(argv):
         if "=" in arg:
             flag, value = arg.split("=", 1)
-            if flag.replace("_", "-") == canonical_flag:
-                cfg = _parse_plugin_config(value)
-                tt_config = cfg.get("tt", {}) if cfg else {}
-                return bool(
-                    isinstance(tt_config, dict)
-                    and tt_config.get("register_test_models") is True
-                )
+            normalized_flag = flag.replace("_", "-")
+            if normalized_flag in canonical_flags:
+                if normalized_flag == "--plugin-config":
+                    _warn_cli_plugin_config()
+                cfg = _parse_namespaced_config(value)
+                if cfg:
+                    parsed_configs[normalized_flag] = cfg
         else:
-            if arg.replace("_", "-") == canonical_flag and i + 1 < len(argv):
-                cfg = _parse_plugin_config(argv[i + 1])
-                tt_config = cfg.get("tt", {}) if cfg else {}
-                return bool(
-                    isinstance(tt_config, dict)
-                    and tt_config.get("register_test_models") is True
-                )
+            normalized_arg = arg.replace("_", "-")
+            if normalized_arg in canonical_flags and i + 1 < len(argv):
+                if normalized_arg == "--plugin-config":
+                    _warn_cli_plugin_config()
+                cfg = _parse_namespaced_config(argv[i + 1])
+                if cfg:
+                    parsed_configs[normalized_arg] = cfg
 
-    return False
+    cfg = parsed_configs.get("--additional-config") or parsed_configs.get(
+        "--plugin-config"
+    )
+    tt_config = cfg.get("tt", {}) if cfg else {}
+    return bool(
+        isinstance(tt_config, dict) and tt_config.get("register_test_models") is True
+    )
 
 
 def _install_tt_harmony_truncation_patch() -> None:

--- a/plugins/vllm-tt-plugin/tests/tt/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/tt/test_config.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import pytest
+from vllm_tt_plugin import config as tt_config
+
+
+@pytest.fixture(autouse=True)
+def reset_warning_state():
+    old_warned_plugin_config = tt_config._warned_plugin_config
+    tt_config._warned_plugin_config = False
+    yield
+    tt_config._warned_plugin_config = old_warned_plugin_config
+
+
+def _vllm_config(additional_config=None, plugin_config=None):
+    return SimpleNamespace(
+        additional_config=additional_config or {},
+        plugin_config=plugin_config or {},
+    )
+
+
+def test_get_tt_config_prefers_additional_config():
+    config = _vllm_config(
+        additional_config={"tt": {"sample_on_device_mode": "all"}},
+    )
+
+    assert tt_config.get_tt_config(config) == {"sample_on_device_mode": "all"}
+
+
+def test_get_tt_config_accepts_plugin_config_with_warning(caplog):
+    config = _vllm_config(
+        plugin_config={"tt": {"sample_on_device_mode": "decode_only"}},
+    )
+
+    assert tt_config.get_tt_config(config) == {"sample_on_device_mode": "decode_only"}
+    assert "--plugin-config is deprecated" in caplog.text
+
+
+def test_get_tt_config_rejects_mismatched_config_sources():
+    config = _vllm_config(
+        additional_config={"tt": {"trace_mode": "all"}},
+        plugin_config={"tt": {"trace_mode": "none"}},
+    )
+
+    with pytest.raises(ValueError, match="differs"):
+        tt_config.get_tt_config(config)


### PR DESCRIPTION
## Purpose

Fix https://github.com/tenstorrent/vllm/issues/397:

Replacing --override-tt-config {...} with --plugin-config {"tt": {...}} introduced non-standard way of passing config to plugins. I overlooked that vllm already had --additional-config which can serve that purpose just fine, without requiring an upstream PR.

Fixing it now by:
* supporting both options for some time period, with the same content {"tt": {...}}
* printing a warning if --plugin-config is used (but accepting it), and
* changing all docs and scripts in our vllm and tt-metal repo to use --additional-config.

For as long as we use our vllm fork, we can keep --plugin-config. Once we switch to stock vllm, that option will no longer work.

Metal PR: https://github.com/tenstorrent/tt-metal/pull/44991

## Testing

* Added `plugins/vllm-tt-plugin/tests/tt/test_config.py` - passing
* CI: https://github.com/tenstorrent/tt-metal/actions/runs/26279375258

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

