### PR TITLE
forward-compat prep for newer vLLM

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -100,6 +100,7 @@ class TTModelRunner:
         mesh_device: ttnn.MeshDevice,
         trace_mode: str,
         enable_model_warmup: bool,
+        num_devices: int,
     ):
         self.vllm_config = vllm_config
         self.model_config = vllm_config.model_config
@@ -127,6 +128,8 @@ class TTModelRunner:
         self.mesh_device = mesh_device
         self.trace_mode = trace_mode
         self.enable_model_warmup = enable_model_warmup
+        # Runtime-discovered physical device count, supplied by the worker.
+        self.num_devices = num_devices
         # Whether to sample on device
         self.sample_on_device_mode = getattr(TTPlatform, "sample_on_device_mode", None)
         assert self.sample_on_device_mode in (None, "all", "decode_only")
@@ -381,8 +384,7 @@ class TTModelRunner:
         side for TT (caches are replicated per submesh and each device
         carries ``num_kv_heads // tp`` heads internally).
         """
-        assert self.device_config.num_devices is not None
-        num_devices = self.device_config.num_devices // self.tt_data_parallel_size
+        num_devices = self.num_devices // self.tt_data_parallel_size
         num_kv_heads = spec.num_kv_heads // min(num_devices, spec.num_kv_heads)
         return (num_blocks, num_kv_heads, spec.block_size, spec.head_size)
 
@@ -2075,8 +2077,7 @@ class TTModelRunner:
             return False
 
         # Calculate number of devices per DP rank
-        assert self.device_config.num_devices is not None
-        num_devices = self.device_config.num_devices // self.tt_data_parallel_size
+        num_devices = self.num_devices // self.tt_data_parallel_size
 
         # Always host-only sampling params: min_p, bad_words, logit_bias,
         # allowed_token_ids, min_tokens require host sampling.

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -99,8 +99,7 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     parallel_config.data_parallel_hybrid_lb = False
 
     # A single-process lane run owns one in-process worker, so pin the uniproc
-    # executor. Today vLLM derives the backend from ``world_size`` (== 1 here),
-    # so this is the value it already resolves to. Newer vLLM derives it from
+    # executor. Newer vLLM derives it from
     # ``world_size_across_dp`` and latches "mp" from the user's
     # --data_parallel_size before this hook runs; pinning "uni" keeps lane-DP
     # single-process there too, so the worker's runtime

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -98,6 +98,15 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     parallel_config.data_parallel_external_lb = False
     parallel_config.data_parallel_hybrid_lb = False
 
+    # A single-process lane run owns one in-process worker, so pin the uniproc
+    # executor. Today vLLM derives the backend from ``world_size`` (== 1 here),
+    # so this is the value it already resolves to. Newer vLLM derives it from
+    # ``world_size_across_dp`` and latches "mp" from the user's
+    # --data_parallel_size before this hook runs; pinning "uni" keeps lane-DP
+    # single-process there too, so the worker's runtime
+    # ``num_gpu_blocks_override`` still reaches the engine's KV-cache sizing.
+    parallel_config.distributed_executor_backend = "uni"
+
 
 def _convert_galaxy_gather_dp_to_lanes(vllm_config: "VllmConfig") -> None:
     """Transparently convert gathered multi-process DP into in-process TT lanes.

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -4,6 +4,7 @@
 import ast
 import math
 import os
+import time
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -23,6 +24,20 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
+
+try:
+    # Newer vLLM has compile_or_warm_up_model return per-worker timings, which
+    # the executor reduces into compilation_config. Older vLLM lacks the type;
+    # fall back to a local definition so the return value is still well-formed.
+    from vllm.v1.worker.worker_base import CompilationTimes
+except ImportError:  # pragma: no cover - older vLLM without the timing contract
+    from typing import NamedTuple
+
+    class CompilationTimes(NamedTuple):
+        language_model: float
+        encoder: float
+
+
 from vllm_tt_plugin.config import (
     get_tt_config,
     get_tt_data_parallel_size,
@@ -99,18 +114,19 @@ class TTWorker(WorkerBase):
             )
             self.device_config.device = self.mesh_device
             assert self.mesh_device is not None
-            self.device_config.num_devices = self.mesh_device.get_num_devices()
+            self.num_devices = self.mesh_device.get_num_devices()
         else:
             mesh_grid = get_mesh_grid(local_dp_rank)
             self.mesh_device = None
             # Num devices is required for determining num blocks in KV cache.
-            self.device_config.num_devices = mesh_grid[0] * mesh_grid[1]
+            self.num_devices = mesh_grid[0] * mesh_grid[1]
         # Init ModelRunner here, so that we have access to self.mesh_device.
         self.model_runner: TTModelRunner = TTModelRunner(
             vllm_config=self.vllm_config,
             mesh_device=self.mesh_device,
             trace_mode=self.trace_mode,
             enable_model_warmup=self.enable_model_warmup,
+            num_devices=self.num_devices,
         )
 
     def load_model(self):
@@ -252,7 +268,7 @@ class TTWorker(WorkerBase):
 
         # TODO: Once we can run profiling, return real available memory
         # instead of overriding the number of blocks.
-        num_tt_blocks = get_num_available_blocks_tt(self.vllm_config)
+        num_tt_blocks = get_num_available_blocks_tt(self.vllm_config, self.num_devices)
         self.cache_config.num_gpu_blocks_override = num_tt_blocks
         return 1 << 64
 
@@ -267,13 +283,22 @@ class TTWorker(WorkerBase):
         self.cache_config.num_gpu_blocks = num_gpu_blocks
         self.cache_config.num_cpu_blocks = num_cpu_blocks
 
-    def compile_or_warm_up_model(self) -> None:
+    def compile_or_warm_up_model(self) -> CompilationTimes:
+        # Newer vLLM reduces per-worker timings returned here into
+        # compilation_config.compilation_time; older vLLM ignores the return.
+        # TT does device warmup rather than graph compilation, so report the
+        # warmup wall time as the language-model figure and zero for the
+        # (absent) encoder phase.
         if not self.enable_model_warmup:
             logger.warning("Skipping model warmup")
-            return
+            return CompilationTimes(language_model=0.0, encoder=0.0)
         local_rank = self.parallel_config.data_parallel_rank_local
+        elapsed = 0.0
         if local_rank == 0:
+            start = time.perf_counter()
             self.model_runner.warmup_model()
+            elapsed = time.perf_counter() - start
+        return CompilationTimes(language_model=elapsed, encoder=0.0)
 
     def execute_model(
         self,
@@ -450,14 +475,16 @@ class TTWorker(WorkerBase):
             super().__del__()  # type: ignore
 
 
-def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
+def get_num_available_blocks_tt(vllm_config: VllmConfig, num_devices: int) -> int:
     """
     Used to set the number of available blocks for the TT KV cache as we
     currently do not run profiling to determine available memory.
+
+    ``num_devices`` is the runtime-discovered physical device count, passed in
+    from the worker rather than read from config; it is not a vLLM config value.
     """
 
     model_config = vllm_config.model_config
-    device_config = vllm_config.device_config
     cache_config = vllm_config.cache_config
 
     # region Get default or model- and device-specific `max_tokens_all_users`
@@ -474,7 +501,7 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig) -> int:
         # identical across both modes.
         max_tokens_all_users = model_class.get_max_tokens_all_users(
             model_name=model_config.model,
-            num_devices=device_config.num_devices,
+            num_devices=num_devices,
             tt_data_parallel=tt_data_parallel,
             max_model_len=model_config.max_model_len,
             max_num_seqs=get_tt_per_lane_max_num_seqs(vllm_config),

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -480,8 +480,7 @@ def get_num_available_blocks_tt(vllm_config: VllmConfig, num_devices: int) -> in
     Used to set the number of available blocks for the TT KV cache as we
     currently do not run profiling to determine available memory.
 
-    ``num_devices`` is the runtime-discovered physical device count, passed in
-    from the worker rather than read from config; it is not a vLLM config value.
+    ``num_devices`` is the runtime-discovered physical device count.
     """
 
     model_config = vllm_config.model_config


### PR DESCRIPTION
## Purpose

Three version-agnostic changes that ready the plugin for a vLLM bump while
    behaving identically on the current fork:
    - Carry the runtime device count on the worker/runner instead of
      DeviceConfig.num_devices, dropping the dependency on that core field.
    - Return CompilationTimes from compile_or_warm_up_model via a defensive
      import (falls back to a local NamedTuple on vLLM versions without it; the
      current executor ignores the return).
    - Pin the uniproc executor when collapsing gathered DP to lanes. Today vLLM
      derives "uni" from world_size==1 anyway; newer vLLM derives the backend
      from world_size_across_dp and latches "mp", which would force lane-DP
      multiprocess and break the worker's runtime num_gpu_blocks_override.

## Test Result

CI: https://github.com/tenstorrent/tt-metal/actions/runs/28094800470
