### PR TITLE
tt-plugin: separate forward from sampling for non-DP and lane-DP

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import threading
 import time
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, replace
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
@@ -13,6 +13,7 @@ import ttnn
 
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOutput
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
+from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
@@ -93,6 +94,15 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         self._completion_event = completion_event
         self._context = context
         self._scheduled_rows = scheduled_rows
+
+    def set_grammar_bitmask(self, bitmask: torch.Tensor) -> None:
+        """Attach a sample-time grammar bitmask before the deferred read.
+
+        The runner reorders the bitmask on the engine thread (where the batch
+        layout still matches this step's forward) and calls this; the read on
+        the output thread then applies it through ``model_input``.
+        """
+        self._model_input = replace(self._model_input, grammar_bitmask=[bitmask])
 
     def get_output(self) -> ModelRunnerOutput:
         try:
@@ -210,9 +220,15 @@ class TTAsyncDecodeController:
         )
         if is_prompt or runner._decode_layout_changed_since_last_decode:
             return False
+        # Structured outputs are detected from the scheduler state, not from a
+        # prepared bitmask: the non-DP/lane paths now defer grammar to sample
+        # time and pass ``grammar_output=None`` here, while gathered DP still
+        # passes a bitmask. Either signal disables steady decode so the grammar
+        # constraint is never skipped by an overlapped step.
         if (
             scheduler_output.pending_structured_output_tokens
             or grammar_output is not None
+            or has_structured_outputs(runner.requests, scheduler_output, None)
         ):
             return False
         input_batch = runner.input_batch

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -75,30 +75,38 @@ class DeferredDecodeOutput(AsyncModelRunnerOutput):
     """Run the deferred device readback exactly once, from whichever caller
     reaches it first.
 
-    Two callers race for the same step on the single engine thread: the engine
-    resolves it via ``get_output`` when it pops the batch-queue future, and the
-    runner's drain (``TTAsyncDecodeController.wait_for_all_pending_async_steps``)
-    resolves it via ``ensure_finalized``. The completion event is set here, when
-    the readback actually runs, not only inside ``get_output``. That is the
-    invariant the drain depends on: vLLM 0.22's ``step_with_batch_queue``
-    schedules the next batch before resolving the prior future, so a drain that
-    merely ``event.wait()``-ed would block forever on an event the same thread
-    only sets after the drain returns.
+    Two callers race for the same step from different threads: vLLM's
+    ``UniProcExecutor`` resolves it via ``get_output`` on its async-output
+    thread when async scheduling is on, while the runner's drain
+    (``TTAsyncDecodeController.wait_for_all_pending_async_steps``) resolves it
+    via ``ensure_finalized`` on the engine thread. ``_finalize_lock`` makes the
+    readback run exactly once across both threads; a second concurrent readback
+    of the same device submission corrupts the decode output. The completion
+    event is set here, when the readback actually runs, not only inside
+    ``get_output``. That is the invariant the drain depends on: vLLM 0.22's
+    ``step_with_batch_queue`` schedules the next batch before resolving the
+    prior future, so a drain that merely ``event.wait()``-ed would block forever
+    on an event nothing else has reached yet.
     """
 
     _completion_event: threading.Event
+    _finalize_lock: threading.Lock
     _finalized: bool
     _cached_output: Any
 
     def _init_deferred(self) -> None:
         self._finalized = False
         self._cached_output = None
+        self._finalize_lock = threading.Lock()
 
     def ensure_finalized(self) -> Any:
-        if not self._finalized:
-            self._cached_output = self._get_output_impl()
-            self._finalized = True
-            self._completion_event.set()
+        if self._finalized:
+            return self._cached_output
+        with self._finalize_lock:
+            if not self._finalized:
+                self._cached_output = self._get_output_impl()
+                self._finalized = True
+                self._completion_event.set()
         return self._cached_output
 
     def is_resolved(self) -> bool:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -71,7 +71,47 @@ class CompletedDecodeStep:
     completion_time_ns: int
 
 
-class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
+class DeferredDecodeOutput(AsyncModelRunnerOutput):
+    """Run the deferred device readback exactly once, from whichever caller
+    reaches it first.
+
+    Two callers race for the same step on the single engine thread: the engine
+    resolves it via ``get_output`` when it pops the batch-queue future, and the
+    runner's drain (``TTAsyncDecodeController.wait_for_all_pending_async_steps``)
+    resolves it via ``ensure_finalized``. The completion event is set here, when
+    the readback actually runs, not only inside ``get_output``. That is the
+    invariant the drain depends on: vLLM 0.22's ``step_with_batch_queue``
+    schedules the next batch before resolving the prior future, so a drain that
+    merely ``event.wait()``-ed would block forever on an event the same thread
+    only sets after the drain returns.
+    """
+
+    _completion_event: threading.Event
+    _finalized: bool
+    _cached_output: Any
+
+    def _init_deferred(self) -> None:
+        self._finalized = False
+        self._cached_output = None
+
+    def ensure_finalized(self) -> Any:
+        if not self._finalized:
+            self._cached_output = self._get_output_impl()
+            self._finalized = True
+            self._completion_event.set()
+        return self._cached_output
+
+    def is_resolved(self) -> bool:
+        return self._completion_event.is_set()
+
+    def get_output(self) -> Any:
+        return self.ensure_finalized()
+
+    def _get_output_impl(self) -> Any:
+        raise NotImplementedError
+
+
+class AsyncTTModelRunnerOutput(DeferredDecodeOutput):
     """Wrap a non-blocking single-process TT decode submission plus async read.
 
     Handles both a plain single-process decode and a lane-DP decode: when
@@ -94,6 +134,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         self._completion_event = completion_event
         self._context = context
         self._scheduled_rows = scheduled_rows
+        self._init_deferred()
 
     def set_grammar_bitmask(self, bitmask: torch.Tensor) -> None:
         """Attach a sample-time grammar bitmask before the deferred read.
