### PR TITLE
Remove --plugin-config

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -259,8 +259,7 @@ TT options are passed through vLLM's generic additional config namespace:
 ```
 
 Plugin code reads this through `vllm_tt_plugin.config.get_tt_config()`, which
-returns `vllm_config.additional_config["tt"]`. The `--plugin-config` flag has
-been removed; passing it errors out and directs you to `--additional-config`.
+returns `vllm_config.additional_config["tt"]`.
 
 Common options:
 

--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -259,8 +259,8 @@ TT options are passed through vLLM's generic additional config namespace:
 ```
 
 Plugin code reads this through `vllm_tt_plugin.config.get_tt_config()`, which
-returns `vllm_config.additional_config["tt"]`. The deprecated
-`--plugin-config '{"tt": {...}}'` form is still accepted with a warning.
+returns `vllm_config.additional_config["tt"]`. The `--plugin-config` flag has
+been removed; passing it errors out and directs you to `--additional-config`.
 
 Common options:
 

--- a/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
+++ b/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
@@ -25,15 +25,6 @@ from vllm.utils.async_utils import merge_async_iterators
 from vllm.v1.engine.async_llm import AsyncLLM
 
 
-class _PluginConfigRemovedAction(argparse.Action):
-    """Reject --plugin-config: it was removed in favor of --additional-config."""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        parser.error(
-            "--plugin-config has been removed. Use --additional-config instead."
-        )
-
-
 def get_sample_multi_modal_llama_inputs():
     """
     Prepare 4 sample multi-modal prompts for Llama3.2-11B
@@ -677,12 +668,6 @@ if __name__ == "__main__":
         type=str,
         default=None,
         help="Additional vLLM options as JSON, for example '{\"tt\": {...}}'",
-    )
-    parser.add_argument(
-        "--plugin-config",
-        nargs="?",
-        action=_PluginConfigRemovedAction,
-        help=argparse.SUPPRESS,
     )
     parser.add_argument("--max_model_len", type=int, default=None, help="Max model len")
     parser.add_argument(

--- a/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
+++ b/plugins/vllm-tt-plugin/examples/offline_inference_tt.py
@@ -3,7 +3,6 @@
 
 import argparse
 import json
-import sys
 import time
 from pathlib import Path
 
@@ -24,6 +23,15 @@ from vllm.entrypoints.openai.api_server import (
 from vllm.inputs.data import TokensPrompt
 from vllm.utils.async_utils import merge_async_iterators
 from vllm.v1.engine.async_llm import AsyncLLM
+
+
+class _PluginConfigRemovedAction(argparse.Action):
+    """Reject --plugin-config: it was removed in favor of --additional-config."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error(
+            "--plugin-config has been removed. Use --additional-config instead."
+        )
 
 
 def get_sample_multi_modal_llama_inputs():
