### PR TITLE
Add coherence guard verbatim-echo test to TT sampling tests

### DIFF
--- a/plugins/vllm-tt-plugin/tests/tt/test_coherence.py
+++ b/plugins/vllm-tt-plugin/tests/tt/test_coherence.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Coherence guard: the model must echo an exact sentence verbatim."""
+
+from tests.tt.utils import RequestConfig, run_concurrent_batch
+
+
+class TestCoherence:
+    def test_coherence_verbatim_echo(self, tt_server, tt_model_name, max_batch_size):
+        """Coherence guard: the model must echo an exact sentence verbatim.
+
+        The other tests here only check structural/determinism properties (n,
+        max_tokens, stop, seed, logprobs, penalties). A backend regression that
+        corrupts the forward pass (e.g. a broken on-device decode trace) still
+        emits deterministic, well-formed-but-garbage tokens, so all of those
+        pass while the model is actually producing gibberish. Requiring a
+        verbatim echo catches that class of bug directly: a model that cannot
+        reproduce a simple sentence is not generating coherent text.
+        """
+        sentence = "The quick brown fox jumps over the lazy dog."
+        configs = [
+            RequestConfig(
+                prompt=(
+                    "Repeat the following sentence exactly, with no extra words, "
+                    f"no quotes, and no commentary: {sentence}"
+                ),
+                max_tokens=32,
+                temperature=0,
+            )
+        ]
+        results = run_concurrent_batch(tt_server, tt_model_name, configs, use_chat=True)
+        assert len(results) == len(configs)
+
+        output_text = results[0]
+        assert output_text is not None, "coherence guard got no output"
+        assert sentence in output_text, (
+            "Coherence guard failed: model did not echo the sentence verbatim "
+            "(likely gibberish from a corrupted forward pass). Expected to find "
+            f"{sentence!r} in output, got: {output_text!r}"
+        )


### PR DESCRIPTION
## Summary
- Adds `plugins/vllm-tt-plugin/tests/tt/test_coherence.py` with a verbatim-echo coherence guard for the TT backend.
- The existing `tests/tt` suite only checks structural/determinism properties (n, max_tokens, stop, seed, logprobs, penalties). A backend regression that corrupts the forward pass (e.g. a broken on-device decode trace) still emits deterministic, well-formed-but-garbage tokens, so all of those pass while the model is actually producing gibberish.
- This guard asks the model to reproduce a simple sentence exactly and asserts the sentence appears verbatim in the output, catching that class of bug directly.

## Details
- Uses the suite's existing harness (`tt_server` / `tt_model_name` fixtures, `RequestConfig` + `run_concurrent_batch(use_chat=True)`), matching the other tests in `tests/tt`.
- Greedy decode (`temperature=0`, `max_tokens=32`).

## How it runs
Runs in the tt-metal vLLM nightly "Run sampling tests" step (`pytest vllm/plugins/vllm-tt-plugin/tests/tt`), i.e. for matrix entries with `sampling-tests: true`.

## Test plan
- [ ] Confirm it passes against a healthy server for a sampling-tests model (e.g. Llama-3.1-8B-Instruct).
- [ ] Confirm it fails when the forward pass is intentionally corrupted (e.g. broken decode trace).

Made with [Cursor](https://cursor.com)