@@ -103,12 +144,6 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         the output thread then applies it through ``model_input``.
         """
         self._model_input = replace(self._model_input, grammar_bitmask=[bitmask])
-
-    def get_output(self) -> ModelRunnerOutput:
-        try:
-            return self._get_output_impl()
-        finally:
-            self._completion_event.set()
 
     def _get_output_impl(self) -> ModelRunnerOutput:
         completed = self._controller.complete_decode_step(
@@ -121,7 +156,7 @@ class AsyncTTModelRunnerOutput(AsyncModelRunnerOutput):
         return self._controller.build_runner_output_from_completed_step(completed)
 
 
-class AsyncTTDPGatherOutput(AsyncModelRunnerOutput):
+class AsyncTTDPGatherOutput(DeferredDecodeOutput):
     """Wrap a non-blocking DP decode submission plus async read submit."""
 
     def __init__(
@@ -135,12 +170,7 @@ class AsyncTTDPGatherOutput(AsyncModelRunnerOutput):
         self._submission = submission
         self._model_input = model_input
         self._completion_event = completion_event
-
-    def get_output(self) -> tuple[torch.Tensor, list]:  # type: ignore[override]
-        try:
-            return self._get_output_impl()
-        finally:
-            self._completion_event.set()
+        self._init_deferred()
 
     def _get_output_impl(self) -> tuple[torch.Tensor, list]:
         finalized = self._controller.finalize_decode(self._submission)
@@ -305,23 +335,23 @@ class TTAsyncDecodeController:
         with self.runner._steady_decode_lock:
             self.runner._completed_decode_steps.append(completed)
 
-    def register_pending_async_event(
+    def register_pending_async_step(
         self,
-        event: threading.Event,
+        step: DeferredDecodeOutput,
         *,
         overlap_ok: bool,
     ) -> None:
         with self.runner._steady_decode_lock:
-            self.runner._pending_async_events.append(event)
+            self.runner._pending_async_steps.append(step)
             self.runner._pending_async_overlap_ok.append(overlap_ok)
 
     def prune_finished_async_events(self) -> None:
         with self.runner._steady_decode_lock:
             while (
-                self.runner._pending_async_events
-                and self.runner._pending_async_events[0].is_set()
+                self.runner._pending_async_steps
+                and self.runner._pending_async_steps[0].is_resolved()
             ):
-                self.runner._pending_async_events.popleft()
+                self.runner._pending_async_steps.popleft()
                 self.runner._pending_async_overlap_ok.popleft()
 
     def drain_completed_decode_steps(self) -> list[CompletedDecodeStep]:
@@ -337,10 +367,15 @@ class TTAsyncDecodeController:
         self.prune_finished_async_events()
 
     def wait_for_all_pending_async_steps(self) -> None:
+        # Drive each pending readback to completion here rather than blocking on
+        # its event: the engine has not popped these futures yet (and on 0.22
+        # will not until after this returns), so nothing else will set the
+        # events. ``ensure_finalized`` is idempotent, so the engine's later
+        # ``get_output`` on the same step returns the cached result.
         with self.runner._steady_decode_lock:
-            events = list(self.runner._pending_async_events)
-        for event in events:
-            event.wait()
+            steps = list(self.runner._pending_async_steps)
+        for step in steps:
+            step.ensure_finalized()
         self.apply_ready_completed_decode_steps()
 
     def must_drain_pending_async_steps(
@@ -348,7 +383,7 @@ class TTAsyncDecodeController:
         steady_decode_candidate: bool,
     ) -> bool:
         with self.runner._steady_decode_lock:
-            if not self.runner._pending_async_events:
+            if not self.runner._pending_async_steps:
                 return False
             if not steady_decode_candidate:
                 return True
@@ -433,19 +468,17 @@ class TTAsyncDecodeController:
             read_from_device=False,
             async_read=True,
         )
-        self.register_pending_async_event(
-            event,
-            overlap_ok=steady_decode_fast_path,
-        )
         if submission.tt_out is None:
             event.set()
-        return AsyncTTModelRunnerOutput(
+        step = AsyncTTModelRunnerOutput(
             controller=self,
             submission=submission,
             model_input=model_input,
             completion_event=event,
             context=context,
         )
+        self.register_pending_async_step(step, overlap_ok=steady_decode_fast_path)
+        return step
 
     def submit_async_dp_decode(
         self,
@@ -468,15 +501,16 @@ class TTAsyncDecodeController:
         submission = self.submit_decode(
             model_input, read_from_device=False, async_read=True
         )
-        self.register_pending_async_event(completion_event, overlap_ok=overlap_ok)
         if submission.tt_out is None:
             completion_event.set()
-        return AsyncTTDPGatherOutput(
+        step = AsyncTTDPGatherOutput(
             controller=self,
             submission=submission,
             model_input=model_input,
             completion_event=completion_event,
         )
+        self.register_pending_async_step(step, overlap_ok=overlap_ok)
+        return step
 
     def submit_async_lane_decode(
         self,
@@ -490,10 +524,9 @@ class TTAsyncDecodeController:
         submission = self.submit_decode(
             model_input, read_from_device=False, async_read=True
         )
-        self.register_pending_async_event(completion_event, overlap_ok=overlap_ok)
         if submission.tt_out is None:
             completion_event.set()
-        return AsyncTTModelRunnerOutput(
+        step = AsyncTTModelRunnerOutput(
             controller=self,
             submission=submission,
             model_input=model_input,
@@ -501,6 +534,8 @@ class TTAsyncDecodeController:
             context=context,
             scheduled_rows=scheduled_rows,
         )
+        self.register_pending_async_step(step, overlap_ok=overlap_ok)
+        return step
 
     def submit_decode(
         self,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -21,7 +21,7 @@ from vllm.v1.engine import (
     ReconfigureDistributedRequest,
     ReconfigureRankType,
 )
-from vllm.v1.engine.core import DPEngineCoreProc, EngineCore, EngineCoreProc
+from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.request import Request
 from vllm_tt_plugin.config import get_tt_config, get_tt_per_lane_max_num_seqs
@@ -77,20 +77,6 @@ class DPGatherHandle:
     any_needs_logprobs: bool
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-
-
-class TTEngineCore(EngineCore):
-    """In-process TT engine core.
-
-    Non-DP and single-process lane-DP execution follow the stock vLLM control
-    flow: ``execute_model`` runs the device forward and returns ``None``, the
-    scheduler computes the grammar bitmask while the forward is in flight, and
-    ``sample_tokens`` applies it. No TT-specific step override is needed.
-    """
-
-
-class TTEngineCoreProc(EngineCoreProc):
-    """Multiprocessing TT engine core; see :class:`TTEngineCore`."""
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -79,160 +79,18 @@ class DPGatherHandle:
     req_id_to_index: dict[str, int]
 
 
-class TTExecutionMixin:
-    """TT non-DP execution policy for plugin-selected engine cores."""
+class TTEngineCore(EngineCore):
+    """In-process TT engine core.
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)  # type: ignore[misc]
-        if (
-            self.batch_queue is not None
-            and self.vllm_config.scheduler_config.async_scheduling
-            and self.vllm_config.parallel_config.data_parallel_size == 1
-        ):
-            self.step_fn = self.step_with_batch_queue_tt
-
-    def _get_grammar_output(
-        self,
-        scheduler_output: SchedulerOutput,
-        *,
-        require_ready: bool = True,
-    ) -> GrammarOutput | None:
-        if require_ready and scheduler_output.pending_structured_output_tokens:
-            return None
-        return self.scheduler.get_grammar_bitmask(scheduler_output)
-
-    def _execute_model_with_grammar(
-        self,
-        scheduler_output: SchedulerOutput,
-        grammar_output: GrammarOutput | None,
-        *,
-        non_block: bool = False,
-    ) -> ModelRunnerOutput | Future[ModelRunnerOutput]:
-        result = self.model_executor.collective_rpc(
-            "execute_model_with_grammar",
-            args=(scheduler_output, grammar_output),
-            non_block=non_block,
-        )
-        if non_block:
-            return _unwrap_single_worker_future(
-                cast(Future[list[ModelRunnerOutput]], result)
-            )
-        return result[0]
-
-    def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
-        """TT regular execution path.
-
-        TT sampling runs inside ``execute_model``, so grammar state is passed
-        through plugin-owned worker calls instead of shared scheduler output.
-        """
-        if self._scheduler_paused:
-            return {}, False
-
-        if not self.scheduler.has_requests():
-            return {}, False
-
-        scheduler_output = self.scheduler.schedule()
-        grammar_output = self._get_grammar_output(scheduler_output)
-        future = cast(
-            Future[ModelRunnerOutput],
-            self._execute_model_with_grammar(
-                scheduler_output, grammar_output, non_block=True
-            ),
-        )
-        with (
-            self.log_error_detail(scheduler_output),
-            self.log_iteration_details(scheduler_output),
-        ):
-            model_output = future.result()
-            if model_output is None:
-                model_output = self.model_executor.sample_tokens(None)
-
-        self._process_aborts_queue()
-        engine_core_outputs = self.scheduler.update_from_output(
-            scheduler_output, model_output
-        )
-        return engine_core_outputs, scheduler_output.total_num_scheduled_tokens > 0
-
-    def step_with_batch_queue_tt(
-        self,
-    ) -> tuple[dict[int, EngineCoreOutputs] | None, bool]:
-        """TT-specific async batch-queue path for non-DP execution."""
-        batch_queue = self.batch_queue
-        assert batch_queue is not None
-
-        # Match the shared queue behavior: prefer keeping the queue filled before
-        # blocking on the oldest in-flight result.
-        assert len(batch_queue) < self.batch_queue_size
-
-        model_executed = False
-        deferred_scheduler_output: SchedulerOutput | None = None
-        if self.scheduler.has_requests():
-            scheduler_output = self.scheduler.schedule()
-            if not self.is_ec_producer:
-                model_executed = scheduler_output.total_num_scheduled_tokens > 0
-
-            if self.is_pooling_model or not model_executed:
-                future = cast(
-                    Future[ModelRunnerOutput],
-                    self._execute_model_with_grammar(
-                        scheduler_output, None, non_block=True
-                    ),
-                )
-            elif scheduler_output.pending_structured_output_tokens:
-                # TT consumes structured-output state inside execute_model(), so
-                # the grammar bitmask must be populated before submission.
-                deferred_scheduler_output = scheduler_output
-            else:
-                grammar_output = self._get_grammar_output(scheduler_output)
-                future = cast(
-                    Future[ModelRunnerOutput],
-                    self._execute_model_with_grammar(
-                        scheduler_output, grammar_output, non_block=True
-                    ),
-                )
-
-            if deferred_scheduler_output is None:
-                batch_queue.appendleft((future, scheduler_output, future))
-                if (
-                    model_executed
-                    and len(batch_queue) < self.batch_queue_size
-                    and not batch_queue[-1][0].done()
-                ):
-                    return None, True
-
-        elif not batch_queue:
-            return None, False
-
-        future, scheduler_output, _ = batch_queue.pop()
-        with self.log_error_detail(scheduler_output):
-            model_output = future.result()
-
-        self._process_aborts_queue()
-        engine_core_outputs = self.scheduler.update_from_output(
-            scheduler_output, model_output
-        )
-
-        if deferred_scheduler_output is not None:
-            grammar_output = self._get_grammar_output(
-                deferred_scheduler_output, require_ready=False
-            )
-            future = cast(
-                Future[ModelRunnerOutput],
-                self._execute_model_with_grammar(
-                    deferred_scheduler_output, grammar_output, non_block=True
-                ),
-            )
-            batch_queue.appendleft((future, deferred_scheduler_output, future))
-
-        return engine_core_outputs, model_executed
+    Non-DP and single-process lane-DP execution follow the stock vLLM control
+    flow: ``execute_model`` runs the device forward and returns ``None``, the
+    scheduler computes the grammar bitmask while the forward is in flight, and
+    ``sample_tokens`` applies it. No TT-specific step override is needed.
+    """
 
 
-class TTEngineCore(TTExecutionMixin, EngineCore):
-    """In-process TT engine core."""
-
-
-class TTEngineCoreProc(TTExecutionMixin, EngineCoreProc):
-    """Multiprocessing TT engine core."""
+class TTEngineCoreProc(EngineCoreProc):
+    """Multiprocessing TT engine core; see :class:`TTEngineCore`."""
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -6,7 +6,8 @@ from __future__ import annotations
 import os
 import threading
 from collections import deque
-from dataclasses import fields
+from dataclasses import dataclass, fields, replace
+from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import regex as re
@@ -16,7 +17,6 @@ import ttnn
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.multimodal.inputs import MultiModalFeatureSpec
-from vllm.sequence import IntermediateTensors
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
@@ -93,6 +93,23 @@ def _parse_layer_index(layer_name: str) -> int:
     return int(match.group(1))
 
 
+@dataclass(frozen=True)
+class _SyncForward:
+    """Materialized non-DP forward result awaiting host/device sampling.
+
+    Carries everything ``_get_output_tokens`` needs so the sampling tail can
+    run in a later ``sample_tokens`` call rather than inside ``execute_model``.
+    """
+
+    tt_out: Any
+    tt_log_probs: Any
+    sampling_params: TTSamplingParams
+    model_input: TTModelInput
+    batch_size_per_dp: list[int]
+    perform_device_sampling: bool
+    is_decode: bool
+
+
 class TTModelRunner:
     def __init__(
         self,
@@ -167,6 +184,13 @@ class TTModelRunner:
         # change during prefill steps (e.g. new requests added), so we keep a
         # sticky flag and clear it only after a decode input consumes it.
         self._decode_layout_changed_since_last_decode: bool = True
+
+        # Forward/sampling split: ``execute_model`` runs the device forward,
+        # enqueues a deferred sampler here, and returns ``None``; the engine
+        # then calls ``sample_tokens`` which pops and runs it. FIFO matches the
+        # batch-queue's oldest-first finalization order, so a single queue stays
+        # correct even with one forward in flight.
+        self._pending_samples: deque[Any] = deque()
 
         # Non-DP async scheduling: overlap CPU scheduling with device execution.
         # Only supported for DP=1 (DP>1 uses a different execution path).
@@ -1873,13 +1897,13 @@ class TTModelRunner:
     def _execute_lane_step(
         self,
         scheduler_output: SchedulerOutput,
-        grammar_output: GrammarOutput | None,
-        intermediate_tensors: IntermediateTensors | None = None,
-    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
-        """Execute one merged single-process multi-lane (lane-DP) step.
+    ) -> ModelRunnerOutput | None:
+        """Run the device forward for one merged lane-DP step.
 
         Invoked by ``execute_model`` when the lane scheduler attached a step
-        plan, so the plan is always present here.
+        plan. Returns ``None`` after enqueuing the lane sampler (the grammar
+        bitmask is applied later in ``sample_tokens``); returns
+        ``EMPTY_MODEL_RUNNER_OUTPUT`` only when there is nothing scheduled.
         """
         plan = get_tt_step_plan(scheduler_output)
         assert plan is not None, "lane step requires a scheduler-attached plan"
