### PR TITLE
requirements: allow transformers 5.x (align with upstream)

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 4.56.0, < 5
+transformers >= 5.5.3  # transformers 5.x: align with upstream vLLM; required for gemma4 model support
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 5.5.3  # transformers 5.x: align with upstream vLLM; required for gemma4 model support
+transformers >= 5.5.3
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.


### PR DESCRIPTION
### What
Bump the runtime transformers constraint from `>= 4.56.0, < 5` to `>= 5.5.3`, matching upstream `vllm-project/vllm` (which already requires `transformers >= 5.5.3`).

### Why
tt-metal pins `transformers == 5.10.2` repo-wide, and its gemma4 models only have native config support in transformers 5.x. The tt-metal vLLM nightly installs this fork via `uv pip install vllm/`; the old `< 5` cap downgrades transformers to 4.57.6, after which vLLM's `ModelConfig` validation rejects `model_type: gemma4` ("Transformers does not recognize this architecture") — failing every gemma4 job in the [vLLM nightly](https://github.com/tenstorrent/tt-metal/actions/runs/28139255072).

Today tt-metal works around this with a `transformers==5.10.2` pin in `models/demos/gemma4/requirements.txt`; aligning this fork with upstream lets that workaround be removed.

### Validation
tt-metal vLLM nightly dispatched against this branch (`vllm-commit=mtairum/transformers-5-compat`):
- [ ] Full matrix (`model=all`) green on transformers 5.10.2 — gemma3, gemma4, qwen3, llama, etc.: https://github.com/tenstorrent/tt-metal/actions/runs/28172722366
- [ ] Gemma4-only (`model=google/gemma-4`, all variants): https://github.com/tenstorrent/tt-metal/actions/runs/28172113508
- [ ] vLLM's own test suite — note `requirements/test.in`/`test.txt`/`rocm-test.txt`/`nightly_torch_test.txt` still pin `transformers==4.57.5` (test-only, compiled lockfiles; not installed by the tt-metal nightly). Left unchanged here to avoid unrelated dependency churn; worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)