### PR TITLE
Disable hybrid KV cache groups in max tokens calculation

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -37,6 +37,13 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+# Keep this in sync with TT model-side KV cache specs. It is currently
+# disabled because HybridAttentionForCausalLM emits FullAttentionSpec for
+# every layer while the sliding-window decode fix is pending. When
+# SlidingWindowSpec is re-enabled for those models, flip this back with the
+# matching model-side change so the block budget includes sliding groups.
+_HYBRID_KV_CACHE_GROUPS_ENABLED = False
+
 # Ensure TT model architectures are registered in this process as early as
 # possible. `WorkerWrapperBase.init_worker` imports the worker class module
 # before initializing multimodal caches; without this, early architecture
@@ -486,17 +493,23 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
     max_batch = scheduler_config.max_num_seqs
     max_tokens_all_users += cache_config.block_size * max_batch
 
-    # Hybrid attention models (Gemma3/4, GPT-OSS, ...) split layers into
-    # multiple kv_cache_groups: a full-attention group plus several
+    # Hybrid attention models (Gemma3/4, GPT-OSS, ...) normally split layers
+    # into multiple kv_cache_groups: a full-attention group plus several
     # sliding-window groups. Upstream's hybrid manager packs these into
-    # ``group_size = min(layer_counts_per_type)`` buffers and indexes them
-    # via per-group block tables, so each request consumes
-    # ``full_blocks_per_request + Σ sliding_blocks_per_request`` block IDs
-    # from the pool. Our heuristic above sizes ``num_tt_blocks`` for the
-    # full-attention demand only; add headroom for the sliding overhead so
-    # hybrid models don't run out of blocks at scheduled batch.
+    # ``group_size = min(layer_counts_per_type)`` buffers and indexes them via
+    # per-group block tables, so each request consumes
+    # ``full_blocks_per_request + Σ sliding_blocks_per_request`` block IDs.
+    #
+    # Hybrid groups are temporarily disabled on the model side by emitting
+    # FullAttentionSpec for every layer. While that is true, this token budget
+    # must stay on the pre-hybrid formula; adding sliding-window headroom here
+    # allocates too many full-size KV blocks and can OOM Gemma3-27B on T3K.
+    #
+    # When SlidingWindowSpec is restored in HybridAttentionForCausalLM, flip
+    # _HYBRID_KV_CACHE_GROUPS_ENABLED at the same time so both the spec shape
+    # and token calculation change together.
     sliding_window = model_config.get_sliding_window()
-    if sliding_window is not None:
+    if _HYBRID_KV_CACHE_GROUPS_ENABLED and sliding_window is not None:
         # Conservative cap: assume up to a few sliding groups per buffer
         # (typical for Gemma3 5:1 / GPT-OSS 1:1 hybrid patterns) and add
         # ``sliding_window * max_batch`` worth of tokens per group as


### PR DESCRIPTION
## Purpose

This is needed after https://github.com/tenstorrent/tt-metal/pull/45184/changes#diff-da9023eab864669ffb75f0f67563f47a72be0ff94d15c1631991083bdd0ae267

Related Metal PR: https://github.com/tenstorrent/tt-metal/pull/45404

Before this change: https://github.com/tenstorrent/tt-metal/actions/runs/26559685789/job/78240675177#step:17:326

After just the VLLM change, but without the linked tt-metal change: https://github.com/tenstorrent/tt-metal/actions/runs/26567209010/job/78266998200#step:17:7281

## Test Result

VLLM Nightly after both: https://github.com/tenstorrent/tt-metal/actions/runs/26570436299
