### PR TITLE
Fix top_k=1 non-determinism in on-device sampling

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -261,12 +261,23 @@ class InputBatch:
         )
 
         self.sampling.temperature[req_index] = sampling_params.temperature
-        self.sampling.top_p[req_index] = sampling_params.top_p
+        top_p = sampling_params.top_p
         top_k = sampling_params.top_k
         if not (0 < top_k < self.vocab_size):
             # Normalize top_k <= 0 or >= vocab_size to vocab_size
             # (consider all tokens)
             top_k = self.vocab_size
+        # top_k == 1 means greedy/argmax for this request. The on-device sampler
+        # always builds a fixed top-32 candidate set and its per-user top_k does
+        # NOT collapse that set to a single token before the RNG draw, so with
+        # any top_p < 1.0 a multi-token nucleus survives and the random seed makes
+        # top_k=1 non-deterministic (e.g. Qwen3's generation_config defaults
+        # top_p=0.95). Force top_p to 0 so the nucleus keeps exactly the single
+        # most-probable token (cum_prob > 0 keeps one), i.e. exact argmax and
+        # RNG-independent. Per-request, so mixed-k batches are unaffected.
+        if top_k == 1:
+            top_p = 0.0
+        self.sampling.top_p[req_index] = top_p
         self.sampling.top_k[req_index] = top_k
         self.sampling.presence_penalty[req_index] = sampling_params.presence_penalty
         self.sampling.frequency_penalty[req_index] = sampling_params.frequency_penalty

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -267,6 +267,7 @@ class InputBatch:
             # Normalize top_k <= 0 or >= vocab_size to vocab_size
             # (consider all tokens)
             top_k = self.vocab_size
+        # Workaround for https://github.com/tenstorrent/tt-metal/issues/46827
         # top_k == 1 means greedy/argmax for this request. The on-device sampler
         # always builds a fixed top-32 candidate set and its per-user top_k does
         # NOT collapse that set to a single token before the RNG draw, so with


### PR DESCRIPTION
## Description

A request with top_k=1 (greedy/argmax) was non-deterministic whenever top_p < 1.0. The on-device sampler always builds a fixed top-32 candidate set and its per-user top_k does NOT collapse that set to a single token before the RNG draw, so a top_p < 1.0 (e.g. Qwen3's generation_config default top_p=0.95) leaves a multi-token nucleus and the unseeded per-request RNG picks a different token each call.

Ticket: https://github.com/tenstorrent/tt-inference-server/issues/4004
test_determinism_parameters[top_k-1] (Qwen3-32B, p300x2).

Fix: in InputBatch.add_request, force top_p=0 when top_k==1 so the nucleus keeps exactly the single most-probable token (cum_prob > 0 => one token), i.e. exact argmax and RNG-independent. Applied per-request, so mixed-k batches and the (arch-gated) force-argmax fast path are unaffected.

test: https://github.com/tenstorrent/tt-shield/actions/runs/27344188268