@@ -1898,7 +1922,7 @@ class TTModelRunner:
         self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_dp_decode_from_scheduler(
-                scheduler_output, grammar_output
+                scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
@@ -1914,32 +1938,43 @@ class TTModelRunner:
             return EMPTY_MODEL_RUNNER_OUTPUT
         scheduled_rows = list(plan.scheduled_rows)
         if not scheduled_rows:
-            return EMPTY_MODEL_RUNNER_OUTPUT
+            # Tokens were scheduled but no slot mapped to them; the engine still
+            # calls sample_tokens, so enqueue an empty result to keep the
+            # forward/sample calls balanced.
+            self._pending_samples.append(lambda _grammar: EMPTY_MODEL_RUNNER_OUTPUT)
+            return None
 
-        model_input = lane_batch.build_model_input(
-            self, scheduler_output, grammar_output, plan
-        )
+        # Grammar is applied at sample time, so the forward builds without it.
+        model_input = lane_batch.build_model_input(self, scheduler_output, None, plan)
         if plan.is_decode:
+            # ``slot_grammar_bitmask`` reorders against the full decode capacity.
+            lane_total = plan.capacity
             if self.non_dp_async_scheduling:
                 req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
                 context = self.async_decode.capture_submitted_step_context(req_ids)
-                return self.async_decode.submit_async_lane_decode(
+                wrapper = self.async_decode.submit_async_lane_decode(
                     model_input, context, scheduled_rows
                 )
+                self._pending_samples.append(
+                    partial(
+                        self._finish_async_decode,
+                        wrapper=wrapper,
+                        model_input=model_input,
+                        lane_total=lane_total,
+                    )
+                )
+                return None
             submission = self.async_decode.submit_decode(
                 model_input, read_from_device=True, async_read=False
             )
             finalized = self.async_decode.finalize_decode(submission)
             assert finalized is not None
-            sampled, logprobs = lane_batch.extract_output(
-                self,
-                finalized.tt_out,
-                finalized.tt_log_probs,
-                model_input,
-                scheduled_rows,
-                is_decode=True,
-            )
+            tt_out = finalized.tt_out
+            tt_log_probs = finalized.tt_log_probs
+            is_decode = True
         else:
+            # Prefill reorders against the per-lane request capacity.
+            lane_total = lane_batch.max_num_reqs
             tt_out = self.submit_prefill(model_input, model_input.unpadded_batch_size)
             tt_log_probs = None
             assert isinstance(
@@ -1953,10 +1988,42 @@ class TTModelRunner:
                 tt_out, tt_log_probs = tt_out
             elif isinstance(tt_out, tuple):
                 tt_out, _ = tt_out
-            sampled, logprobs = lane_batch.extract_output(
-                self, tt_out, tt_log_probs, model_input, scheduled_rows, is_decode=False
-            )
+            is_decode = False
 
+        # Forward done; defer the lane sampling tail to ``sample_tokens``. The
+        # step runs synchronously, so the lane batch layout is stable between
+        # this enqueue and the deferred sample.
+        self._pending_samples.append(
+            partial(
+                self._finish_lane_sync,
+                tt_out=tt_out,
+                tt_log_probs=tt_log_probs,
+                model_input=model_input,
+                scheduled_rows=scheduled_rows,
+                is_decode=is_decode,
+                lane_total=lane_total,
+            )
+        )
+        return None
+
+    def _finish_lane_sync(
+        self,
+        grammar_output: GrammarOutput | None,
+        *,
+        tt_out: Any,
+        tt_log_probs: Any,
+        model_input: TTModelInput,
+        scheduled_rows: list[int],
+        is_decode: bool,
+        lane_total: int,
+    ) -> ModelRunnerOutput:
+        """Sample and build the runner output for a deferred lane forward."""
+        model_input = self._apply_grammar_to_input(
+            model_input, grammar_output, lane_total=lane_total
+        )
+        sampled, logprobs = self.lane_batch.extract_output(
+            self, tt_out, tt_log_probs, model_input, scheduled_rows, is_decode=is_decode
+        )
         # ``scheduled_rows`` are persistent slots; their req_ids in row order are
         # the canonical merged output order.
         req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
@@ -1966,28 +2033,21 @@ class TTModelRunner:
     def execute_model(
         self,
         scheduler_output: SchedulerOutput,
-        grammar_output: GrammarOutput | None,
-        intermediate_tensors: IntermediateTensors | None = None,
-    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
-        """Public non-DP runner entrypoint used by the TT worker.
+    ) -> ModelRunnerOutput | None:
+        """Run the device forward for one non-DP or lane-DP step.
 
-        Dispatches one non-DP step from scheduler output to the appropriate TT
-        execution path and returns either a completed `ModelRunnerOutput` or an
-        async decode wrapper.
+        Returns ``None`` after enqueuing a pending sampler; the engine computes
+        the grammar bitmask while the forward runs and then calls
+        ``sample_tokens``. Returns ``EMPTY_MODEL_RUNNER_OUTPUT`` only when
+        nothing was scheduled (no sampler is enqueued). Gathered multi-process
+        DP does not use this entrypoint; the worker calls its dedicated facade.
         """
-        # In the DP case, this function is skipped!
-        # tt_worker.py uses the dedicated DP facade instead.
-        # With DP, the actual model pass happens on a batch
-        # produced by concatenating the inputs from all DP ranks.
-
         # Single-process lane-DP: the lane scheduler attaches a per-step plan to
         # the scheduler output. When present, the step runs over the merged lane
         # batch (``TTLaneInputBatch`` owns all the lane-specific input/output
         # shaping); the generic path below stays lane-agnostic.
         if get_tt_step_plan(scheduler_output) is not None:
-            return self._execute_lane_step(
-                scheduler_output, grammar_output, intermediate_tensors
-            )
+            return self._execute_lane_step(scheduler_output)
 
         # Apply any decode steps that have already completed on the async
         # thread. In steady decode mode we intentionally allow one step of
@@ -1996,14 +2056,14 @@ class TTModelRunner:
         self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_decode_from_scheduler(
-                scheduler_output, grammar_output
+                scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
             self.async_decode.wait_for_all_pending_async_steps()
 
-        # Update cached state and prepare model inputs
-        model_input = self.build_model_input(scheduler_output, grammar_output)
+        # Grammar is applied at sample time, so the forward builds without it.
+        model_input = self.build_model_input(scheduler_output, None)
         if model_input is None:
             return EMPTY_MODEL_RUNNER_OUTPUT
 
@@ -2012,20 +2072,121 @@ class TTModelRunner:
             steady_decode_fast_path = self.async_decode.can_use_steady_decode_fast_path(
                 model_input
             )
-            return self.async_decode.submit_async_non_dp_decode(
+            wrapper = self.async_decode.submit_async_non_dp_decode(
                 model_input,
                 steady_decode_fast_path=steady_decode_fast_path,
             )
+            self._pending_samples.append(
+                partial(
+                    self._finish_async_decode,
+                    wrapper=wrapper,
+                    model_input=model_input,
+                    lane_total=None,
+                )
+            )
+            return None
 
-        # Synchronous path (prefill, or decode without async scheduling)
-        sampled_token_ids_per_dp, logprobs_per_dp = self.execute_sync_with_model_input(  # noqa: E501
-            model_input
+        # Synchronous path (prefill, or decode without async scheduling): run
+        # the forward now and defer sampling to ``sample_tokens``.
+        fwd = self._forward_with_model_input(model_input)
+        self._pending_samples.append(partial(self._finish_nondp_sync, fwd=fwd))
+        return None
+
+    def _reorder_grammar_bitmask(
+        self,
+        grammar_output: GrammarOutput | None,
+        model_input: TTModelInput,
+        *,
+        lane_total: int | None,
+    ) -> torch.Tensor | None:
+        """Reorder a scheduler grammar bitmask into TT batch layout, or ``None``.
+
+        Runs at sample time. ``sample_tokens`` executes before the next
+        schedule, so the live batch/lane layout still matches the forward this
+        bitmask belongs to. ``lane_total`` selects the lane reorder (full slot
+        capacity) over the non-DP front-packed reorder.
+        """
+        if grammar_output is None or grammar_output.grammar_bitmask is None:
+            return None
+        if lane_total is not None:
+            return self.lane_batch.slot_grammar_bitmask(grammar_output, lane_total)
+        bitmask = torch.from_numpy(grammar_output.grammar_bitmask)
+        return reorder_grammar_bitmask_for_tt_batch(
+            bitmask=bitmask,
+            structured_output_request_ids=grammar_output.structured_output_request_ids,
+            req_id_to_index=self.input_batch.req_id_to_index,
+            req_indices=list(range(self.input_batch.num_reqs)),
+            batch_length=model_input.input_tokens.shape[0],
         )
+
+    def _apply_grammar_to_input(
+        self,
+        model_input: TTModelInput,
+        grammar_output: GrammarOutput | None,
+        *,
+        lane_total: int | None,
+    ) -> TTModelInput:
+        """Return ``model_input`` with the sample-time grammar bitmask attached."""
+        bitmask = self._reorder_grammar_bitmask(
+            grammar_output, model_input, lane_total=lane_total
+        )
+        if bitmask is None:
+            return model_input
+        return replace(model_input, grammar_bitmask=[bitmask])
+
+    def _finish_async_decode(
+        self,
+        grammar_output: GrammarOutput | None,
+        *,
+        wrapper: AsyncTTModelRunnerOutput,
+        model_input: TTModelInput,
+        lane_total: int | None,
+    ) -> AsyncTTModelRunnerOutput:
+        """Attach the sample-time grammar bitmask to a deferred async decode.
+
+        The reorder happens here on the engine thread (layout still matches the
+        forward); the wrapper applies the bitmask when its read completes.
+        """
+        bitmask = self._reorder_grammar_bitmask(
+            grammar_output, model_input, lane_total=lane_total
+        )
+        if bitmask is not None:
+            wrapper.set_grammar_bitmask(bitmask)
+        return wrapper
+
+    def _finish_nondp_sync(
+        self, grammar_output: GrammarOutput | None, *, fwd: _SyncForward | None
+    ) -> ModelRunnerOutput:
+        """Sample and build the runner output for a deferred non-DP forward."""
+        if fwd is None:
+            return self.apply_and_build_runner_output(
+                torch.tensor([], dtype=torch.int32), None
+            )
+        fwd = replace(
+            fwd,
+            model_input=self._apply_grammar_to_input(
+                fwd.model_input, grammar_output, lane_total=None
+            ),
+        )
+        sampled_token_ids_per_dp, logprobs_per_dp = self._sample_sync_forward(fwd)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
-        output = self.apply_and_build_runner_output(sampled_token_ids, logprobs)
-        return output
+        return self.apply_and_build_runner_output(sampled_token_ids, logprobs)
+
+    def sample_tokens(
+        self, grammar_output: GrammarOutput | None
+    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
+        """Sample the forward deferred by a preceding ``execute_model``.
+
+        Pops the oldest pending forward (FIFO, matching the engine's
+        oldest-first finalization), applies the now-ready grammar bitmask, and
+        produces its output (or an async wrapper for overlapped decode). The
+        engine calls this exactly once per ``execute_model`` that returned
+        ``None``.
+        """
+        finish = self._pending_samples.popleft()
+        return finish(grammar_output)
 
     def pack_dp_results(
         self,
@@ -2175,20 +2336,15 @@ class TTModelRunner:
             return tt_out
         return self.model.prefill_forward(**kwargs)
 
-    def execute_sync_with_model_input(
+    def _forward_with_model_input(
         self,
         model_input: TTModelInput,
-    ) -> tuple[list[torch.Tensor], list[LogprobsTensors | None]]:
-        """Run a fully synchronous TT execution for a prebuilt model input.
+    ) -> _SyncForward | None:
+        """Run the synchronous device forward for a prebuilt model input.
 
-        Executes a prebuilt TT input to completion, including prefill or decode
-        submission, decode finalization when needed, and per-DP token/logprob
-        extraction.
-
-        Returns:
-            Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
-            Each element in logprobs_per_dp is None if logprobs were not
-            requested for that DP rank.
+        Submits prefill or decode and finalizes the device read, but does not
+        sample. Returns the materialized forward state, or ``None`` when the
+        batch is empty (no rows to sample).
         """
         is_decode = model_input.prompt_lens is None
 
@@ -2196,8 +2352,7 @@ class TTModelRunner:
         if not isinstance(batch_size_per_dp, list):
             batch_size_per_dp = [batch_size_per_dp]
         if not any(bs > 0 for bs in batch_size_per_dp):
-            num_dp = len(batch_size_per_dp)
-            return ([torch.tensor([], dtype=torch.int32)] * num_dp, [None] * num_dp)
+            return None
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
@@ -2230,7 +2385,7 @@ class TTModelRunner:
             sampling_params = submission.sampling_params
             perform_device_sampling = submission.perform_device_sampling
 
-        return self._get_output_tokens(
+        return _SyncForward(
             tt_out=tt_out,
             tt_log_probs=tt_log_probs,
             sampling_params=sampling_params,
@@ -2239,6 +2394,45 @@ class TTModelRunner:
             perform_device_sampling=perform_device_sampling,
             is_decode=is_decode,
         )
+
+    def _sample_sync_forward(
+        self, fwd: _SyncForward
+    ) -> tuple[list[torch.Tensor], list[LogprobsTensors | None]]:
+        """Sample a forward produced by ``_forward_with_model_input``."""
+        return self._get_output_tokens(
+            tt_out=fwd.tt_out,
+            tt_log_probs=fwd.tt_log_probs,
+            sampling_params=fwd.sampling_params,
+            model_input=fwd.model_input,
+            batch_size_per_dp=fwd.batch_size_per_dp,
+            perform_device_sampling=fwd.perform_device_sampling,
+            is_decode=fwd.is_decode,
+        )
+
+    def execute_sync_with_model_input(
+        self,
+        model_input: TTModelInput,
+    ) -> tuple[list[torch.Tensor], list[LogprobsTensors | None]]:
+        """Run a fully synchronous TT execution for a prebuilt model input.
+
+        Executes a prebuilt TT input to completion, including prefill or decode
+        submission, decode finalization when needed, and per-DP token/logprob
+        extraction.
+
+        Returns:
+            Tuple of (sampled_token_ids_per_dp, logprobs_per_dp).
+            Each element in logprobs_per_dp is None if logprobs were not
+            requested for that DP rank.
+        """
+        fwd = self._forward_with_model_input(model_input)
+        if fwd is None:
+            num_dp = (
+                len(model_input.unpadded_batch_size)
+                if isinstance(model_input.unpadded_batch_size, list)
+                else 1
+            )
+            return ([torch.tensor([], dtype=torch.int32)] * num_dp, [None] * num_dp)
+        return self._sample_sync_forward(fwd)
 
     def prepare_dp_model_input(
         self,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -32,6 +32,7 @@ from vllm.v1.sample.sampler import Sampler
 from vllm_tt_plugin.async_decode import (
     AsyncTTModelRunnerOutput,
     CompletedDecodeStep,
+    DeferredDecodeOutput,
     TTAsyncDecodeController,
 )
 from vllm_tt_plugin.config import (
@@ -199,7 +200,7 @@ class TTModelRunner:
             and self.parallel_config.data_parallel_size == 1
         )
         self._steady_decode_lock = threading.Lock()
-        self._pending_async_events: deque[threading.Event] = deque()
+        self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
         self.async_decode = TTAsyncDecodeController(self)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -499,8 +499,8 @@ class TTPlatform(Platform):
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
             parallel_config.worker_cls = "vllm_tt_plugin.worker.TTWorker"
-        parallel_config.engine_core_cls = "vllm_tt_plugin.engine.TTEngineCore"
-        parallel_config.engine_core_proc_cls = "vllm_tt_plugin.engine.TTEngineCoreProc"
+        parallel_config.engine_core_cls = "vllm.v1.engine.core.EngineCore"
+        parallel_config.engine_core_proc_cls = "vllm.v1.engine.core.EngineCoreProc"
         parallel_config.dp_engine_core_proc_cls = (
             "vllm_tt_plugin.engine.TTDPEngineCoreProc"
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -21,7 +21,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
     MLAAttentionSpec,
 )
-from vllm.v1.outputs import ModelRunnerOutput
+from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
 from vllm_tt_plugin.config import (
     get_tt_config,
@@ -286,27 +286,29 @@ class TTWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | None:
-        """Expose the non-DP TT execution service to the executor layer.
+        """Run the device forward for a non-DP or lane-DP step.
 
-        Returns the runner's non-DP execution result for the provided
-        scheduler output.
-        """
-        return self.execute_model_with_grammar(scheduler_output, None)
-
-    def execute_model_with_grammar(
-        self,
-        scheduler_output: "SchedulerOutput",
-        grammar_output: "GrammarOutput | None",
-    ) -> ModelRunnerOutput | None:
-        """Execute a single-process TT step with plugin-owned structured-output
-        data.
-
-        ``execute_model`` handles both plain single-process and lane-DP steps:
-        it dispatches on the lane scheduler's per-step plan, so the worker does
-        not need to know whether lane-DP is active.
+        Returns ``None``: the forward leaves a pending sampler that the engine
+        finalizes via ``sample_tokens``. The runner dispatches plain
+        single-process vs lane-DP internally on the scheduler's step plan, so
+        the worker does not need to know which is active.
         """
         assert self.is_driver_worker, "There should only be one Worker for TT"
-        return self.model_runner.execute_model(scheduler_output, grammar_output)
+        return self.model_runner.execute_model(scheduler_output)
+
+    def sample_tokens(
+        self,
+        grammar_output: "GrammarOutput | None",
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput:
+        """Sample the forward deferred by ``execute_model``.
+
+        Called by the engine exactly once after ``execute_model`` returns
+        ``None``, matching the vLLM V1 forward-then-sample flow. The grammar
+        bitmask is reordered and applied here, at sample time. Returns an async
+        wrapper for overlapped decode, otherwise a completed output.
+        """
+        assert self.is_driver_worker, "There should only be one Worker for TT"
+        return self.model_runner.sample_tokens(grammar_output)
 
     def check_health(self) -> None:
         # Worker will always be healthy as long as it's running.

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -83,7 +83,7 @@ def test_lane_step_rejects_request_specific_rope():
     )
 
     with pytest.raises(NotImplementedError, match="request-specific RoPE"):
-        TTModelRunner._execute_lane_step(runner, output, grammar_output=None)
+        TTModelRunner._execute_lane_step(runner, output)
 
 
 # --------------------------------------------------------------------------

--- a/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
+++ b/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-only tests for the grammar-at-sample-time seam.
+
+The non-DP/lane-DP forward runs without the grammar bitmask and defers sampling
+to ``sample_tokens``; the bitmask is reordered into the live batch/lane layout
+and attached at that point. These tests pin the seam that makes that safe: FIFO
+pairing of each deferred forward with its grammar, the lane-vs-non-DP reorder
+dispatch, and grammar being applied before sampling in every finisher. No device
+execution; the index logic runs on plain tensors with fake collaborators.
+Requires the ttnn-enabled environment because importing the plugin modules pulls
+in ttnn.
+"""
+
+from dataclasses import replace
+from functools import partial
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+from vllm_tt_plugin.model_input import TTModelInput
+from vllm_tt_plugin.model_runner import TTModelRunner, _SyncForward
+
+from vllm.v1.core.sched.output import GrammarOutput
+
+VOCAB_WORDS = 2  # int32 words per grammar bitmask row
+
+
+def _model_input(**overrides) -> TTModelInput:
+    """A minimal real ``TTModelInput`` so ``dataclasses.replace`` works."""
+    base = dict(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        prompt_lens=None,
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=object(),
+        multi_modal_kwargs={},
+        perform_device_sampling=False,
+        grammar_bitmask=[None],
+        logitsprocs_list=[None],
+        bad_words_token_ids_list=[{}],
+        allowed_token_ids_mask_list=[None],
+        generators_list=[{}],
+        max_num_logprobs=[None],
+    )
+    base.update(overrides)
+    return TTModelInput(**base)
+
+
+def _grammar(num_structured: int) -> GrammarOutput:
+    bitmask = np.arange(num_structured * VOCAB_WORDS, dtype=np.int32).reshape(
+        num_structured, VOCAB_WORDS
+    )
+    req_ids = [f"req-{i}" for i in range(num_structured)]
+    return GrammarOutput(structured_output_request_ids=req_ids, grammar_bitmask=bitmask)
+
+
+# --------------------------------------------------------------------------
+# sample_tokens FIFO pairing
+# --------------------------------------------------------------------------
+
+
+def test_sample_tokens_pops_fifo_and_passes_grammar_through():
+    """Each deferred forward must sample with the grammar of its own step."""
+    from collections import deque
+
+    seen: list[tuple[str, object]] = []
+
+    def finisher(tag, grammar_output):
+        seen.append((tag, grammar_output))
+        return tag
+
+    runner = SimpleNamespace(_pending_samples=deque())
+    runner._pending_samples.append(partial(finisher, "first"))
+    runner._pending_samples.append(partial(finisher, "second"))
+
+    out0 = TTModelRunner.sample_tokens(runner, "grammar-A")
+    out1 = TTModelRunner.sample_tokens(runner, "grammar-B")
+
+    assert out0 == "first"
+    assert out1 == "second"
+    assert seen == [("first", "grammar-A"), ("second", "grammar-B")]
+    assert len(runner._pending_samples) == 0
+
+
+# --------------------------------------------------------------------------
+# _reorder_grammar_bitmask dispatch (lane vs non-DP vs none)
+# --------------------------------------------------------------------------
+
+
+def test_reorder_grammar_bitmask_none_returns_none():
+    runner = SimpleNamespace()
+    result = TTModelRunner._reorder_grammar_bitmask(
+        runner, None, _model_input(), lane_total=None
+    )
+    assert result is None
+
+
+def test_reorder_grammar_bitmask_lane_path_delegates_to_slot_reorder():
+    """``lane_total`` selects the full-slot lane reorder, not the non-DP one."""
+    calls: list[tuple] = []
+    sentinel = torch.tensor([[7, 7]], dtype=torch.int32)
+
+    def slot_grammar_bitmask(grammar_output, batch_length):
+        calls.append((grammar_output, batch_length))
+        return sentinel
+
+    runner = SimpleNamespace(
+        lane_batch=SimpleNamespace(slot_grammar_bitmask=slot_grammar_bitmask)
+    )
+    grammar = _grammar(1)
+
+    result = TTModelRunner._reorder_grammar_bitmask(
+        runner, grammar, _model_input(), lane_total=32
+    )
+
+    assert result is sentinel
+    assert calls == [(grammar, 32)]
+
+
+def test_reorder_grammar_bitmask_non_dp_path_uses_front_packed_reorder():
+    """Non-DP (``lane_total=None``) reorders against the front-packed batch."""
+    # Two requests, only req-1 structured; batch_length comes from input_tokens.
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(
+            req_id_to_index={"req-0": 0, "req-1": 1}, num_reqs=2
+        )
+    )
+    grammar = GrammarOutput(
+        structured_output_request_ids=["req-1"],
+        grammar_bitmask=np.array([[5, 6]], dtype=np.int32),
+    )
+    model_input = _model_input(input_tokens=torch.zeros((2, 1), dtype=torch.int32))
+
+    result = TTModelRunner._reorder_grammar_bitmask(
+        runner, grammar, model_input, lane_total=None
+    )
+
+    assert result.shape == (2, VOCAB_WORDS)
+    # req-1 (batch index 1) gets its scheduler bitmask row; req-0 is left
+    # all-ones (-1 in int32 = every token allowed).
+    assert result[1].tolist() == [5, 6]
+    assert torch.all(result[0] == -1)
+
+
+# --------------------------------------------------------------------------
+# _apply_grammar_to_input (attach only when a bitmask exists)
+# --------------------------------------------------------------------------
+
+
+def test_apply_grammar_to_input_returns_input_unchanged_when_no_bitmask():
+    runner = SimpleNamespace(_reorder_grammar_bitmask=lambda *a, **k: None)
+    model_input = _model_input()
+
+    result = TTModelRunner._apply_grammar_to_input(
+        runner, model_input, None, lane_total=None
+    )
+
+    assert result is model_input
+
+
+def test_apply_grammar_to_input_wraps_bitmask_in_single_element_list():
+    bitmask = torch.tensor([[1, 2]], dtype=torch.int32)
+    runner = SimpleNamespace(_reorder_grammar_bitmask=lambda *a, **k: bitmask)
+    model_input = _model_input()
+
+    result = TTModelRunner._apply_grammar_to_input(
+        runner, model_input, _grammar(1), lane_total=None
+    )
+
+    assert result is not model_input  # replace() returns a new frozen instance
+    assert len(result.grammar_bitmask) == 1
+    assert torch.equal(result.grammar_bitmask[0], bitmask)
+
+
+# --------------------------------------------------------------------------
+# _finish_async_decode (reorder on engine thread, attach to wrapper)
+# --------------------------------------------------------------------------
+
+
+def test_finish_async_decode_skips_bitmask_when_grammar_absent():
+    calls: list = []
+    wrapper = SimpleNamespace(set_grammar_bitmask=lambda bm: calls.append(bm))
+    runner = SimpleNamespace(_reorder_grammar_bitmask=lambda *a, **k: None)
+
+    result = TTModelRunner._finish_async_decode(
+        runner, None, wrapper=wrapper, model_input=_model_input(), lane_total=32
+    )
+
+    assert result is wrapper
+    assert calls == []  # no bitmask set on the wrapper
+
+
+def test_finish_async_decode_sets_bitmask_when_grammar_present():
+    calls: list = []
+    bitmask = torch.tensor([[3, 4]], dtype=torch.int32)
+    wrapper = SimpleNamespace(set_grammar_bitmask=lambda bm: calls.append(bm))
+    runner = SimpleNamespace(_reorder_grammar_bitmask=lambda *a, **k: bitmask)
+
+    result = TTModelRunner._finish_async_decode(
+        runner, _grammar(1), wrapper=wrapper, model_input=_model_input(), lane_total=32
+    )
+
+    assert result is wrapper
+    assert len(calls) == 1 and torch.equal(calls[0], bitmask)
+
+
+# --------------------------------------------------------------------------
+# _finish_nondp_sync / _finish_lane_sync (grammar applied before sampling)
+# --------------------------------------------------------------------------
+
+
+def _sync_forward(model_input: TTModelInput) -> _SyncForward:
+    return _SyncForward(
+        tt_out=object(),
+        tt_log_probs=None,
+        sampling_params=object(),
+        model_input=model_input,
+        batch_size_per_dp=[1],
+        perform_device_sampling=False,
+        is_decode=True,
+    )
+
+
+def test_finish_nondp_sync_applies_grammar_before_sampling():
+    order: list[str] = []
+
+    def apply_grammar(model_input, grammar_output, *, lane_total):
+        order.append("grammar")
+        assert lane_total is None
+        return replace(model_input, reset_batch=True)  # mark it was applied
+
+    def sample_sync(fwd):
+        order.append("sample")
+        # Grammar must already be on the input the sampler runs against.
+        assert fwd.model_input.reset_batch is True
+        return [torch.tensor([[42]], dtype=torch.int32)], []
+
+    def build_output(sampled, logprobs, **kwargs):
+        order.append("build")
+        return SimpleNamespace(sampled=sampled, logprobs=logprobs)
+
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=apply_grammar,
+        _sample_sync_forward=sample_sync,
+        apply_and_build_runner_output=build_output,
+    )
+    fwd = _sync_forward(_model_input())
+
+    output = TTModelRunner._finish_nondp_sync(runner, _grammar(1), fwd=fwd)
+
+    assert order == ["grammar", "sample", "build"]
+    assert output.sampled.tolist() == [[42]]
+
+
+def test_finish_nondp_sync_with_no_forward_builds_empty_output():
+    captured: dict = {}
+
+    def build_output(sampled, logprobs, **kwargs):
+        captured["sampled"] = sampled
+        captured["logprobs"] = logprobs
+        return "empty"
+
+    runner = SimpleNamespace(apply_and_build_runner_output=build_output)
+
+    output = TTModelRunner._finish_nondp_sync(runner, None, fwd=None)
+
+    assert output == "empty"
+    assert captured["sampled"].numel() == 0
+    assert captured["logprobs"] is None
+
+
+def test_finish_lane_sync_builds_req_ids_in_scheduled_row_order():
+    order: list[str] = []
+
+    def apply_grammar(model_input, grammar_output, *, lane_total):
+        order.append("grammar")
+        assert lane_total == 32
+        return model_input
+
+    def extract_output(
+        runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
+    ):
+        order.append("extract")
+        return torch.tensor([[11], [12]], dtype=torch.int32), None
+
+    captured: dict = {}
+
+    def build_output(sampled, logprobs, *, req_ids):
+        order.append("build")
+        captured["req_ids"] = req_ids
+        return SimpleNamespace(sampled=sampled)
+
+    # Row index -> req_id; scheduled_rows pick a subset out of slot order.
+    lane_req_ids = {4: "req-d", 1: "req-a"}
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=apply_grammar,
+        lane_batch=SimpleNamespace(extract_output=extract_output, req_ids=lane_req_ids),
+        apply_and_build_runner_output=build_output,
+    )
+
+    output = TTModelRunner._finish_lane_sync(
+        runner,
+        _grammar(1),
+        tt_out=object(),
+        tt_log_probs=None,
+        model_input=_model_input(),
+        scheduled_rows=[4, 1],
+        is_decode=True,
+        lane_total=32,
+    )
+
+    assert order == ["grammar", "extract", "build"]
+    # req_ids follow scheduled_rows order, not slot order.
+    assert captured["req_ids"] == ["req-d", "req-a"]
+    assert output.sampled.tolist() == [[11], [12]]


### PR DESCRIPTION
## Purpose

Implements the forward/sampling split from issue #382. 

Make execute_model run only the device forward and return None; the engine then computes the grammar bitmask and calls sample_tokens, which applies it and returns the output (or an async wrapper for overlapped decode). This matches the vLLM V1 forward-then-sample flow, so the non-DP/lane engine cores drop their grammar-threading fork and inherit the stock EngineCore step paths.

Grammar moves from input-build to sample time: the forward no longer waits for the bitmask, and structured-output decode is detected from scheduler state so steady decode never overlaps it. 

`execute_model` never sees the bitmask. To be more precise, `EngineCore` calls `execute_model` and `sample_tokens` separately. `execute_model` in `TTModelRunner` submits forward to the device and adds the sampling job to its internal `_pending_samples` queue. In the sync case, `sample_tokens` adds the bitmask to that queue entry and does the actual sampling. In the async case happy path, `sample_tokens` only adds the bitmask, then later `EngineCore` waits on `future.result()` which does the actual sampling.

**Important**: While the interface to EngineCore is now fully split, the actual *device* sampling still happens in forward. It's not straightforward to separate it out just yet:

* galaxy generator computes reset_inputs internally from many triggers (page-table change, mode switch, mixed greedy/random, sampling-mode change) and passes it to sample_decode_on_device — it's neither returned nor stashed. TTModelRunner
* tt_transformers generator.merges start_pos/tokens for the reset-step device-ahead case before sampling; the merged start_pos is discarded.

Given that in this PR we still support device sampling only for prompts without structured outputs, this works for now. However, to support device sampling with bitmask, proper split on device will be needed, and so more cleanup around reset_inputs will be needed. (Stash state on generator instance, or return extra context from decode_forward?)

Gathered multi-process DP is unchanged and still prepares grammar at build time. (We're planning to drop that code branch.)

## Test Result

CI: https://github.com/tenstorrent/tt-metal/actions/runs/28154758659

Validated locally on Galaxy:

| Topology | Sampling | seqs | Boot | Determinism/mixed-batch tests | Other tests |
|---|---|---|---|---|---|
| 70B lane-DP (DP=4) | device `"all"` | 8 | OK | **PASS** (4/4 solid) | PASS |
| 70B lane-DP (DP=4) | host (`None`) | 8 | OK | **FAIL 5, consistent (3/3 reruns)** | PASS |
| 1B non-DP (1,1) | device `"all"` | 8 | OK | FAIL ~5-6, **flaky** (set varies) | PASS |
| 1B non-DP (1,1) | device `"all"` | 32 | OK | FAIL 8 (flagged set) | PASS |
| 1B non-DP (1,1) | host (`None`) | 8 | OK | FAIL ~7-14, **flaky** (set varies) | PASS |
| 1B non-DP (1,1) | host (`None`) | 32 | OK | FAIL 12 (flagged set) | PASS |

Fails are known flaky sampling tests that sometimes fail even on `dev`.