### PR TITLE
Fix test that fails after last-minute change

### DIFF
--- a/plugins/vllm-tt-plugin/tests/tt/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/tt/test_config.py
@@ -38,11 +38,13 @@ def test_get_tt_config_accepts_plugin_config_with_warning(caplog):
     assert "--plugin-config is deprecated" in caplog.text
 
 
-def test_get_tt_config_rejects_mismatched_config_sources():
+def test_get_tt_config_rejects_both_config_sources():
     config = _vllm_config(
         additional_config={"tt": {"trace_mode": "all"}},
         plugin_config={"tt": {"trace_mode": "none"}},
     )
 
-    with pytest.raises(ValueError, match="differs"):
+    with pytest.raises(
+        ValueError, match="Only one of additional_config or plugin_config"
+    ):
         tt_config.get_tt_config(config)


### PR DESCRIPTION
## Purpose

This fixes a failing test which happened after last-minute change https://github.com/tenstorrent/vllm/pull/400/changes/03d132d687b24cfcab86b8e4d5a9cafd79804ade to https://github.com/tenstorrent/vllm/pull/400

## Test Result
```
pytest plugins/vllm-tt-plugin/tests/tt/test_config.py::test_get_tt_config_rejects_both_config_sources -v \
  --tt-server-url=http://localhost:8000 \
  --tt-model-name=test
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.10.18, pytest-8.4.2, pluggy-1.6.0 -- /proj_sw/user_dev/viktorpus/envs/bin/python3
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /proj_sw/user_dev/viktorpus/vllm
configfile: pyproject.toml
plugins: split-0.10.0, benchmark-5.1.0, asyncio-1.3.0, cov-7.0.0, timeout-2.4.0, github-actions-annotate-failures-0.3.0, anyio-4.13.0, dash-2.15.0
asyncio: mode=strict, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1 item

plugins/vllm-tt-plugin/tests/tt/test_config.py::test_get_tt_config_rejects_both_config_sources PASSED                                                                                 [100%]

==================================================================================== 1 passed in 21.14s =====================================================================================
```
