### PR TITLE
Pass max_model_len and max_num_seqs to TT block calculator

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -459,6 +459,8 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
             model_name=model_config.model,
             num_devices=device_config.num_devices,
             tt_data_parallel=data_parallel,
+            max_model_len=model_config.max_model_len,
+            max_num_seqs=scheduler_config.max_num_seqs,
         )
 
         logger.info(


### PR DESCRIPTION
## Summary
- Forward `max_model_len` (from `ModelConfig`) and `max_num_seqs` (from `SchedulerConfig`) into `get_num_available_blocks_tt` when calling the TT generator helper, so block sizing reflects the configured limits.

## Test plan
- [ ] Verify `get_num_available_blocks_tt` produces the expected block count when `--max-model-len` / `--max-num-seqs` are passed on the command line.
- [ ] Smoke test serving a TT-backed model end-to-end.