@@ -248,7 +256,6 @@ def run_inference(
     multi_image=False,
     mm_processor_kwargs=None,
     test_increasing_seq_lens=False,
-    plugin_config=None,
     additional_config=None,
     max_model_len=None,
     max_num_batched_tokens=None,
@@ -302,34 +309,11 @@ def run_inference(
     }
 
     try:
-        parsed_additional_config = None
         if additional_config:
             parsed_additional_config = json.loads(additional_config)
             if not isinstance(parsed_additional_config, dict):
                 raise ValueError("additional_config must be a JSON object")
-
-        parsed_plugin_config = None
-        if plugin_config:
-            print(
-                "WARNING: --plugin-config is deprecated. "
-                "Use --additional-config '{\"tt\": {...}}' instead.",
-                file=sys.stderr,
-            )
-            parsed_plugin_config = json.loads(plugin_config)
-            if not isinstance(parsed_plugin_config, dict):
-                raise ValueError("plugin_config must be a JSON object")
-
-        if parsed_additional_config is not None and parsed_plugin_config is not None:
-            raise ValueError(
-                "Only one of additional_config or plugin_config may be provided. "
-                "Prefer additional_config."
-            )
-        if parsed_additional_config is not None or parsed_plugin_config is not None:
-            engine_kw_args["additional_config"] = (
-                parsed_additional_config
-                if parsed_additional_config is not None
-                else parsed_plugin_config
-            )
+            engine_kw_args["additional_config"] = parsed_additional_config
     except json.JSONDecodeError as err:
         raise ValueError(f"Invalid JSON config string: {err}") from err
 
@@ -696,13 +680,9 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--plugin-config",
-        dest="plugin_config",
-        type=str,
-        default=None,
-        help=(
-            "Deprecated alias; prefer --additional-config. "
-            "Value must use the same '{\"tt\": {...}}' JSON shape."
-        ),
+        nargs="?",
+        action=_PluginConfigRemovedAction,
+        help=argparse.SUPPRESS,
     )
     parser.add_argument("--max_model_len", type=int, default=None, help="Max model len")
     parser.add_argument(
@@ -763,7 +743,6 @@ if __name__ == "__main__":
         mm_processor_kwargs=args.mm_processor_kwargs,
         test_increasing_seq_lens=args.test_increasing_seq_lens,
         additional_config=args.additional_config,
-        plugin_config=args.plugin_config,
         max_model_len=args.max_model_len,
         max_num_batched_tokens=args.max_num_batched_tokens,
         data_parallel_size=args.data_parallel_size,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-_warned_plugin_config = False
-
 
 def _extract_tt_config(
     config: dict[str, Any], config_name: str
@@ -26,36 +24,12 @@ def _extract_tt_config(
     return tt_config, True
 
 
-def _warn_plugin_config() -> None:
-    global _warned_plugin_config
-    if _warned_plugin_config:
-        return
-    logger.warning(
-        "TT config passed through --plugin-config is deprecated. "
-        "Use --additional-config '{\"tt\": {...}}' instead."
-    )
-    _warned_plugin_config = True
-
-
 def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
     """Return TT config from vLLM's generic additional config namespace."""
-    additional_config, has_additional_config = _extract_tt_config(
+    additional_config, _ = _extract_tt_config(
         getattr(vllm_config, "additional_config", {}) or {}, "additional_config"
     )
-    plugin_config, has_plugin_config = _extract_tt_config(
-        getattr(vllm_config, "plugin_config", {}) or {}, "plugin_config"
-    )
-
-    if has_plugin_config:
-        _warn_plugin_config()
-
-    if has_additional_config and has_plugin_config:
-        raise ValueError(
-            "Only one of additional_config or plugin_config may contain TT config. "
-            "Prefer additional_config. plugin_config is deprecated."
-        )
-
-    return dict(additional_config if has_additional_config else plugin_config)
+    return dict(additional_config)
 
 
 # Internal key recording the resolved TT lane count. Stored at the top level of

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -32,7 +32,6 @@ logger = init_logger(__name__)
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"
-_warned_cli_plugin_config = False
 
 # TT model versions backed by the single-execute Galaxy generator
 # (models.demos.llama3_70b_galaxy.tt.generator:Generator). For these, gathered
@@ -54,17 +53,6 @@ def _galaxy_generator_version() -> str | None:
         if os.getenv(env_var) == version:
             return version
     return None
-
-
-def _warn_cli_plugin_config() -> None:
-    global _warned_cli_plugin_config
-    if _warned_cli_plugin_config:
-        return
-    logger.warning(
-        "TT config passed through --plugin-config is deprecated. "
-        "Use --additional-config '{\"tt\": {...}}' instead."
-    )
-    _warned_cli_plugin_config = True
 
 
 def _collapse_parallel_config_to_single_process(parallel_config) -> None:
@@ -173,30 +161,15 @@ def _should_pre_register_tt_test_models_from_cli() -> bool:
             return None
         return parsed if isinstance(parsed, dict) else None
 
-    canonical_flags = {"--additional-config", "--plugin-config"}
-    parsed_configs: dict[str, dict] = {}
+    cfg = None
     for i, arg in enumerate(argv):
         if "=" in arg:
             flag, value = arg.split("=", 1)
-            normalized_flag = flag.replace("_", "-")
-            if normalized_flag in canonical_flags:
-                if normalized_flag == "--plugin-config":
-                    _warn_cli_plugin_config()
-                cfg = _parse_namespaced_config(value)
-                if cfg:
-                    parsed_configs[normalized_flag] = cfg
-        else:
-            normalized_arg = arg.replace("_", "-")
-            if normalized_arg in canonical_flags and i + 1 < len(argv):
-                if normalized_arg == "--plugin-config":
-                    _warn_cli_plugin_config()
-                cfg = _parse_namespaced_config(argv[i + 1])
-                if cfg:
-                    parsed_configs[normalized_arg] = cfg
+            if flag.replace("_", "-") == "--additional-config":
+                cfg = _parse_namespaced_config(value) or cfg
+        elif arg.replace("_", "-") == "--additional-config" and i + 1 < len(argv):
+            cfg = _parse_namespaced_config(argv[i + 1]) or cfg
 
-    cfg = parsed_configs.get("--additional-config") or parsed_configs.get(
-        "--plugin-config"
-    )
     tt_config = cfg.get("tt", {}) if cfg else {}
     return bool(
         isinstance(tt_config, dict) and tt_config.get("register_test_models") is True

--- a/plugins/vllm-tt-plugin/tests/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/test_config.py
@@ -18,7 +18,6 @@ def _vllm_config(
 
     return SimpleNamespace(
         additional_config=additional_config,
-        plugin_config={},
         parallel_config=SimpleNamespace(data_parallel_size=data_parallel_size),
         scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
     )
@@ -73,7 +72,6 @@ def test_store_tt_lane_count_round_trips_through_get():
 def test_store_tt_lane_count_creates_additional_config_when_missing():
     config = SimpleNamespace(
         additional_config=None,
-        plugin_config={},
         parallel_config=SimpleNamespace(data_parallel_size=1),
         scheduler_config=SimpleNamespace(max_num_seqs=8),
     )

--- a/plugins/vllm-tt-plugin/tests/test_galaxy_dp_conversion.py
+++ b/plugins/vllm-tt-plugin/tests/test_galaxy_dp_conversion.py
@@ -16,7 +16,6 @@ from vllm_tt_plugin import platform as tt_platform
 def _vllm_config(*, data_parallel_size, max_num_seqs):
     return SimpleNamespace(
         additional_config={"tt": {}},
-        plugin_config={},
         parallel_config=SimpleNamespace(
             data_parallel_size=data_parallel_size,
             data_parallel_size_local=data_parallel_size,

--- a/plugins/vllm-tt-plugin/tests/test_num_available_blocks.py
+++ b/plugins/vllm-tt-plugin/tests/test_num_available_blocks.py
@@ -41,9 +41,9 @@ def cfg():
     Mocks ttnn.get_arch_name so the wormhole check passes; otherwise we'd
     need a real device to land on the per-SKU branches.
 
-    additional_config and plugin_config are set to empty dicts so that
-    get_tt_config's isinstance(config, dict) guard doesn't raise on
-    the auto-generated MagicMock attributes.
+    additional_config is set to an empty dict so that get_tt_config's
+    isinstance(config, dict) guard doesn't raise on the auto-generated
+    MagicMock attribute.
     """
     c = MagicMock()
     c.model_config.model = "unknown-model-falls-into-default-branch"
@@ -53,7 +53,6 @@ def cfg():
     c.scheduler_config.max_num_seqs = 32
     c.cache_config.block_size = 64
     c.additional_config = {}
-    c.plugin_config = {}
     return c
 
 

--- a/plugins/vllm-tt-plugin/tests/tt/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/tt/test_config.py
@@ -6,55 +6,24 @@ import pytest
 from vllm_tt_plugin import config as tt_config
 
 
-@pytest.fixture(autouse=True)
-def reset_warning_state():
-    old_warned_plugin_config = tt_config._warned_plugin_config
-    tt_config._warned_plugin_config = False
-    yield
-    tt_config._warned_plugin_config = old_warned_plugin_config
-
-
 def _vllm_config(
     additional_config=None,
-    plugin_config=None,
     data_parallel_size=1,
     max_num_seqs=8,
 ):
     return SimpleNamespace(
         additional_config=additional_config or {},
-        plugin_config=plugin_config or {},
         parallel_config=SimpleNamespace(data_parallel_size=data_parallel_size),
         scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
     )
 
 
-def test_get_tt_config_prefers_additional_config():
+def test_get_tt_config_reads_additional_config():
     config = _vllm_config(
         additional_config={"tt": {"sample_on_device_mode": "all"}},
     )
 
     assert tt_config.get_tt_config(config) == {"sample_on_device_mode": "all"}
-
-
-def test_get_tt_config_accepts_plugin_config_with_warning(caplog):
-    config = _vllm_config(
-        plugin_config={"tt": {"sample_on_device_mode": "decode_only"}},
-    )
-
-    assert tt_config.get_tt_config(config) == {"sample_on_device_mode": "decode_only"}
-    assert "--plugin-config is deprecated" in caplog.text
-
-
-def test_get_tt_config_rejects_both_config_sources():
-    config = _vllm_config(
-        additional_config={"tt": {"trace_mode": "all"}},
-        plugin_config={"tt": {"trace_mode": "none"}},
-    )
-
-    with pytest.raises(
-        ValueError, match="Only one of additional_config or plugin_config"
-    ):
-        tt_config.get_tt_config(config)
 
 
 def test_get_tt_per_lane_max_num_seqs_derives_lane_capacity_from_global_cap():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -273,8 +273,6 @@ class VllmConfig:
     """Additional config for specified platform. Different platforms may
     support different configs. Make sure the configs are valid for the platform
     you are using. Contents must be hashable."""
-    plugin_config: dict[str, dict[str, Any]] = Field(default_factory=dict)
-    """Plugin-owned configuration keyed by plugin namespace."""
     instance_id: str = ""
     """The ID of the vLLM instance."""
     optimization_level: OptimizationLevel = OptimizationLevel.O2
@@ -1479,7 +1477,6 @@ class VllmConfig:
             f"enable_prefix_caching={self.cache_config.enable_prefix_caching}, "
             f"enable_chunked_prefill={self.scheduler_config.enable_chunked_prefill}, "  # noqa
             f"pooler_config={self.model_config.pooler_config!r}, "
-            f"plugin_config={self.plugin_config!r}, "
             f"compilation_config={self.compilation_config!r}"
         )
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -348,6 +348,25 @@ def get_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     return copy.deepcopy(_compute_kwargs(cls))
 
 
+class _PluginConfigRemovedAction(argparse.Action):
+    """Reject --plugin-config: it was removed in favor of --additional-config.
+
+    Consumes an optional value so users who pass `--plugin-config '{...}'` hit
+    the directed error instead of argparse's generic "unrecognized arguments".
+    """
+
+    def __init__(self, option_strings, dest, **kwargs):
+        kwargs["nargs"] = "?"
+        kwargs["default"] = argparse.SUPPRESS
+        kwargs["help"] = argparse.SUPPRESS
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        parser.error(
+            "--plugin-config has been removed. Use --additional-config instead."
+        )
+
+
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
@@ -566,7 +585,6 @@ class EngineArgs:
     mamba_cache_mode: MambaCacheMode = CacheConfig.mamba_cache_mode
 
     additional_config: dict[str, Any] = get_field(VllmConfig, "additional_config")
-    plugin_config: dict[str, dict[str, Any]] = get_field(VllmConfig, "plugin_config")
 
     use_tqdm_on_load: bool = LoadConfig.use_tqdm_on_load
     pt_load_map_location: str = LoadConfig.pt_load_map_location
@@ -610,11 +628,6 @@ class EngineArgs:
             self.weight_transfer_config = WeightTransferConfig(
                 **self.weight_transfer_config
             )
-        if not isinstance(self.plugin_config, dict) or any(
-            not isinstance(key, str) or not isinstance(value, dict)
-            for key, value in self.plugin_config.items()
-        ):
-            raise ValueError("plugin_config must map plugin names to object values")
         # Setup plugins
         from vllm.plugins import load_general_plugins
 
@@ -1217,7 +1230,7 @@ class EngineArgs:
         vllm_group.add_argument(
             "--additional-config", **vllm_kwargs["additional_config"]
         )
-        vllm_group.add_argument("--plugin-config", **vllm_kwargs["plugin_config"])
+        vllm_group.add_argument("--plugin-config", action=_PluginConfigRemovedAction)
         vllm_group.add_argument(
             "--structured-outputs-config", **vllm_kwargs["structured_outputs_config"]
         )
@@ -1825,7 +1838,6 @@ class EngineArgs:
             ec_transfer_config=self.ec_transfer_config,
             profiler_config=self.profiler_config,
             additional_config=self.additional_config,
-            plugin_config=self.plugin_config,
             optimization_level=self.optimization_level,
             weight_transfer_config=self.weight_transfer_config,
         )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -348,25 +348,6 @@ def get_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     return copy.deepcopy(_compute_kwargs(cls))
 
 
-class _PluginConfigRemovedAction(argparse.Action):
-    """Reject --plugin-config: it was removed in favor of --additional-config.
-
-    Consumes an optional value so users who pass `--plugin-config '{...}'` hit
-    the directed error instead of argparse's generic "unrecognized arguments".
-    """
-
-    def __init__(self, option_strings, dest, **kwargs):
-        kwargs["nargs"] = "?"
-        kwargs["default"] = argparse.SUPPRESS
-        kwargs["help"] = argparse.SUPPRESS
-        super().__init__(option_strings, dest, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        parser.error(
-            "--plugin-config has been removed. Use --additional-config instead."
-        )
-
-
 @dataclass
 class EngineArgs:
     """Arguments for vLLM engine."""
@@ -1230,7 +1211,6 @@ class EngineArgs:
         vllm_group.add_argument(
             "--additional-config", **vllm_kwargs["additional_config"]
         )
-        vllm_group.add_argument("--plugin-config", action=_PluginConfigRemovedAction)
         vllm_group.add_argument(
             "--structured-outputs-config", **vllm_kwargs["structured_outputs_config"]
         )


### PR DESCRIPTION
## Purpose

Fixes #402 - removes `--plugin-config`. Prints warning for now. When we switch to upstream vLLM, this will automatically become unrecognized argument, no nice warning.

## Test Result

https://github.com/tenstorrent/tt-metal/actions/runs/28166342740