### PR TITLE
[Bugfix][Metrics] Tolerate path-less routes in metrics middleware 

### DIFF
--- a/vllm/entrypoints/serve/instrumentator/metrics.py
+++ b/vllm/entrypoints/serve/instrumentator/metrics.py
@@ -7,9 +7,46 @@ import regex as re
 from fastapi import FastAPI, Response
 from prometheus_client import make_asgi_app
 from prometheus_fastapi_instrumentator import Instrumentator
-from starlette.routing import Mount
+from prometheus_fastapi_instrumentator import routing as _pfi_routing
+from starlette.routing import Match, Mount
+from starlette.types import Scope
 
 from vllm.v1.metrics.prometheus import get_prometheus_registry
+
+
+def _patch_instrumentator_route_walk() -> None:
+    """Make prometheus-fastapi-instrumentator's route walk tolerate routes
+    without a ``.path``.
+
+    FastAPI >= 0.137 stores lazy ``_IncludedRouter`` objects in ``app.routes``;
+    these are ``BaseRoute`` subclasses with no ``.path`` attribute. The
+    instrumentator's ``_get_route_name`` (up to 8.0.0) reads ``route.path``
+    unconditionally, so every request raises ``AttributeError`` in the metrics
+    middleware and the server returns 500 (e.g. ``/health`` never goes ready).
+    Skip path-less routes; this only affects the metric handler label, not
+    request routing. Idempotent.
+    """
+
+    def _get_route_name(scope: Scope, routes, route_name=None):
+        for route in routes:
+            if getattr(route, "path", None) is None:
+                continue
+            match, child_scope = route.matches(scope)
+            if match == Match.FULL:
+                route_name = route.path
+                child_scope = {**scope, **child_scope}
+                if isinstance(route, Mount) and route.routes:
+                    child = _get_route_name(child_scope, route.routes, route_name)
+                    route_name = None if child is None else route_name + child
+                return route_name
+            elif match == Match.PARTIAL and route_name is None:
+                route_name = route.path
+        return None
+
+    _pfi_routing._get_route_name = _get_route_name
+
+
+_patch_instrumentator_route_walk()
 
 
 class PrometheusResponse(Response):


### PR DESCRIPTION
Cherry pick fb7bcea5c (#45629) from upstream.

CI before: https://github.com/tenstorrent/tt-metal/actions/runs/27517701622/job/81330112704#step:17:722
CI after: https://github.com/tenstorrent/tt-metal/actions/runs/27534300343


FastAPI >=0.137 stores lazy `_IncludedRouter` objects (BaseRoute subclasses with no `.path`) in `app.routes`. prometheus-fastapi-instrumentator (<=8.0.0) reads `route.path` unconditionally in `_get_route_name`, so every request raises AttributeError in the metrics middleware and the server returns 500 -- e.g. `/health` never becomes ready and the engine looks hung at startup.

Patch the instrumentator's route walk at metrics-setup time to skip path-less routes (only affects the per-request metric handler label, not request routing). Idempotent and a no-op on older FastAPI.