### PR TITLE
[Feature] Make standard vLLM DP default (replaces #408)

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -58,22 +58,6 @@ def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
     return dict(additional_config if has_additional_config else plugin_config)
 
 
-def validate_no_tt_gathered_dp_override(vllm_config: "VllmConfig") -> None:
-    """Reject the removed TT gathered-DP override.
-
-    Standard vLLM DP is now the only multi-process DP mode. Galaxy models keep
-    their transparent single-process lane conversion, so the old gathered-DP
-    override is no longer supported.
-    """
-    tt_config = get_tt_config(vllm_config)
-    if "tt_data_parallel_size" in tt_config:
-        raise ValueError(
-            "TT config key 'tt_data_parallel_size' is no longer supported. "
-            "Use --data_parallel_size for standard DP. Galaxy models are "
-            "converted to single-process lane-DP automatically."
-        )
-
-
 # Internal key recording the resolved TT lane count. Stored at the top level of
 # additional_config -- deliberately outside the user "tt" namespace -- so it
 # never collides with user config and reads as platform-derived state rather

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -85,14 +85,13 @@ _RESOLVED_LANE_COUNT_KEY = "_tt_resolved_lane_count"
 def get_tt_data_parallel_size(vllm_config: "VllmConfig") -> int:
     """Effective TT lane count for batching, KV sizing, and merged execution.
 
-    With standard multi-process DP (``data_parallel_size > 1``) this is just
-    ``data_parallel_size`` (one engine per rank). With a single engine
-    (``data_parallel_size == 1``) it is the lane count resolved by the Galaxy
-    DP-to-lanes conversion (see ``platform.py``) and recorded via
-    ``store_tt_lane_count``; absent that, the count is 1. Not user-facing.
+    Standard multi-process DP runs one independent TT mesh per rank, so the TT
+    model itself sees no internal DP and the effective TT lane count remains 1.
+    With a single engine (``data_parallel_size == 1``) the value is the lane
+    count resolved by the Galaxy DP-to-lanes conversion (see ``platform.py``)
+    and recorded via ``store_tt_lane_count``; absent that, the count is 1.
+    Not user-facing.
     """
-    if vllm_config.parallel_config.data_parallel_size > 1:
-        return vllm_config.parallel_config.data_parallel_size
     additional = getattr(vllm_config, "additional_config", None) or {}
     return int(additional.get(_RESOLVED_LANE_COUNT_KEY, 1))
 
@@ -118,16 +117,11 @@ def store_tt_lane_count(vllm_config: "VllmConfig", lanes: int) -> None:
 def get_tt_max_batch_size(vllm_config: "VllmConfig") -> int:
     """Return the global TT batch capacity for model/KV sizing.
 
-    Standard multi-process DP keeps the historical contract: each rank receives
-    ``max_num_seqs`` requests and the TT model is initialized for the gathered
-    DP batch. Single-process lane mode is different: vLLM sees one engine, so
-    ``max_num_seqs`` is already the global engine capacity and lanes are only an
-    internal partition.
+    Standard DP is per-rank and single-process lane mode already stores the
+    global engine capacity in ``max_num_seqs`` after the Galaxy conversion, so
+    the TT model should always size itself to the visible engine-local batch.
     """
-    max_num_seqs = int(vllm_config.scheduler_config.max_num_seqs)
-    if vllm_config.parallel_config.data_parallel_size > 1:
-        return max_num_seqs * vllm_config.parallel_config.data_parallel_size
-    return max_num_seqs
+    return int(vllm_config.scheduler_config.max_num_seqs)
 
 
 def get_tt_per_lane_max_num_seqs(vllm_config: "VllmConfig") -> int:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -58,6 +58,22 @@ def get_tt_config(vllm_config: "VllmConfig") -> dict[str, Any]:
     return dict(additional_config if has_additional_config else plugin_config)
 
 
+def validate_no_tt_gathered_dp_override(vllm_config: "VllmConfig") -> None:
+    """Reject the removed TT gathered-DP override.
+
+    Standard vLLM DP is now the only multi-process DP mode. Galaxy models keep
+    their transparent single-process lane conversion, so the old gathered-DP
+    override is no longer supported.
+    """
+    tt_config = get_tt_config(vllm_config)
+    if "tt_data_parallel_size" in tt_config:
+        raise ValueError(
+            "TT config key 'tt_data_parallel_size' is no longer supported. "
+            "Use --data_parallel_size for standard DP. Galaxy models are "
+            "converted to single-process lane-DP automatically."
+        )
+
+
 # Internal key recording the resolved TT lane count. Stored at the top level of
 # additional_config -- deliberately outside the user "tt" namespace -- so it
 # never collides with user config and reads as platform-derived state rather
@@ -69,10 +85,10 @@ _RESOLVED_LANE_COUNT_KEY = "_tt_resolved_lane_count"
 def get_tt_data_parallel_size(vllm_config: "VllmConfig") -> int:
     """Effective TT lane count for batching, KV sizing, and merged execution.
 
-    With gathered multi-process DP (``data_parallel_size > 1``) this is just
+    With standard multi-process DP (``data_parallel_size > 1``) this is just
     ``data_parallel_size`` (one engine per rank). With a single engine
     (``data_parallel_size == 1``) it is the lane count resolved by the Galaxy
-    gather-DP-to-lanes conversion (see ``platform.py``) and recorded via
+    DP-to-lanes conversion (see ``platform.py``) and recorded via
     ``store_tt_lane_count``; absent that, the count is 1. Not user-facing.
     """
     if vllm_config.parallel_config.data_parallel_size > 1:
@@ -102,7 +118,7 @@ def store_tt_lane_count(vllm_config: "VllmConfig", lanes: int) -> None:
 def get_tt_max_batch_size(vllm_config: "VllmConfig") -> int:
     """Return the global TT batch capacity for model/KV sizing.
 
-    Gathered multi-process DP keeps the historical contract: each rank receives
+    Standard multi-process DP keeps the historical contract: each rank receives
     ``max_num_seqs`` requests and the TT model is initialized for the gathered
     DP batch. Single-process lane mode is different: vLLM sees one engine, so
     ``max_num_seqs`` is already the global engine capacity and lanes are only an

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
@@ -20,7 +20,7 @@ from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
 from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPlan
 from vllm.v1.executor.abstract import UniProcExecutor
-from vllm_tt_plugin.config import get_tt_config, validate_no_tt_gathered_dp_override
+from vllm_tt_plugin.config import get_tt_config
 
 logger = init_logger(__name__)
 
@@ -199,8 +199,6 @@ def parse_tt_mpi_params(vllm_config: VllmConfig) -> tuple[str | None, set[int]]:
         "TT does not support ray-based data parallel backend"
     )
 
-    validate_no_tt_gathered_dp_override(vllm_config)
-
     tt_config = get_tt_config(vllm_config)
     rank_binding_file = tt_config.get("rank_binding")
     non_device_dp_ranks: set[int] = set()
@@ -375,9 +373,6 @@ def main() -> None:
     )
     if not has_mpi:
         raise RuntimeError("TT engine core must be launched under MPI")
-
-    validate_no_tt_gathered_dp_override(vllm_config)
-
     pc = vllm_config.parallel_config
     _resolve_remote_dp_rank(vllm_config, mpi_world)
     pc.data_parallel_rank = mpi_rank

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
@@ -20,7 +20,7 @@ from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
 from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPlan
 from vllm.v1.executor.abstract import UniProcExecutor
-from vllm_tt_plugin.config import get_tt_config
+from vllm_tt_plugin.config import get_tt_config, validate_no_tt_gathered_dp_override
 
 logger = init_logger(__name__)
 
@@ -183,12 +183,24 @@ def _validate_launch_from_rank0_host(mpi_args: str, host_ip: str) -> None:
     logger.info("Validated launching from MPI rank 0 host %s", rank0_host)
 
 
+def _resolve_remote_dp_rank(vllm_config: VllmConfig, mpi_world: int) -> None:
+    pc = vllm_config.parallel_config
+    if pc.data_parallel_size != mpi_world:
+        raise RuntimeError(
+            "Standard DP mode requires one TT MPI rank per DP rank: "
+            f"data_parallel_size ({pc.data_parallel_size}) must equal "
+            f"MPI world size ({mpi_world})"
+        )
+
+
 def parse_tt_mpi_params(vllm_config: VllmConfig) -> tuple[str | None, set[int]]:
     parallel_config = vllm_config.parallel_config
     assert parallel_config.data_parallel_backend != "ray", (
         "TT does not support ray-based data parallel backend"
     )
-    dp_size = parallel_config.data_parallel_size
+
+    validate_no_tt_gathered_dp_override(vllm_config)
+
     tt_config = get_tt_config(vllm_config)
     rank_binding_file = tt_config.get("rank_binding")
     non_device_dp_ranks: set[int] = set()
@@ -200,21 +212,18 @@ def parse_tt_mpi_params(vllm_config: VllmConfig) -> tuple[str | None, set[int]]:
         try:
             with open(rank_binding_file) as f:
                 rb = yaml.safe_load(f)
-            mpi_world = len(rb.get("rank_bindings", []))
+            rank_bindings = rb.get("rank_bindings", [])
+            mpi_world = len(rank_bindings)
         except Exception as e:
             raise RuntimeError(
                 f"Failed to read rank binding '{rank_binding_file}': {e}"
             ) from e
-        if mpi_world <= 0 or dp_size % mpi_world != 0:
-            raise RuntimeError(
-                f"data_parallel_size ({dp_size}) must be divisible by number "
-                f"of device MPI ranks ({mpi_world})"
-            )
-        # Only the first DP rank in each MPI segment owns a TT device process.
-        # The other DP ranks stay local and participate as non-device ranks.
-        dp_size_per_mpi_rank = dp_size // mpi_world
-        device_dp_ranks = {i * dp_size_per_mpi_rank for i in range(mpi_world)}
-        non_device_dp_ranks = {i for i in range(dp_size) if i not in device_dp_ranks}
+        if mpi_world <= 0:
+            raise RuntimeError("rank_binding must contain at least one MPI rank")
+
+        _resolve_remote_dp_rank(vllm_config, mpi_world)
+        non_device_dp_ranks = set()
+
     return rank_binding_file, non_device_dp_ranks
 
 
@@ -367,11 +376,13 @@ def main() -> None:
     if not has_mpi:
         raise RuntimeError("TT engine core must be launched under MPI")
 
+    validate_no_tt_gathered_dp_override(vllm_config)
+
     pc = vllm_config.parallel_config
-    assert pc.data_parallel_size % mpi_world == 0
-    segment = pc.data_parallel_size // mpi_world
-    pc.data_parallel_rank = mpi_rank * segment
+    _resolve_remote_dp_rank(vllm_config, mpi_world)
+    pc.data_parallel_rank = mpi_rank
     pc.data_parallel_rank_local = 0
+
     assert pc.distributed_executor_backend == "uni", (
         "TT MPI must be used with uniproc executor backend"
     )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
@@ -23,6 +23,7 @@ from vllm.v1.executor.abstract import UniProcExecutor
 from vllm_tt_plugin.config import get_tt_config
 
 logger = init_logger(__name__)
+_TT_VISIBLE_DEVICES_ENV = "TT_VISIBLE_DEVICES"
 
 
 class TTLaunchPlan(EngineLaunchPlan):
@@ -193,6 +194,105 @@ def _resolve_remote_dp_rank(vllm_config: VllmConfig, mpi_world: int) -> None:
         )
 
 
+def _requires_tt_mpi_rank_binding(vllm_config: VllmConfig) -> bool:
+    tt_config = get_tt_config(vllm_config)
+    parallel_config = vllm_config.parallel_config
+    return bool(
+        tt_config.get("mpi_args")
+        or getattr(parallel_config, "nnodes", 1) > 1
+        or getattr(parallel_config, "node_rank", 0) > 0
+    )
+
+
+def _parse_rank_binding_visible_devices(raw_value: object, rank: int) -> set[int]:
+    if not isinstance(raw_value, str):
+        raise RuntimeError(
+            f"rank_binding rank {rank} must set env_overrides."
+            f"{_TT_VISIBLE_DEVICES_ENV} to a non-empty string"
+        )
+
+    device_tokens = [token.strip() for token in raw_value.split(",") if token.strip()]
+    if not device_tokens:
+        raise RuntimeError(
+            f"rank_binding rank {rank} must set env_overrides."
+            f"{_TT_VISIBLE_DEVICES_ENV} to a non-empty device list"
+        )
+
+    device_ids: set[int] = set()
+    for token in device_tokens:
+        try:
+            device_id = int(token)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"rank_binding rank {rank} contains non-integer "
+                f"{_TT_VISIBLE_DEVICES_ENV} entry {token!r}"
+            ) from exc
+        if device_id in device_ids:
+            raise RuntimeError(
+                f"rank_binding rank {rank} assigns duplicate "
+                f"{_TT_VISIBLE_DEVICES_ENV} device {device_id}"
+            )
+        device_ids.add(device_id)
+
+    return device_ids
+
+
+def _validate_rank_bindings(rank_bindings: object) -> int:
+    if not isinstance(rank_bindings, list):
+        raise RuntimeError("rank_binding field 'rank_bindings' must be a list")
+
+    if not rank_bindings:
+        raise RuntimeError("rank_binding must contain at least one MPI rank")
+
+    seen_ranks: set[int] = set()
+    device_owners: dict[int, int] = {}
+    for entry in rank_bindings:
+        if not isinstance(entry, dict):
+            raise RuntimeError("rank_binding entries must be mappings")
+
+        rank = entry.get("rank")
+        if not isinstance(rank, int):
+            raise RuntimeError("rank_binding entries must define an integer rank")
+        if rank in seen_ranks:
+            raise RuntimeError(f"rank_binding contains duplicate rank {rank}")
+        seen_ranks.add(rank)
+
+        env_overrides = entry.get("env_overrides")
+        if not isinstance(env_overrides, dict):
+            raise RuntimeError(
+                f"rank_binding rank {rank} must define env_overrides with "
+                f"{_TT_VISIBLE_DEVICES_ENV}"
+            )
+
+        device_ids = _parse_rank_binding_visible_devices(
+            env_overrides.get(_TT_VISIBLE_DEVICES_ENV),
+            rank,
+        )
+        overlapping_devices = sorted(
+            device_id for device_id in device_ids if device_id in device_owners
+        )
+        if overlapping_devices:
+            owners = ", ".join(
+                f"{device_id} (already owned by rank {device_owners[device_id]})"
+                for device_id in overlapping_devices
+            )
+            raise RuntimeError(
+                f"rank_binding rank {rank} overlaps {_TT_VISIBLE_DEVICES_ENV} "
+                f"assignments: {owners}"
+            )
+        for device_id in device_ids:
+            device_owners[device_id] = rank
+
+    expected_ranks = set(range(len(rank_bindings)))
+    if seen_ranks != expected_ranks:
+        raise RuntimeError(
+            "rank_binding ranks must form a contiguous 0..N-1 range; "
+            f"got {sorted(seen_ranks)}"
+        )
+
+    return len(rank_bindings)
+
+
 def parse_tt_mpi_params(vllm_config: VllmConfig) -> tuple[str | None, set[int]]:
     parallel_config = vllm_config.parallel_config
     assert parallel_config.data_parallel_backend != "ray", (
@@ -201,23 +301,27 @@ def parse_tt_mpi_params(vllm_config: VllmConfig) -> tuple[str | None, set[int]]:
 
     tt_config = get_tt_config(vllm_config)
     rank_binding_file = tt_config.get("rank_binding")
+    if not rank_binding_file and _requires_tt_mpi_rank_binding(vllm_config):
+        raise RuntimeError(
+            "TT explicit MPI launch requires tt.rank_binding when mpi_args, "
+            "nnodes > 1, or node_rank > 0 are set"
+        )
+
     non_device_dp_ranks: set[int] = set()
     if rank_binding_file:
-        if not isinstance(rank_binding_file, str):
+        if not isinstance(rank_binding_file, str) or not rank_binding_file.strip():
             raise RuntimeError(
                 "TT plugin config key 'rank_binding' must be a non-empty string"
             )
         try:
             with open(rank_binding_file) as f:
-                rb = yaml.safe_load(f)
+                rb = yaml.safe_load(f) or {}
             rank_bindings = rb.get("rank_bindings", [])
-            mpi_world = len(rank_bindings)
+            mpi_world = _validate_rank_bindings(rank_bindings)
         except Exception as e:
             raise RuntimeError(
                 f"Failed to read rank binding '{rank_binding_file}': {e}"
             ) from e
-        if mpi_world <= 0:
-            raise RuntimeError("rank_binding must contain at least one MPI rank")
 
         _resolve_remote_dp_rank(vllm_config, mpi_world)
         non_device_dp_ranks = set()

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -211,10 +211,9 @@ class TTModelRunner:
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
 
-        # Sampler for sampling on host when device sampling is not supported.
-        # Only used by device ranks (local dp rank 0).
-        if self.parallel_config.data_parallel_rank_local == 0:
-            self.host_sampler = Sampler()
+        # Every standard-DP rank owns its own mesh and therefore its own host
+        # sampler state. Single-process modes also instantiate exactly one.
+        self.host_sampler = Sampler()
 
         # Host-side logits processors (min_p, logit_bias, min_tokens, plus any
         # custom logits processors). Used by the host sampler when device
@@ -381,10 +380,6 @@ class TTModelRunner:
                     "in some group's layer_names."
                 )
             self._layer_to_group_idx = mapping  # type: ignore[assignment]
-
-        # Only DP rank 0 allocates KV cache.
-        if self.parallel_config.data_parallel_rank_local != 0:
-            return
 
         self.kv_caches = self._allocate_kv_caches(kv_cache_config)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -359,9 +359,10 @@ class TTModelRunner:
         # can expand ``block_tables_per_group`` into ``block_tables_per_layer``
         # without re-deriving vLLM's group construction order. Non-hybrid
         # configurations (single group) skip the expansion entirely. The
-        # check is on ``len(kv_cache_groups)`` rather than the model class
-        # so it works on every DP rank — only ``data_parallel_rank_local
-        # == 0`` actually loads ``self.model``.
+        # check is on ``len(kv_cache_groups)`` rather than the model class so
+        # it works on every DP rank, including standard-DP subprocesses whose
+        # local parallel config is collapsed to DP=1 by upstream before the TT
+        # worker loads the model.
         self._layer_to_group_idx: list[int] | None = None
         if len(kv_cache_groups) > 1:
             num_layers = self.model_config.get_num_layers_by_block_type(

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -501,9 +501,6 @@ class TTPlatform(Platform):
             parallel_config.worker_cls = "vllm_tt_plugin.worker.TTWorker"
         parallel_config.engine_core_cls = "vllm.v1.engine.core.EngineCore"
         parallel_config.engine_core_proc_cls = "vllm.v1.engine.core.EngineCoreProc"
-        parallel_config.dp_engine_core_proc_cls = (
-            "vllm_tt_plugin.engine.TTDPEngineCoreProc"
-        )
         parallel_config.engine_core_launcher_cls = (
             "vllm_tt_plugin.launcher.TTCoreEngineLauncher"
         )
@@ -615,7 +612,8 @@ class TTPlatform(Platform):
         # validation/routing below so the lane path is selected.
         _convert_galaxy_gather_dp_to_lanes(vllm_config)
 
-        if uses_tt_lane_coordinator(vllm_config):
+        is_lane_mode = uses_tt_lane_coordinator(vllm_config)
+        if is_lane_mode:
             # Fail fast on misconfiguration: lane mode requires max_num_seqs to
             # split evenly across the internal TT lanes.
             validate_tt_lane_config(vllm_config)
@@ -626,6 +624,17 @@ class TTPlatform(Platform):
             )
         else:
             vllm_config.scheduler_config.scheduler_cls = TT_SCHEDULER_CLS
+
+        # region DP config
+        if is_lane_mode:
+            parallel_config.dp_engine_core_proc_cls = (
+                "vllm_tt_plugin.engine.TTDPEngineCoreProc"
+            )
+        else:
+            parallel_config.dp_engine_core_proc_cls = (
+                "vllm.v1.engine.core.DPEngineCoreProc"
+            )
+        # endregion
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -10,8 +10,6 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
-import ttnn
-from models.tt_transformers.tt.generator import create_submeshes
 
 from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum
@@ -34,6 +32,12 @@ else:
     FlexibleArgumentParser = object
 
 logger = init_logger(__name__)
+
+_STANDARD_DP_DISCOVERY_RECV_TIMEOUT_S = 60.0
+_STANDARD_DP_DISCOVERY_JOIN_TIMEOUT_S = 5.0
+_STANDARD_DP_MESH_GRIDS_KEY = "_tt_standard_dp_mesh_grids"
+
+StandardDPAssignmentT = tuple[str, tuple[int, int]]
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"
@@ -103,6 +107,7 @@ def _parse_mesh_grid(
         if isinstance(parsed_value, (tuple, list)) and len(parsed_value) == 2:
             return tuple(int(dim) for dim in parsed_value)
         raise ValueError("Not a valid tuple")
+
     except (ValueError, SyntaxError, TypeError):
         mesh_grid = mesh_grid_dict.get(mesh_device_env)
         if mesh_grid is None:
@@ -130,10 +135,12 @@ def _resolve_parent_mesh_grid(
 
 
 def _maybe_reorder_standard_dp_visible_device_groups(
-    device_groups: list[str],
+    device_groups: list[StandardDPAssignmentT],
     mesh_grid: tuple[int, int],
     data_parallel_size: int,
-) -> list[str]:
+) -> list[StandardDPAssignmentT]:
+    import ttnn
+
     # ``MeshDevice.create_submeshes`` stamps submeshes in logical row-major
     # order. On WH Galaxy DP=4, the known-good runtime mapping uses mesh-id
     # order 0,2,3,1 instead of row-major 0,1,2,3 for the four 1x8 submeshes.
@@ -147,20 +154,82 @@ def _maybe_reorder_standard_dp_visible_device_groups(
         logger.info(
             "Reordered TT single-host DP device groups for WH Galaxy DP=4 "
             "from row-major %s to mesh-id order %s",
-            device_groups,
-            reordered_groups,
+            [visible_devices for visible_devices, _shape in device_groups],
+            [visible_devices for visible_devices, _shape in reordered_groups],
         )
         return reordered_groups
 
     return device_groups
 
 
+def _store_standard_dp_mesh_grids(
+    vllm_config: "VllmConfig",
+    mesh_grids: dict[str, tuple[int, int]],
+) -> None:
+    additional_config = getattr(vllm_config, "additional_config", None)
+    if not isinstance(additional_config, dict):
+        additional_config = {}
+        vllm_config.additional_config = additional_config
+    additional_config[_STANDARD_DP_MESH_GRIDS_KEY] = {
+        visible_devices: [mesh_grid[0], mesh_grid[1]]
+        for visible_devices, mesh_grid in mesh_grids.items()
+    }
+
+
+def _load_standard_dp_mesh_grids(
+    vllm_config: "VllmConfig",
+) -> dict[str, tuple[int, int]]:
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    if not isinstance(additional_config, dict):
+        return {}
+
+    raw_mesh_grids = additional_config.get(_STANDARD_DP_MESH_GRIDS_KEY, {})
+    if not isinstance(raw_mesh_grids, dict):
+        return {}
+
+    mesh_grids: dict[str, tuple[int, int]] = {}
+    for visible_devices, mesh_grid in raw_mesh_grids.items():
+        if not isinstance(visible_devices, str):
+            continue
+        if not isinstance(mesh_grid, (list, tuple)) or len(mesh_grid) != 2:
+            continue
+        try:
+            mesh_grids[visible_devices] = (int(mesh_grid[0]), int(mesh_grid[1]))
+        except (TypeError, ValueError):
+            continue
+
+    return mesh_grids
+
+
+def _split_standard_dp_discovery_result(
+    discovery_result: list[str] | list[StandardDPAssignmentT] | None,
+) -> tuple[list[str] | None, dict[str, tuple[int, int]]]:
+    if discovery_result is None:
+        return None, {}
+    if not discovery_result:
+        return [], {}
+
+    first_entry = discovery_result[0]
+    if isinstance(first_entry, str):
+        return discovery_result, {}
+
+    assignments = discovery_result
+    return (
+        [visible_devices for visible_devices, _mesh_grid in assignments],
+        {visible_devices: mesh_grid for visible_devices, mesh_grid in assignments},
+    )
+
+
 def _discover_standard_dp_visible_device_groups(
     mesh_device_env: str | None,
     data_parallel_size: int,
-) -> list[str]:
+) -> list[StandardDPAssignmentT]:
+    import ttnn
+    from models.tt_transformers.tt.generator import create_submeshes
+
     mesh_device = None
     submeshes = []
+
     try:
         num_devices_available = ttnn.get_num_devices()
         mesh_grid = _resolve_parent_mesh_grid(mesh_device_env, num_devices_available)
@@ -177,7 +246,12 @@ def _discover_standard_dp_visible_device_groups(
             device_ids = list(submesh.get_device_ids())
             if not device_ids:
                 raise RuntimeError(f"TT DP rank {dp_rank} resolved to an empty submesh")
-            device_groups.append(",".join(str(device_id) for device_id in device_ids))
+            device_groups.append(
+                (
+                    ",".join(str(device_id) for device_id in device_ids),
+                    tuple(int(dim) for dim in submesh.shape),
+                )
+            )
 
         device_groups = _maybe_reorder_standard_dp_visible_device_groups(
             device_groups,
@@ -187,9 +261,14 @@ def _discover_standard_dp_visible_device_groups(
 
         logger.info(
             "Resolved TT single-host DP device groups: %s",
-            device_groups,
+            [
+                f"{visible_devices}@{mesh_shape}"
+                for visible_devices, mesh_shape in device_groups
+            ],
         )
+
         return device_groups
+
     finally:
         for submesh in submeshes:
             with suppress(Exception):
@@ -219,9 +298,27 @@ def _run_standard_dp_visible_device_group_discovery(
         conn.close()
 
 
+def _terminate_discovery_process(proc: multiprocessing.Process) -> None:
+    proc.terminate()
+    proc.join(timeout=_STANDARD_DP_DISCOVERY_JOIN_TIMEOUT_S)
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=_STANDARD_DP_DISCOVERY_JOIN_TIMEOUT_S)
+
+
+def _join_discovery_process_or_raise(
+    proc: multiprocessing.Process,
+    message: str,
+) -> None:
+    proc.join(timeout=_STANDARD_DP_DISCOVERY_JOIN_TIMEOUT_S)
+    if proc.is_alive():
+        _terminate_discovery_process(proc)
+        raise RuntimeError(message)
+
+
 def _resolve_standard_dp_visible_device_groups(
     vllm_config: "VllmConfig",
-) -> list[str] | None:
+) -> list[StandardDPAssignmentT] | None:
     parallel_config = vllm_config.parallel_config
     if parallel_config.data_parallel_size <= 1 or _uses_explicit_tt_mpi_launch(
         vllm_config
@@ -243,17 +340,34 @@ def _resolve_standard_dp_visible_device_groups(
     child_conn.close()
 
     try:
+        if not parent_conn.poll(_STANDARD_DP_DISCOVERY_RECV_TIMEOUT_S):
+            _terminate_discovery_process(proc)
+            raise RuntimeError(
+                "TT standard-DP device discovery subprocess timed out after "
+                f"{_STANDARD_DP_DISCOVERY_RECV_TIMEOUT_S:.1f}s waiting for "
+                "device groups"
+            )
         status, payload = parent_conn.recv()
+
     except EOFError as exc:
-        proc.join()
+        _join_discovery_process_or_raise(
+            proc,
+            "TT standard-DP device discovery subprocess did not exit cleanly "
+            "after closing its result pipe",
+        )
         raise RuntimeError(
             "TT standard-DP device discovery subprocess exited before returning "
             "device groups"
         ) from exc
+
     finally:
         parent_conn.close()
 
-    proc.join()
+    _join_discovery_process_or_raise(
+        proc,
+        "TT standard-DP device discovery subprocess did not exit after "
+        "returning device groups",
+    )
     if proc.exitcode not in (0, None):
         raise RuntimeError(
             "TT standard-DP device discovery subprocess failed with exit code "
@@ -261,6 +375,7 @@ def _resolve_standard_dp_visible_device_groups(
         )
     if status != "ok":
         raise RuntimeError(f"TT standard-DP device discovery failed: {payload}")
+
     return payload
 
 
@@ -601,6 +716,7 @@ class TTPlatform(Platform):
     device_type: str = "tt"
     device_control_env_var: str = "TT_VISIBLE_DEVICES"
     _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
+    _standard_dp_mesh_grids: ClassVar[dict[str, tuple[int, int]]] = {}
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
     # Disable torch.compile on TT platform - the triton version in tt-metal
     # is incompatible with torch's inductor backend.
@@ -653,6 +769,7 @@ class TTPlatform(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
         cls._standard_dp_visible_device_groups = None
+        cls._standard_dp_mesh_grids = {}
         if vllm_config.scheduler_config.enable_chunked_prefill:
             logger.info("Chunked prefill is not yet supported for TT backend")
             vllm_config.scheduler_config.enable_chunked_prefill = False
@@ -811,6 +928,16 @@ class TTPlatform(Platform):
         _convert_galaxy_gather_dp_to_lanes(vllm_config)
 
         is_lane_mode = uses_tt_lane_coordinator(vllm_config)
+        if (
+            getattr(model_config, "is_moe", False)
+            and parallel_config.data_parallel_size > 1
+            and not is_lane_mode
+        ):
+            raise ValueError(
+                "TT standard DP does not support MoE models yet. "
+                "Use data_parallel_size=1."
+            )
+
         if is_lane_mode:
             # Fail fast on misconfiguration: lane mode requires max_num_seqs to
             # split evenly across the internal TT lanes.
@@ -826,9 +953,15 @@ class TTPlatform(Platform):
         parallel_config.dp_engine_core_proc_cls = "vllm.v1.engine.core.DPEngineCoreProc"
 
         if not is_lane_mode:
-            cls._standard_dp_visible_device_groups = (
-                _resolve_standard_dp_visible_device_groups(vllm_config)
-            )
+            cls._standard_dp_mesh_grids = _load_standard_dp_mesh_grids(vllm_config)
+            discovery_result = _resolve_standard_dp_visible_device_groups(vllm_config)
+            (
+                cls._standard_dp_visible_device_groups,
+                resolved_mesh_grids,
+            ) = _split_standard_dp_discovery_result(discovery_result)
+            if resolved_mesh_grids:
+                cls._standard_dp_mesh_grids = resolved_mesh_grids
+                _store_standard_dp_mesh_grids(vllm_config, resolved_mesh_grids)
         if _uses_explicit_tt_mpi_launch(vllm_config):
             parallel_config.engine_core_launcher_cls = (
                 "vllm_tt_plugin.launcher.TTCoreEngineLauncher"

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -129,6 +129,32 @@ def _resolve_parent_mesh_grid(
     return mesh_grid
 
 
+def _maybe_reorder_standard_dp_visible_device_groups(
+    device_groups: list[str],
+    mesh_grid: tuple[int, int],
+    data_parallel_size: int,
+) -> list[str]:
+    # ``MeshDevice.create_submeshes`` stamps submeshes in logical row-major
+    # order. On WH Galaxy DP=4, the known-good runtime mapping uses mesh-id
+    # order 0,2,3,1 instead of row-major 0,1,2,3 for the four 1x8 submeshes.
+    if (
+        ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+        and mesh_grid == (4, 8)
+        and data_parallel_size == 4
+        and len(device_groups) == 4
+    ):
+        reordered_groups = [device_groups[index] for index in (0, 2, 3, 1)]
+        logger.info(
+            "Reordered TT single-host DP device groups for WH Galaxy DP=4 "
+            "from row-major %s to mesh-id order %s",
+            device_groups,
+            reordered_groups,
+        )
+        return reordered_groups
+
+    return device_groups
+
+
 def _discover_standard_dp_visible_device_groups(
     mesh_device_env: str | None,
     data_parallel_size: int,
@@ -152,6 +178,12 @@ def _discover_standard_dp_visible_device_groups(
             if not device_ids:
                 raise RuntimeError(f"TT DP rank {dp_rank} resolved to an empty submesh")
             device_groups.append(",".join(str(device_id) for device_id in device_ids))
+
+        device_groups = _maybe_reorder_standard_dp_visible_device_groups(
+            device_groups,
+            mesh_grid,
+            data_parallel_size,
+        )
 
         logger.info(
             "Resolved TT single-host DP device groups: %s",

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -15,7 +15,6 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     store_tt_lane_count,
     uses_tt_lane_coordinator,
-    validate_no_tt_gathered_dp_override,
     validate_tt_lane_config,
 )
 
@@ -498,7 +497,6 @@ class TTPlatform(Platform):
         # may be inspected (e.g. multimodal processor cache init) before this
         # `check_and_update_config()` hook is reached in that process.
         tt_config = get_tt_config(vllm_config)
-        validate_no_tt_gathered_dp_override(vllm_config)
         register_test_models = False
         if tt_config and "register_test_models" in tt_config:
             register_test_models = tt_config["register_test_models"]

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -420,6 +420,7 @@ class TTPlatform(Platform):
     _enum = PlatformEnum.OOT
     device_name: str = "tt"
     device_type: str = "tt"
+    device_control_env_var: str = "TT_VISIBLE_DEVICES"
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
     # Disable torch.compile on TT platform - the triton version in tt-metal
     # is incompatible with torch's inductor backend.

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -3,6 +3,7 @@
 
 import ast
 import json
+import multiprocessing
 import os
 import sys
 from contextlib import suppress
@@ -129,28 +130,20 @@ def _resolve_parent_mesh_grid(
 
 
 def _discover_standard_dp_visible_device_groups(
-    vllm_config: "VllmConfig",
-) -> list[str] | None:
-    parallel_config = vllm_config.parallel_config
-    if parallel_config.data_parallel_size <= 1 or _uses_explicit_tt_mpi_launch(
-        vllm_config
-    ):
-        return None
-
+    mesh_device_env: str | None,
+    data_parallel_size: int,
+) -> list[str]:
     mesh_device = None
     submeshes = []
     try:
         num_devices_available = ttnn.get_num_devices()
-        mesh_grid = _resolve_parent_mesh_grid(
-            os.environ.get("MESH_DEVICE"), num_devices_available
-        )
+        mesh_grid = _resolve_parent_mesh_grid(mesh_device_env, num_devices_available)
         mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(*mesh_grid))
-        submeshes = create_submeshes(mesh_device, parallel_config.data_parallel_size)
-        if len(submeshes) != parallel_config.data_parallel_size:
+        submeshes = create_submeshes(mesh_device, data_parallel_size)
+        if len(submeshes) != data_parallel_size:
             raise RuntimeError(
                 "TT create_submeshes returned "
-                f"{len(submeshes)} groups for data_parallel_size="
-                f"{parallel_config.data_parallel_size}"
+                f"{len(submeshes)} groups for data_parallel_size={data_parallel_size}"
             )
 
         device_groups = []
@@ -172,6 +165,71 @@ def _discover_standard_dp_visible_device_groups(
         if mesh_device is not None:
             with suppress(Exception):
                 ttnn.close_mesh_device(mesh_device)
+
+
+def _run_standard_dp_visible_device_group_discovery(
+    conn,
+    mesh_device_env: str | None,
+    data_parallel_size: int,
+) -> None:
+    try:
+        conn.send(
+            (
+                "ok",
+                _discover_standard_dp_visible_device_groups(
+                    mesh_device_env, data_parallel_size
+                ),
+            )
+        )
+    except Exception as exc:
+        conn.send(("error", f"{type(exc).__name__}: {exc}"))
+    finally:
+        conn.close()
+
+
+def _resolve_standard_dp_visible_device_groups(
+    vllm_config: "VllmConfig",
+) -> list[str] | None:
+    parallel_config = vllm_config.parallel_config
+    if parallel_config.data_parallel_size <= 1 or _uses_explicit_tt_mpi_launch(
+        vllm_config
+    ):
+        return None
+
+    mp_ctx = multiprocessing.get_context("spawn")
+    parent_conn, child_conn = mp_ctx.Pipe(duplex=False)
+    proc = mp_ctx.Process(
+        target=_run_standard_dp_visible_device_group_discovery,
+        args=(
+            child_conn,
+            os.environ.get("MESH_DEVICE"),
+            parallel_config.data_parallel_size,
+        ),
+        name="TTVisibleDevicesDiscovery",
+    )
+    proc.start()
+    child_conn.close()
+
+    try:
+        status, payload = parent_conn.recv()
+    except EOFError as exc:
+        proc.join()
+        raise RuntimeError(
+            "TT standard-DP device discovery subprocess exited before returning "
+            "device groups"
+        ) from exc
+    finally:
+        parent_conn.close()
+
+    proc.join()
+    if proc.exitcode not in (0, None):
+        raise RuntimeError(
+            "TT standard-DP device discovery subprocess failed with exit code "
+            f"{proc.exitcode}"
+        )
+    if status != "ok":
+        raise RuntimeError(f"TT standard-DP device discovery failed: {payload}")
+    return payload
 
 
 def _collapse_parallel_config_to_single_process(parallel_config) -> None:
@@ -737,7 +795,7 @@ class TTPlatform(Platform):
 
         if not is_lane_mode:
             cls._standard_dp_visible_device_groups = (
-                _discover_standard_dp_visible_device_groups(vllm_config)
+                _resolve_standard_dp_visible_device_groups(vllm_config)
             )
         if _uses_explicit_tt_mpi_launch(vllm_config):
             parallel_config.engine_core_launcher_cls = (

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -79,16 +79,14 @@ def _collapse_parallel_config_to_single_process(parallel_config) -> None:
     multiply it (no external launcher), so ``world_size_across_dp`` collapses to
     1 automatically once ``data_parallel_size`` is reset.
 
-    ``data_parallel_rank_local`` must be ``0`` here. The TT plugin gates device
-    bring-up on ``data_parallel_rank_local == 0``: that rank opens the mesh,
-    loads the model, and allocates the KV cache (see
-    ``worker.init_device``/``load_model`` and
-    ``TTModelRunner.initialize_kv_cache``). A single-process lane run owns the
-    one device mesh, so it is that device rank and must be ``0`` for those gates
-    to fire and bring the device up. ``0`` is also the value a genuine
-    single-process run resolves to (``ParallelConfig.__post_init__`` defaults
-    ``data_parallel_rank_local`` from ``VLLM_DP_RANK_LOCAL`` / ``VLLM_DP_RANK``,
-    both ``0``).
+    ``data_parallel_rank_local`` must be ``0`` here because a single-process
+    lane run owns one device mesh. Standard DP ownership is handled separately:
+    upstream rewrites each dense DP subprocess to a local DP=1 view while
+    preserving its shard identity, and the TT worker uses that preserved shard
+    index to decide that every standard-DP rank owns its own mesh/model/KV.
+    ``0`` is also the value a genuine single-process run resolves to
+    (``ParallelConfig.__post_init__`` defaults ``data_parallel_rank_local``
+    from ``VLLM_DP_RANK_LOCAL`` / ``VLLM_DP_RANK``, both ``0``).
     """
     parallel_config.data_parallel_size = 1
     parallel_config.data_parallel_size_local = 1

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
 import json
 import os
 import sys
+from contextlib import suppress
 from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
+import ttnn
+from models.tt_transformers.tt.generator import create_submeshes
 
 from vllm.logger import init_logger
 from vllm.platforms.interface import Platform, PlatformEnum
@@ -53,6 +57,121 @@ def _galaxy_generator_version() -> str | None:
         if os.getenv(env_var) == version:
             return version
     return None
+
+
+def _uses_explicit_tt_mpi_launch(vllm_config: "VllmConfig") -> bool:
+    tt_config = get_tt_config(vllm_config)
+    parallel_config = vllm_config.parallel_config
+    return bool(
+        tt_config.get("rank_binding")
+        or tt_config.get("mpi_args")
+        or getattr(parallel_config, "nnodes", 1) > 1
+        or getattr(parallel_config, "node_rank", 0) > 0
+    )
+
+
+_MESH_GRID_PRESETS = {
+    "N150": (1, 1),
+    "P100": (1, 1),
+    "P150": (1, 1),
+    "P150x2": (1, 2),
+    "N300": (1, 2),
+    "P300": (1, 2),
+    "N150x4": (1, 4),
+    "P150x4": (1, 4),
+    "T3K": (1, 8),
+    "P150x8": (1, 8),
+    "P300x2": (1, 4),
+}
+
+
+def _parse_mesh_grid(
+    mesh_device_env: str | None,
+    num_devices_available: int,
+    *,
+    tg_mesh_grid: tuple[int, int],
+) -> tuple[int, int]:
+    mesh_grid_dict = dict(_MESH_GRID_PRESETS)
+    mesh_grid_dict["TG"] = tg_mesh_grid
+
+    if mesh_device_env is None:
+        return (1, num_devices_available)
+
+    try:
+        parsed_value = ast.literal_eval(mesh_device_env)
+        if isinstance(parsed_value, (tuple, list)) and len(parsed_value) == 2:
+            return tuple(int(dim) for dim in parsed_value)
+        raise ValueError("Not a valid tuple")
+    except (ValueError, SyntaxError, TypeError):
+        mesh_grid = mesh_grid_dict.get(mesh_device_env)
+        if mesh_grid is None:
+            raise ValueError(
+                f"Invalid MESH_DEVICE: {mesh_device_env}. "
+                f"Expected one of: {list(mesh_grid_dict.keys())}"
+            ) from None
+        return mesh_grid
+
+
+def _resolve_parent_mesh_grid(
+    mesh_device_env: str | None,
+    num_devices_available: int,
+) -> tuple[int, int]:
+    mesh_grid = _parse_mesh_grid(
+        mesh_device_env,
+        num_devices_available,
+        tg_mesh_grid=(4, 8),
+    )
+
+    if mesh_grid[0] * mesh_grid[1] != num_devices_available:
+        mesh_grid = (1, num_devices_available)
+
+    return mesh_grid
+
+
+def _discover_standard_dp_visible_device_groups(
+    vllm_config: "VllmConfig",
+) -> list[str] | None:
+    parallel_config = vllm_config.parallel_config
+    if parallel_config.data_parallel_size <= 1 or _uses_explicit_tt_mpi_launch(
+        vllm_config
+    ):
+        return None
+
+    mesh_device = None
+    submeshes = []
+    try:
+        num_devices_available = ttnn.get_num_devices()
+        mesh_grid = _resolve_parent_mesh_grid(
+            os.environ.get("MESH_DEVICE"), num_devices_available
+        )
+        mesh_device = ttnn.open_mesh_device(ttnn.MeshShape(*mesh_grid))
+        submeshes = create_submeshes(mesh_device, parallel_config.data_parallel_size)
+        if len(submeshes) != parallel_config.data_parallel_size:
+            raise RuntimeError(
+                "TT create_submeshes returned "
+                f"{len(submeshes)} groups for data_parallel_size="
+                f"{parallel_config.data_parallel_size}"
+            )
+
+        device_groups = []
+        for dp_rank, submesh in enumerate(submeshes):
+            device_ids = list(submesh.get_device_ids())
+            if not device_ids:
+                raise RuntimeError(f"TT DP rank {dp_rank} resolved to an empty submesh")
+            device_groups.append(",".join(str(device_id) for device_id in device_ids))
+
+        logger.info(
+            "Resolved TT single-host DP device groups: %s",
+            device_groups,
+        )
+        return device_groups
+    finally:
+        for submesh in submeshes:
+            with suppress(Exception):
+                ttnn.close_mesh_device(submesh)
+        if mesh_device is not None:
+            with suppress(Exception):
+                ttnn.close_mesh_device(mesh_device)
 
 
 def _collapse_parallel_config_to_single_process(parallel_config) -> None:
@@ -391,10 +510,18 @@ class TTPlatform(Platform):
     device_name: str = "tt"
     device_type: str = "tt"
     device_control_env_var: str = "TT_VISIBLE_DEVICES"
+    _standard_dp_visible_device_groups: ClassVar[list[str] | None] = None
     sample_on_device_mode: ClassVar[Literal["all", "decode_only"] | None] = None
     # Disable torch.compile on TT platform - the triton version in tt-metal
     # is incompatible with torch's inductor backend.
     simple_compile_backend: str = "eager"
+
+    @classmethod
+    def device_id_to_physical_device_id(cls, device_id: int):
+        groups = cls._standard_dp_visible_device_groups
+        if groups is not None:
+            return groups[device_id]
+        return super().device_id_to_physical_device_id(device_id)
 
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:
@@ -435,6 +562,7 @@ class TTPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
+        cls._standard_dp_visible_device_groups = None
         if vllm_config.scheduler_config.enable_chunked_prefill:
             logger.info("Chunked prefill is not yet supported for TT backend")
             vllm_config.scheduler_config.enable_chunked_prefill = False
@@ -482,7 +610,7 @@ class TTPlatform(Platform):
         parallel_config.engine_core_cls = "vllm.v1.engine.core.EngineCore"
         parallel_config.engine_core_proc_cls = "vllm.v1.engine.core.EngineCoreProc"
         parallel_config.engine_core_launcher_cls = (
-            "vllm_tt_plugin.launcher.TTCoreEngineLauncher"
+            "vllm.v1.engine.utils.CoreEngineLauncher"
         )
 
         # For TT models, prepend "TT" to the architecture name,
@@ -606,6 +734,15 @@ class TTPlatform(Platform):
             vllm_config.scheduler_config.scheduler_cls = TT_SCHEDULER_CLS
 
         parallel_config.dp_engine_core_proc_cls = "vllm.v1.engine.core.DPEngineCoreProc"
+
+        if not is_lane_mode:
+            cls._standard_dp_visible_device_groups = (
+                _discover_standard_dp_visible_device_groups(vllm_config)
+            )
+        if _uses_explicit_tt_mpi_launch(vllm_config):
+            parallel_config.engine_core_launcher_cls = (
+                "vllm_tt_plugin.launcher.TTCoreEngineLauncher"
+            )
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -15,6 +15,7 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     store_tt_lane_count,
     uses_tt_lane_coordinator,
+    validate_no_tt_gathered_dp_override,
     validate_tt_lane_config,
 )
 
@@ -496,6 +497,7 @@ class TTPlatform(Platform):
         # may be inspected (e.g. multimodal processor cache init) before this
         # `check_and_update_config()` hook is reached in that process.
         tt_config = get_tt_config(vllm_config)
+        validate_no_tt_gathered_dp_override(vllm_config)
         register_test_models = False
         if tt_config and "register_test_models" in tt_config:
             register_test_models = tt_config["register_test_models"]
@@ -633,16 +635,7 @@ class TTPlatform(Platform):
         else:
             vllm_config.scheduler_config.scheduler_cls = TT_SCHEDULER_CLS
 
-        # region DP config
-        if is_lane_mode:
-            parallel_config.dp_engine_core_proc_cls = (
-                "vllm_tt_plugin.engine.TTDPEngineCoreProc"
-            )
-        else:
-            parallel_config.dp_engine_core_proc_cls = (
-                "vllm.v1.engine.core.DPEngineCoreProc"
-            )
-        # endregion
+        parallel_config.dp_engine_core_proc_cls = "vllm.v1.engine.core.DPEngineCoreProc"
 
         if vllm_config.cache_config.enable_prefix_caching:
             # Check prefix caching support from capabilities (default to False)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -102,10 +102,13 @@ def _resolve_mesh_grid(
                 mesh_grid = parsed_value
             else:
                 raise ValueError("Not a valid tuple")
-        except (ValueError, SyntaxError):
-            assert mesh_device_env in mesh_grid_dict, (
-                f"Invalid MESH_DEVICE: {mesh_device_env}"
-            )
+        except (ValueError, SyntaxError) as err:
+            if mesh_device_env not in mesh_grid_dict:
+                raise ValueError(
+                    f"Invalid MESH_DEVICE: {mesh_device_env}. "
+                    f"Expected one of: {list(mesh_grid_dict.keys())}"
+                ) from err
+
             mesh_grid = mesh_grid_dict[mesh_device_env]
     else:
         mesh_grid = (1, num_devices_available)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -159,6 +159,15 @@ class TTWorker(WorkerBase):
             )
 
         local_dp_rank = self.parallel_config.data_parallel_rank_local
+        logger.info(
+            "TT worker standard-DP binding: data_parallel_index=%s "
+            "data_parallel_rank_local=%s %s=%s MESH_DEVICE=%s",
+            getattr(self.parallel_config, "data_parallel_index", None),
+            local_dp_rank,
+            TTPlatform.device_control_env_var,
+            os.environ.get(TTPlatform.device_control_env_var),
+            os.environ.get("MESH_DEVICE"),
+        )
         self.mesh_device = open_mesh_device(
             get_tt_config(self.vllm_config), self.trace_mode, local_dp_rank
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -122,9 +122,16 @@ def _resolve_mesh_grid(
 
     # In standard local DP, upstream constrains each rank through
     # TT_VISIBLE_DEVICES. Prefer the visible-device count over the full-machine
-    # preset so each rank opens only its local shard.
-    if visible_devices_env and mesh_grid[0] * mesh_grid[1] != num_devices_available:
-        mesh_grid = (1, num_devices_available)
+    # preset so each rank opens only its local shard, even if
+    # ``ttnn.get_num_devices()`` reports the full machine size.
+    if visible_devices_env:
+        visible_count = len([d for d in visible_devices_env.split(",") if d.strip()])
+        if visible_count > 0 and mesh_grid[0] * mesh_grid[1] != visible_count:
+            mesh_grid = (1, visible_count)
+        elif (
+            visible_count == 0 and mesh_grid[0] * mesh_grid[1] != num_devices_available
+        ):
+            mesh_grid = (1, num_devices_available)
 
     return mesh_grid
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
 import math
 import os
 import time
@@ -48,6 +47,7 @@ from vllm_tt_plugin.model_input import TTModelInput
 from vllm_tt_plugin.model_runner import TTModelRunner
 from vllm_tt_plugin.platform import (
     TTPlatform,
+    _parse_mesh_grid,
     _should_pre_register_tt_test_models_from_cli,
     register_tt_models,
 )
@@ -88,37 +88,11 @@ def _resolve_mesh_grid(
     num_devices_available: int,
     visible_devices_env: str | None,
 ) -> tuple[int, int]:
-    mesh_grid_dict = {
-        "N150": (1, 1),
-        "P100": (1, 1),
-        "P150": (1, 1),
-        "P150x2": (1, 2),
-        "N300": (1, 2),
-        "P300": (1, 2),
-        "N150x4": (1, 4),
-        "P150x4": (1, 4),
-        "T3K": (1, 8),
-        "P150x8": (1, 8),
-        "P300x2": (1, 4),
-        "TG": (8, 4),
-    }
-    if mesh_device_env is not None:
-        try:
-            parsed_value = ast.literal_eval(mesh_device_env)
-            if isinstance(parsed_value, tuple) and len(parsed_value) == 2:
-                mesh_grid = parsed_value
-            else:
-                raise ValueError("Not a valid tuple")
-        except (ValueError, SyntaxError) as err:
-            if mesh_device_env not in mesh_grid_dict:
-                raise ValueError(
-                    f"Invalid MESH_DEVICE: {mesh_device_env}. "
-                    f"Expected one of: {list(mesh_grid_dict.keys())}"
-                ) from err
-
-            mesh_grid = mesh_grid_dict[mesh_device_env]
-    else:
-        mesh_grid = (1, num_devices_available)
+    mesh_grid = _parse_mesh_grid(
+        mesh_device_env,
+        num_devices_available,
+        tg_mesh_grid=(8, 4),
+    )
 
     # In standard local DP, upstream constrains each rank through
     # TT_VISIBLE_DEVICES. Prefer the visible-device count over the full-machine

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -99,6 +99,10 @@ def _resolve_mesh_grid(
     # preset so each rank opens only its local shard, even if
     # ``ttnn.get_num_devices()`` reports the full machine size.
     if visible_devices_env:
+        stored_mesh_grid = TTPlatform._standard_dp_mesh_grids.get(visible_devices_env)
+        if stored_mesh_grid is not None:
+            return stored_mesh_grid
+
         visible_count = len([d for d in visible_devices_env.split(",") if d.strip()])
         if visible_count > 0 and mesh_grid[0] * mesh_grid[1] != visible_count:
             mesh_grid = (1, visible_count)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -68,12 +68,19 @@ register_tt_models(register_test_models=_should_pre_register_tt_test_models_from
 def _rank_owns_mesh(parallel_config: Any) -> bool:
     """Return whether this worker process should own a TT mesh device.
 
-    Standard DP runs one independent TT mesh per rank, while single-process
-    modes only have the rank-0 worker.
+    Standard DP runs one independent TT mesh per rank. Upstream rewrites each
+    dense DP subprocess to look like a local DP=1 engine
+    (``data_parallel_size == 1``) while preserving the original shard identity
+    in ``data_parallel_index`` and ``data_parallel_rank_local``; treat those
+    collapsed ranks as mesh-owning too. True single-process modes still only
+    have the rank-0 worker.
     """
     local_dp_rank = getattr(parallel_config, "data_parallel_rank_local", None)
     data_parallel_size = getattr(parallel_config, "data_parallel_size", 1)
-    return data_parallel_size > 1 or local_dp_rank in (None, 0)
+    data_parallel_index = getattr(parallel_config, "data_parallel_index", 0)
+    return (
+        data_parallel_size > 1 or data_parallel_index > 0 or local_dp_rank in (None, 0)
+    )
 
 
 def _resolve_mesh_grid(
@@ -328,8 +335,10 @@ class TTWorker(WorkerBase):
         return 1 << 64
 
     def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
-        """Allocate TT KV cache (only DP rank 0) and initialize persistent
-        input batch (all DP ranks) with the specified kv_cache_config.
+        """Allocate TT KV cache and initialize persistent input batch.
+
+        Every standard-DP rank owns its own TT mesh/KV cache, while
+        single-process lane mode has only one rank.
         """
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
@@ -347,9 +356,8 @@ class TTWorker(WorkerBase):
         if not self.enable_model_warmup:
             logger.warning("Skipping model warmup")
             return CompilationTimes(language_model=0.0, encoder=0.0)
-        local_rank = self.parallel_config.data_parallel_rank_local
         elapsed = 0.0
-        if local_rank == 0:
+        if _rank_owns_mesh(self.parallel_config):
             start = time.perf_counter()
             self.model_runner.warmup_model()
             elapsed = time.perf_counter() - start

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -5,6 +5,7 @@ import ast
 import math
 import os
 import time
+import warnings
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -64,6 +65,60 @@ logger = init_logger(__name__)
 register_tt_models(register_test_models=_should_pre_register_tt_test_models_from_cli())
 
 
+def _rank_owns_mesh(parallel_config: Any) -> bool:
+    """Return whether this worker process should own a TT mesh device.
+
+    Standard DP runs one independent TT mesh per rank, while single-process
+    modes only have the rank-0 worker.
+    """
+    local_dp_rank = getattr(parallel_config, "data_parallel_rank_local", None)
+    data_parallel_size = getattr(parallel_config, "data_parallel_size", 1)
+    return data_parallel_size > 1 or local_dp_rank in (None, 0)
+
+
+def _resolve_mesh_grid(
+    mesh_device_env: str | None,
+    num_devices_available: int,
+    visible_devices_env: str | None,
+) -> tuple[int, int]:
+    mesh_grid_dict = {
+        "N150": (1, 1),
+        "P100": (1, 1),
+        "P150": (1, 1),
+        "P150x2": (1, 2),
+        "N300": (1, 2),
+        "P300": (1, 2),
+        "N150x4": (1, 4),
+        "P150x4": (1, 4),
+        "T3K": (1, 8),
+        "P150x8": (1, 8),
+        "P300x2": (1, 4),
+        "TG": (8, 4),
+    }
+    if mesh_device_env is not None:
+        try:
+            parsed_value = ast.literal_eval(mesh_device_env)
+            if isinstance(parsed_value, tuple) and len(parsed_value) == 2:
+                mesh_grid = parsed_value
+            else:
+                raise ValueError("Not a valid tuple")
+        except (ValueError, SyntaxError):
+            assert mesh_device_env in mesh_grid_dict, (
+                f"Invalid MESH_DEVICE: {mesh_device_env}"
+            )
+            mesh_grid = mesh_grid_dict[mesh_device_env]
+    else:
+        mesh_grid = (1, num_devices_available)
+
+    # In standard local DP, upstream constrains each rank through
+    # TT_VISIBLE_DEVICES. Prefer the visible-device count over the full-machine
+    # preset so each rank opens only its local shard.
+    if visible_devices_env and mesh_grid[0] * mesh_grid[1] != num_devices_available:
+        mesh_grid = (1, num_devices_available)
+
+    return mesh_grid
+
+
 class TTWorker(WorkerBase):
     def __init__(
         self,
@@ -106,20 +161,19 @@ class TTWorker(WorkerBase):
         # subprocess) before runner init.
         TTPlatform.check_and_update_config(self.vllm_config)
 
-        local_dp_rank = self.parallel_config.data_parallel_rank_local
-        # Open mesh only on local DP rank 0 (device ranks).
-        if local_dp_rank == 0:
-            self.mesh_device = open_mesh_device(
-                get_tt_config(self.vllm_config), self.trace_mode, local_dp_rank
+        if not _rank_owns_mesh(self.parallel_config):
+            raise RuntimeError(
+                "TT worker reached an unsupported non-device rank state under "
+                "the standard-DP-only runtime path"
             )
-            self.device_config.device = self.mesh_device
-            assert self.mesh_device is not None
-            self.num_devices = self.mesh_device.get_num_devices()
-        else:
-            mesh_grid = get_mesh_grid(local_dp_rank)
-            self.mesh_device = None
-            # Num devices is required for determining num blocks in KV cache.
-            self.num_devices = mesh_grid[0] * mesh_grid[1]
+
+        local_dp_rank = self.parallel_config.data_parallel_rank_local
+        self.mesh_device = open_mesh_device(
+            get_tt_config(self.vllm_config), self.trace_mode, local_dp_rank
+        )
+        self.device_config.device = self.mesh_device
+        assert self.mesh_device is not None
+        self.num_devices = self.mesh_device.get_num_devices()
         # Init ModelRunner here, so that we have access to self.mesh_device.
         self.model_runner: TTModelRunner = TTModelRunner(
             vllm_config=self.vllm_config,
@@ -130,9 +184,7 @@ class TTWorker(WorkerBase):
         )
 
     def load_model(self):
-        # Only local DP rank 0 (device rank) loads the model
-        if self.parallel_config.data_parallel_rank_local == 0:
-            self.model_runner.load_model()
+        self.model_runner.load_model()
 
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         return self.model_runner.get_supported_tasks()
@@ -598,14 +650,14 @@ def get_dispatch_core_config(tt_config):
 
 def get_fabric_config(tt_config, num_devices):
     if num_devices == 1:
-        # No fabric config for single device
-        fabric_config = None
-    else:
-        # Set the most common value as default
-        is_6u = ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
-        fabric_config = (
-            ttnn.FabricConfig.FABRIC_1D_RING if is_6u else ttnn.FabricConfig.FABRIC_1D
-        )
+        # Ignore any explicit fabric request for single-device meshes.
+        return None
+
+    # Set the most common value as default
+    is_6u = ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
+    fabric_config = (
+        ttnn.FabricConfig.FABRIC_1D_RING if is_6u else ttnn.FabricConfig.FABRIC_1D
+    )
 
     # Override fabric_config if specified in TT plugin config.
     if tt_config is not None and "fabric_config" in tt_config:
@@ -688,49 +740,24 @@ def device_params_from_tt_config(tt_config, trace_mode):
     return device_params
 
 
-def get_mesh_grid(local_dp_rank=0):
-    if local_dp_rank == 0:
-        # Only DP rank 0 should query devices.
-        num_devices_available = ttnn.get_num_devices()
-    mesh_grid_dict = {
-        "N150": (1, 1),
-        "P100": (1, 1),
-        "P150": (1, 1),
-        "P150x2": (1, 2),
-        "N300": (1, 2),
-        "P300": (1, 2),
-        "N150x4": (1, 4),
-        "P150x4": (1, 4),
-        "T3K": (1, 8),
-        "P150x8": (1, 8),
-        "P300x2": (1, 4),
-        "TG": (8, 4),
-    }
-    mesh_device_env = os.environ.get("MESH_DEVICE")
-    if mesh_device_env is not None:
-        try:
-            # Try to parse as a literal tuple first
-            parsed_value = ast.literal_eval(mesh_device_env)
-            if isinstance(parsed_value, tuple) and len(parsed_value) == 2:
-                mesh_grid = parsed_value
-            else:
-                raise ValueError("Not a valid tuple")
-        except (ValueError, SyntaxError):
-            # If parsing fails, treat as a string key for mesh_grid_dict
-            assert mesh_device_env in mesh_grid_dict, (
-                f"Invalid MESH_DEVICE: {mesh_device_env}"
-            )
-            mesh_grid = mesh_grid_dict[mesh_device_env]
-    else:
-        assert local_dp_rank == 0, (
-            "MESH_DEVICE must be set when running with data_parallel_size > 1"
+def get_mesh_grid(*args: Any, **kwargs: Any):
+    if args or kwargs.get("local_dp_rank") is not None:
+        warnings.warn(
+            "get_mesh_grid() ignores deprecated local_dp_rank; mesh selection "
+            "now derives from MESH_DEVICE and TT_VISIBLE_DEVICES",
+            UserWarning,
+            stacklevel=2,
         )
-        mesh_grid = (1, num_devices_available)
 
-    assert (
-        local_dp_rank != 0
-        or ttnn.using_distributed_env()
-        or (mesh_grid[0] * mesh_grid[1] <= num_devices_available)
+    num_devices_available = ttnn.get_num_devices()
+    mesh_grid = _resolve_mesh_grid(
+        os.environ.get("MESH_DEVICE"),
+        num_devices_available,
+        os.environ.get(TTPlatform.device_control_env_var),
+    )
+
+    assert ttnn.using_distributed_env() or (
+        mesh_grid[0] * mesh_grid[1] <= num_devices_available
     ), (
         f"Requested mesh grid shape {mesh_grid} is larger than "
         f"number of available devices {num_devices_available}"
@@ -740,8 +767,7 @@ def get_mesh_grid(local_dp_rank=0):
 
 
 def open_mesh_device(tt_config, trace_mode, local_dp_rank=0):
-    assert local_dp_rank == 0, "open_mesh_device must run on local DP rank 0"
-    mesh_grid = get_mesh_grid(local_dp_rank)
+    mesh_grid = get_mesh_grid()
     logger.info("Attempting to open mesh device with grid shape %s", mesh_grid)
 
     device_params = device_params_from_tt_config(tt_config, trace_mode)

--- a/plugins/vllm-tt-plugin/tests/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/test_config.py
@@ -11,8 +11,11 @@ def _vllm_config(
     data_parallel_size: int = 1,
     max_num_seqs: int = 8,
     lane_count: int | None = None,
+    tt_cfg: dict | None = None,
 ):
     additional_config: dict = {}
+    if tt_cfg is not None:
+        additional_config["tt"] = dict(tt_cfg)
     if lane_count is not None:
         additional_config[tt_config._RESOLVED_LANE_COUNT_KEY] = lane_count
 
@@ -47,6 +50,17 @@ def test_get_tt_max_batch_size_keeps_gathered_dp_contract():
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
     assert tt_config.get_tt_max_batch_size(config) == 32
+
+
+def test_validate_no_tt_gathered_dp_override_accepts_normal_configs():
+    tt_config.validate_no_tt_gathered_dp_override(_vllm_config(data_parallel_size=4))
+
+
+def test_validate_no_tt_gathered_dp_override_rejects_removed_override():
+    config = _vllm_config(tt_cfg={"tt_data_parallel_size": 4})
+
+    with pytest.raises(ValueError, match="no longer supported"):
+        tt_config.validate_no_tt_gathered_dp_override(config)
 
 
 def test_uses_tt_lane_coordinator_only_for_single_process_lanes():

--- a/plugins/vllm-tt-plugin/tests/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/test_config.py
@@ -52,21 +52,22 @@ def test_get_tt_data_parallel_size_is_one_for_standard_dp():
     assert tt_config.get_tt_data_parallel_size(config) == 1
 
 
+def test_legacy_tt_data_parallel_size_is_ignored_for_standard_dp():
+    config = _vllm_config(
+        data_parallel_size=4,
+        max_num_seqs=8,
+        tt_cfg={"tt_data_parallel_size": 99},
+    )
+
+    assert tt_config.get_tt_data_parallel_size(config) == 1
+    assert tt_config.get_tt_max_batch_size(config) == 8
+    assert not tt_config.uses_tt_lane_coordinator(config)
+
+
 def test_get_tt_max_batch_size_keeps_local_cap_for_standard_dp():
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
     assert tt_config.get_tt_max_batch_size(config) == 8
-
-
-def test_validate_no_tt_gathered_dp_override_accepts_normal_configs():
-    tt_config.validate_no_tt_gathered_dp_override(_vllm_config(data_parallel_size=4))
-
-
-def test_validate_no_tt_gathered_dp_override_rejects_removed_override():
-    config = _vllm_config(tt_cfg={"tt_data_parallel_size": 4})
-
-    with pytest.raises(ValueError, match="no longer supported"):
-        tt_config.validate_no_tt_gathered_dp_override(config)
 
 
 def test_uses_tt_lane_coordinator_only_for_single_process_lanes():

--- a/plugins/vllm-tt-plugin/tests/test_config.py
+++ b/plugins/vllm-tt-plugin/tests/test_config.py
@@ -46,10 +46,16 @@ def test_get_tt_max_batch_size_uses_global_cap_for_single_process_lanes():
     assert tt_config.get_tt_max_batch_size(config) == 32
 
 
-def test_get_tt_max_batch_size_keeps_gathered_dp_contract():
+def test_get_tt_data_parallel_size_is_one_for_standard_dp():
     config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
 
-    assert tt_config.get_tt_max_batch_size(config) == 32
+    assert tt_config.get_tt_data_parallel_size(config) == 1
+
+
+def test_get_tt_max_batch_size_keeps_local_cap_for_standard_dp():
+    config = _vllm_config(data_parallel_size=4, max_num_seqs=8)
+
+    assert tt_config.get_tt_max_batch_size(config) == 8
 
 
 def test_validate_no_tt_gathered_dp_override_accepts_normal_configs():

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unittests for the standard vLLM data parallelism."""
+
+import pathlib
+from types import SimpleNamespace
+
+import pytest
+from vllm_tt_plugin.launcher import parse_tt_mpi_params
+from vllm_tt_plugin.platform import TTPlatform
+
+
+class TestDPModes:
+    """Tests how successfully we set DP mode."""
+
+    @pytest.fixture
+    def vllm_config(self) -> SimpleNamespace:
+        """Fixture for a dummy vLLM config."""
+        return SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_size=1,
+                tensor_parallel_size=1,
+                pipeline_parallel_size=1,
+                worker_cls="auto",
+            ),
+            model_config=SimpleNamespace(
+                model="dummy",
+                hf_config=SimpleNamespace(architectures=["DummyModel"]),
+                max_logprobs=10,
+            ),
+            scheduler_config=SimpleNamespace(
+                enable_chunked_prefill=False,
+                async_scheduling=False,
+                scheduler_cls=None,
+                max_num_seqs=4,
+            ),
+            speculative_config=None,
+            lora_config=None,
+            cache_config=SimpleNamespace(enable_prefix_caching=False),
+        )
+
+    @pytest.fixture
+    def dummy_model_class(self) -> type:
+        """Fixture for a dummy model class."""
+        return type(
+            "DummyModel",
+            (),
+            {"__module__": "models.tt_transformers.tt.generator_vllm"},
+        )
+
+    @staticmethod
+    def register_dummy_model(
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        """Registers a dummy model class for testing."""
+        with monkeypatch.context() as m:
+            m.setattr("vllm_tt_plugin.platform.register_tt_models", lambda _: None)
+            m.setattr(
+                "vllm.model_executor.models.registry.ModelRegistry.get_supported_archs",
+                lambda: ["TTDummyModel"],
+            )
+            m.setattr(
+                "vllm.model_executor.model_loader.utils.get_model_architecture",
+                lambda _model_config: (dummy_model_class, None),
+            )
+
+            TTPlatform.check_and_update_config(vllm_config)
+
+    def test_upstream_dp_engine_core_is_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        """Default mode should route TT to upstream vLLM DP core proc."""
+        self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
+
+        assert (
+            vllm_config.parallel_config.engine_core_cls
+            == "vllm.v1.engine.core.EngineCore"
+        ), "Expected `EngineCore` to be the default engine core class for TT models."
+
+        assert (
+            vllm_config.parallel_config.engine_core_proc_cls
+            == "vllm.v1.engine.core.EngineCoreProc"
+        ), (
+            "Expected `EngineCoreProc` to be the default engine core proc class for "
+            "TT models."
+        )
+
+        assert (
+            vllm_config.parallel_config.dp_engine_core_proc_cls
+            == "vllm.v1.engine.core.DPEngineCoreProc"
+        ), (
+            "Expected `DPEngineCoreProc` to be the default DP engine core proc class "
+            "for TT models."
+        )
+
+    def test_lane_mode_dp_engine_core_is_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        """Setting TT lane count should route TT to the TT DP core proc."""
+        vllm_config.additional_config = {"_tt_resolved_lane_count": 2}
+        vllm_config.parallel_config.data_parallel_size = 1
+
+        self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
+
+        assert (
+            vllm_config.parallel_config.engine_core_cls
+            == "vllm.v1.engine.core.EngineCore"
+        ), "Expected `EngineCore` to be the default engine core class for TT models."
+
+        assert (
+            vllm_config.parallel_config.engine_core_proc_cls
+            == "vllm.v1.engine.core.EngineCoreProc"
+        ), (
+            "Expected `EngineCoreProc` to be the default engine core proc class for "
+            "TT models."
+        )
+
+        assert (
+            vllm_config.parallel_config.dp_engine_core_proc_cls
+            == "vllm_tt_plugin.engine.TTDPEngineCoreProc"
+        ), (
+            "Expected `TTDPEngineCoreProc` to be the default DP engine core proc class "
+            "for TT models."
+        )
+
+    def test_standard_dp_uses_all_device_ranks(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        """Standard DP should use one MPI rank per DP rank."""
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "0"\n'
+            "\n"
+            "  - rank: 1\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "3"\n'
+            "\n"
+            "  - rank: 2\n"
+            "    mesh_id: 2\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "1"\n'
+            "\n"
+            "  - rank: 3\n"
+            "    mesh_id: 3\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "2"\n'
+        )
+
+        vllm_config.additional_config = {"tt": {"rank_binding": str(rank_binding)}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        parsed_rank_binding, non_device_dp_ranks = parse_tt_mpi_params(vllm_config)
+
+        assert parsed_rank_binding == str(rank_binding), (
+            "Expected rank binding to be returned correctly."
+        )
+        assert non_device_dp_ranks == set(), (
+            "Expected no non-device DP ranks in standard DP mode."
+        )
+
+    def test_lane_dp_has_non_device_dp_ranks(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        """Lane DP should have non-device DP ranks."""
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "0, 1"\n'
+            "\n"
+            "  - rank: 1\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "2, 3"\n'
+        )
+
+        vllm_config.additional_config = {
+            "tt": {"rank_binding": str(rank_binding)},
+        }
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        parsed_rank_binding, non_device_dp_ranks = parse_tt_mpi_params(vllm_config)
+
+        assert parsed_rank_binding == str(rank_binding), (
+            "Expected rank binding to be returned correctly."
+        )
+        assert non_device_dp_ranks == {1, 3}, (
+            "Expected non-device DP ranks in lane DP mode."
+        )

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -11,6 +11,8 @@ from vllm_tt_plugin.launcher import parse_tt_mpi_params
 from vllm_tt_plugin.platform import TTPlatform
 from vllm_tt_plugin.worker import TTWorker, _rank_owns_mesh, _resolve_mesh_grid
 
+import vllm.v1.engine.utils as engine_utils
+
 
 class TestDPModes:
     """Tests how successfully we set DP mode."""
@@ -55,10 +57,15 @@ class TestDPModes:
         monkeypatch: pytest.MonkeyPatch,
         vllm_config: SimpleNamespace,
         dummy_model_class: type,
+        visible_device_groups: list[str] | None = None,
     ) -> None:
         """Registers a dummy model class for testing."""
         with monkeypatch.context() as m:
             m.setattr("vllm_tt_plugin.platform.register_tt_models", lambda _: None)
+            m.setattr(
+                "vllm_tt_plugin.platform._discover_standard_dp_visible_device_groups",
+                lambda _cfg: visible_device_groups,
+            )
             m.setattr(
                 "vllm.model_executor.models.registry.ModelRegistry.get_supported_archs",
                 lambda: ["TTDummyModel"],
@@ -180,6 +187,71 @@ class TestDPModes:
         assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)
         assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
         assert _resolve_mesh_grid("P150x8", 8, "3") == (1, 1)
+
+    def test_single_host_standard_dp_uses_upstream_launcher(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        self.register_dummy_model(
+            monkeypatch,
+            vllm_config,
+            dummy_model_class,
+            visible_device_groups=["24,25", "26,27", "3,2", "1,0"],
+        )
+
+        assert (
+            vllm_config.parallel_config.engine_core_launcher_cls
+            == "vllm.v1.engine.utils.CoreEngineLauncher"
+        )
+        assert TTPlatform._standard_dp_visible_device_groups == [
+            "24,25",
+            "26,27",
+            "3,2",
+            "1,0",
+        ]
+
+    def test_rank_binding_keeps_tt_launcher(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        vllm_config.parallel_config.data_parallel_size = 4
+        vllm_config.additional_config = {
+            "tt": {"rank_binding": "/tmp/rank_binding.yaml"}
+        }
+
+        self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
+
+        assert (
+            vllm_config.parallel_config.engine_core_launcher_cls
+            == "vllm_tt_plugin.launcher.TTCoreEngineLauncher"
+        )
+        assert TTPlatform._standard_dp_visible_device_groups is None
+
+    def test_standard_dp_visible_device_groups_feed_upstream_env_assignment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(engine_utils, "current_platform", TTPlatform)
+        monkeypatch.setattr(
+            TTPlatform,
+            "_standard_dp_visible_device_groups",
+            ["24,25,26,27,3,2,1,0", "16,17,18,19,20,21,22,23"],
+        )
+
+        assert (
+            engine_utils.get_device_indices(
+                TTPlatform.device_control_env_var,
+                local_dp_rank=1,
+                world_size=1,
+            )
+            == "16,17,18,19,20,21,22,23"
+        )
 
     def test_legacy_gathered_override_is_ignored_by_platform(
         self,

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 from vllm_tt_plugin.launcher import parse_tt_mpi_params
 from vllm_tt_plugin.platform import TTPlatform
-from vllm_tt_plugin.worker import _rank_owns_mesh, _resolve_mesh_grid
+from vllm_tt_plugin.worker import TTWorker, _rank_owns_mesh, _resolve_mesh_grid
 
 
 class TestDPModes:
@@ -141,6 +141,15 @@ class TestDPModes:
 
         assert _rank_owns_mesh(parallel_config)
 
+    def test_collapsed_standard_dp_rank_still_owns_mesh(self) -> None:
+        parallel_config = SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_rank_local=3,
+            data_parallel_index=3,
+        )
+
+        assert _rank_owns_mesh(parallel_config)
+
     def test_single_process_only_rank_zero_owns_mesh(self) -> None:
         assert _rank_owns_mesh(
             SimpleNamespace(data_parallel_size=1, data_parallel_rank_local=0)
@@ -148,6 +157,24 @@ class TestDPModes:
         assert not _rank_owns_mesh(
             SimpleNamespace(data_parallel_size=1, data_parallel_rank_local=1)
         )
+
+    def test_collapsed_standard_dp_rank_warms_up_model(self) -> None:
+        worker = TTWorker.__new__(TTWorker)
+        worker.enable_model_warmup = True
+        worker.parallel_config = SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_rank_local=7,
+            data_parallel_index=7,
+        )
+        warmup_calls: list[str] = []
+        worker.model_runner = SimpleNamespace(
+            warmup_model=lambda: warmup_calls.append("warmup")
+        )
+
+        timings = TTWorker.compile_or_warm_up_model(worker)
+
+        assert warmup_calls == ["warmup"]
+        assert timings.language_model >= 0.0
 
     def test_visible_devices_override_full_machine_mesh_preset(self) -> None:
         assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -12,6 +12,7 @@ from vllm_tt_plugin.launcher import parse_tt_mpi_params
 from vllm_tt_plugin.platform import (
     TTPlatform,
     _maybe_reorder_standard_dp_visible_device_groups,
+    _resolve_standard_dp_visible_device_groups,
 )
 from vllm_tt_plugin.worker import TTWorker, _rank_owns_mesh, _resolve_mesh_grid
 
@@ -192,6 +193,14 @@ class TestDPModes:
         assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
         assert _resolve_mesh_grid("P150x8", 8, "3") == (1, 1)
 
+    def test_visible_devices_use_discovered_submesh_shape(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(TTPlatform, "_standard_dp_mesh_grids", {"0,1,2,3": (2, 2)})
+
+        assert _resolve_mesh_grid("TG", 4, "0,1,2,3") == (2, 2)
+
     def test_single_host_standard_dp_uses_upstream_launcher(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -265,6 +274,134 @@ class TestDPModes:
         )
         assert TTPlatform._standard_dp_visible_device_groups is None
 
+    def test_standard_dp_discovery_timeout_terminates_subprocess(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        class FakeConn:
+            def poll(self, timeout: float) -> bool:
+                return False
+
+            def recv(self):
+                raise AssertionError("recv should not be called after timeout")
+
+            def close(self) -> None:
+                return
+
+        class FakeProc:
+            def __init__(self) -> None:
+                self.exitcode = None
+                self.join_timeouts: list[float | None] = []
+                self.terminated = False
+                self.killed = False
+
+            def start(self) -> None:
+                return
+
+            def join(self, timeout: float | None = None) -> None:
+                self.join_timeouts.append(timeout)
+
+            def is_alive(self) -> bool:
+                return self.terminated and not self.killed
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def kill(self) -> None:
+                self.killed = True
+
+        fake_parent_conn = FakeConn()
+        fake_child_conn = SimpleNamespace(close=lambda: None)
+        fake_proc = FakeProc()
+
+        class FakeContext:
+            def Pipe(self, duplex: bool = False):
+                assert not duplex
+                return fake_parent_conn, fake_child_conn
+
+            def Process(self, **_kwargs):
+                return fake_proc
+
+        monkeypatch.setattr(
+            tt_platform.multiprocessing, "get_context", lambda _mode: FakeContext()
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="timed out after",
+        ):
+            _resolve_standard_dp_visible_device_groups(vllm_config)
+
+        assert fake_proc.terminated
+        assert fake_proc.killed
+
+    def test_standard_dp_discovery_join_timeout_terminates_subprocess(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        class FakeConn:
+            def poll(self, timeout: float) -> bool:
+                return True
+
+            def recv(self):
+                return ("ok", ["0", "1", "2", "3"])
+
+            def close(self) -> None:
+                return
+
+        class FakeProc:
+            def __init__(self) -> None:
+                self.exitcode = None
+                self.join_timeouts: list[float | None] = []
+                self.terminated = False
+                self.killed = False
+
+            def start(self) -> None:
+                return
+
+            def join(self, timeout: float | None = None) -> None:
+                self.join_timeouts.append(timeout)
+
+            def is_alive(self) -> bool:
+                return self.terminated and not self.killed or not self.terminated
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            def kill(self) -> None:
+                self.killed = True
+
+        fake_parent_conn = FakeConn()
+        fake_child_conn = SimpleNamespace(close=lambda: None)
+        fake_proc = FakeProc()
+
+        class FakeContext:
+            def Pipe(self, duplex: bool = False):
+                assert not duplex
+                return fake_parent_conn, fake_child_conn
+
+            def Process(self, **_kwargs):
+                return fake_proc
+
+        monkeypatch.setattr(
+            tt_platform.multiprocessing, "get_context", lambda _mode: FakeContext()
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="did not exit after returning device groups",
+        ):
+            _resolve_standard_dp_visible_device_groups(vllm_config)
+
+        assert fake_proc.terminated
+        assert fake_proc.killed
+
     def test_standard_dp_visible_device_groups_feed_upstream_env_assignment(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -306,6 +443,36 @@ class TestDPModes:
             vllm_config.scheduler_config.scheduler_cls
             == "vllm_tt_plugin.scheduler.TTScheduler"
         )
+
+    def test_standard_dp_rejects_moe_models(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        vllm_config.parallel_config.data_parallel_size = 4
+        vllm_config.model_config.is_moe = True
+
+        with monkeypatch.context() as m:
+            m.setattr("vllm_tt_plugin.platform.register_tt_models", lambda _: None)
+            m.setattr(
+                "vllm_tt_plugin.platform._resolve_standard_dp_visible_device_groups",
+                lambda _cfg: None,
+            )
+            m.setattr(
+                "vllm.model_executor.models.registry.ModelRegistry.get_supported_archs",
+                lambda: ["TTDummyModel"],
+            )
+            m.setattr(
+                "vllm.model_executor.model_loader.utils.get_model_architecture",
+                lambda _model_config: (dummy_model_class, None),
+            )
+
+            with pytest.raises(
+                ValueError,
+                match="TT standard DP does not support MoE models yet",
+            ):
+                TTPlatform.check_and_update_config(vllm_config)
 
     def test_standard_dp_uses_all_device_ranks(
         self,
@@ -377,6 +544,119 @@ class TestDPModes:
         with pytest.raises(
             RuntimeError,
             match="Standard DP mode requires one TT MPI rank per DP rank",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_explicit_mpi_args_require_rank_binding(
+        self,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        vllm_config.additional_config = {"tt": {"mpi_args": "--host hostA"}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        with pytest.raises(
+            RuntimeError,
+            match="TT explicit MPI launch requires tt.rank_binding",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_multinode_requires_rank_binding(
+        self,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        vllm_config.additional_config = {"tt": {}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 4
+        vllm_config.parallel_config.nnodes = 2
+
+        with pytest.raises(
+            RuntimeError,
+            match="TT explicit MPI launch requires tt.rank_binding",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_rank_binding_requires_visible_devices(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            "      OTHER_ENV: foo\n"
+            "  - rank: 1\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "1"\n'
+        )
+
+        vllm_config.additional_config = {"tt": {"rank_binding": str(rank_binding)}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 2
+
+        with pytest.raises(
+            RuntimeError,
+            match="TT_VISIBLE_DEVICES",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_rank_binding_rejects_overlapping_visible_devices(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "0, 1"\n'
+            "  - rank: 1\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "1, 2"\n'
+        )
+
+        vllm_config.additional_config = {"tt": {"rank_binding": str(rank_binding)}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 2
+
+        with pytest.raises(
+            RuntimeError,
+            match="overlaps TT_VISIBLE_DEVICES assignments",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_rank_binding_rejects_duplicate_rank_ids(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "0"\n'
+            "  - rank: 0\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "1"\n'
+        )
+
+        vllm_config.additional_config = {"tt": {"rank_binding": str(rank_binding)}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 2
+
+        with pytest.raises(
+            RuntimeError,
+            match="duplicate rank 0",
         ):
             parse_tt_mpi_params(vllm_config)
 

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""Unittests for the standard vLLM data parallelism."""
+"""Unit tests for TT DP mode selection and TT MPI launch semantics."""
 
 import pathlib
 from types import SimpleNamespace
@@ -99,13 +99,13 @@ class TestDPModes:
             "for TT models."
         )
 
-    def test_lane_mode_dp_engine_core_is_set(
+    def test_lane_mode_keeps_upstream_dp_engine_core(
         self,
         monkeypatch: pytest.MonkeyPatch,
         vllm_config: SimpleNamespace,
         dummy_model_class: type,
     ) -> None:
-        """Setting TT lane count should route TT to the TT DP core proc."""
+        """Lane mode should not select the removed TT DP core proc."""
         vllm_config.additional_config = {"_tt_resolved_lane_count": 2}
         vllm_config.parallel_config.data_parallel_size = 1
 
@@ -126,11 +126,24 @@ class TestDPModes:
 
         assert (
             vllm_config.parallel_config.dp_engine_core_proc_cls
-            == "vllm_tt_plugin.engine.TTDPEngineCoreProc"
+            == "vllm.v1.engine.core.DPEngineCoreProc"
         ), (
-            "Expected `TTDPEngineCoreProc` to be the default DP engine core proc class "
-            "for TT models."
+            "Expected lane mode to leave `DPEngineCoreProc` on the upstream "
+            "default path."
         )
+
+    def test_removed_gathered_override_is_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vllm_config: SimpleNamespace,
+        dummy_model_class: type,
+    ) -> None:
+        """The removed TT gathered-DP override should fail fast."""
+        vllm_config.additional_config = {"tt": {"tt_data_parallel_size": 4}}
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        with pytest.raises(ValueError, match="no longer supported"):
+            self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
 
     def test_standard_dp_uses_all_device_ranks(
         self,
@@ -175,12 +188,12 @@ class TestDPModes:
             "Expected no non-device DP ranks in standard DP mode."
         )
 
-    def test_lane_dp_has_non_device_dp_ranks(
+    def test_standard_dp_rejects_mismatched_mpi_world(
         self,
         tmp_path: pathlib.Path,
         vllm_config: SimpleNamespace,
     ) -> None:
-        """Lane DP should have non-device DP ranks."""
+        """Standard DP must map one TT MPI rank to one DP rank."""
         rank_binding = tmp_path / "rank_binding.json"
         rank_binding.write_text(
             "rank_bindings:\n"
@@ -195,17 +208,54 @@ class TestDPModes:
             '      TT_VISIBLE_DEVICES: "2, 3"\n'
         )
 
+        vllm_config.additional_config = {"tt": {"rank_binding": str(rank_binding)}}
+        vllm_config.parallel_config.data_parallel_backend = "mp"
+        vllm_config.parallel_config.data_parallel_size = 4
+
+        with pytest.raises(
+            RuntimeError,
+            match="Standard DP mode requires one TT MPI rank per DP rank",
+        ):
+            parse_tt_mpi_params(vllm_config)
+
+    def test_removed_gathered_override_is_rejected_by_launcher(
+        self,
+        tmp_path: pathlib.Path,
+        vllm_config: SimpleNamespace,
+    ) -> None:
+        """Launcher should reject the removed TT gathered-DP override too."""
+        rank_binding = tmp_path / "rank_binding.json"
+        rank_binding.write_text(
+            "rank_bindings:\n"
+            "  - rank: 0\n"
+            "    mesh_id: 0\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "0"\n'
+            "\n"
+            "  - rank: 1\n"
+            "    mesh_id: 1\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "1"\n'
+            "\n"
+            "  - rank: 2\n"
+            "    mesh_id: 2\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "2"\n'
+            "\n"
+            "  - rank: 3\n"
+            "    mesh_id: 3\n"
+            "    env_overrides:\n"
+            '      TT_VISIBLE_DEVICES: "3"\n'
+        )
+
         vllm_config.additional_config = {
-            "tt": {"rank_binding": str(rank_binding)},
+            "tt": {
+                "rank_binding": str(rank_binding),
+                "tt_data_parallel_size": 4,
+            }
         }
         vllm_config.parallel_config.data_parallel_backend = "mp"
         vllm_config.parallel_config.data_parallel_size = 4
 
-        parsed_rank_binding, non_device_dp_ranks = parse_tt_mpi_params(vllm_config)
-
-        assert parsed_rank_binding == str(rank_binding), (
-            "Expected rank binding to be returned correctly."
-        )
-        assert non_device_dp_ranks == {1, 3}, (
-            "Expected non-device DP ranks in lane DP mode."
-        )
+        with pytest.raises(ValueError, match="no longer supported"):
+            parse_tt_mpi_params(vllm_config)

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -7,8 +7,12 @@ import pathlib
 from types import SimpleNamespace
 
 import pytest
+import vllm_tt_plugin.platform as tt_platform
 from vllm_tt_plugin.launcher import parse_tt_mpi_params
-from vllm_tt_plugin.platform import TTPlatform
+from vllm_tt_plugin.platform import (
+    TTPlatform,
+    _maybe_reorder_standard_dp_visible_device_groups,
+)
 from vllm_tt_plugin.worker import TTWorker, _rank_owns_mesh, _resolve_mesh_grid
 
 import vllm.v1.engine.utils as engine_utils
@@ -212,6 +216,34 @@ class TestDPModes:
             "26,27",
             "3,2",
             "1,0",
+        ]
+
+    def test_wh_galaxy_dp4_groups_follow_known_good_mesh_order(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            tt_platform.ttnn.cluster,
+            "get_cluster_type",
+            lambda: tt_platform.ttnn.cluster.ClusterType.GALAXY,
+        )
+
+        groups = [
+            "0,1,2,3,4,5,6,7",
+            "8,9,10,11,12,13,14,15",
+            "16,17,18,19,20,21,22,23",
+            "24,25,26,27,28,29,30,31",
+        ]
+
+        assert _maybe_reorder_standard_dp_visible_device_groups(
+            groups,
+            (4, 8),
+            4,
+        ) == [
+            "0,1,2,3,4,5,6,7",
+            "16,17,18,19,20,21,22,23",
+            "24,25,26,27,28,29,30,31",
+            "8,9,10,11,12,13,14,15",
         ]
 
     def test_rank_binding_keeps_tt_launcher(

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -179,6 +179,7 @@ class TestDPModes:
     def test_visible_devices_override_full_machine_mesh_preset(self) -> None:
         assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)
         assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
+        assert _resolve_mesh_grid("P150x8", 8, "3") == (1, 1)
 
     def test_legacy_gathered_override_is_ignored_by_platform(
         self,

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -63,7 +63,7 @@ class TestDPModes:
         with monkeypatch.context() as m:
             m.setattr("vllm_tt_plugin.platform.register_tt_models", lambda _: None)
             m.setattr(
-                "vllm_tt_plugin.platform._discover_standard_dp_visible_device_groups",
+                "vllm_tt_plugin.platform._resolve_standard_dp_visible_device_groups",
                 lambda _cfg: visible_device_groups,
             )
             m.setattr(

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from vllm_tt_plugin.launcher import parse_tt_mpi_params
 from vllm_tt_plugin.platform import TTPlatform
+from vllm_tt_plugin.worker import _rank_owns_mesh, _resolve_mesh_grid
 
 
 class TestDPModes:
@@ -131,6 +132,26 @@ class TestDPModes:
             "Expected lane mode to leave `DPEngineCoreProc` on the upstream "
             "default path."
         )
+
+    def test_standard_dp_all_ranks_own_mesh(self) -> None:
+        parallel_config = SimpleNamespace(
+            data_parallel_size=4,
+            data_parallel_rank_local=3,
+        )
+
+        assert _rank_owns_mesh(parallel_config)
+
+    def test_single_process_only_rank_zero_owns_mesh(self) -> None:
+        assert _rank_owns_mesh(
+            SimpleNamespace(data_parallel_size=1, data_parallel_rank_local=0)
+        )
+        assert not _rank_owns_mesh(
+            SimpleNamespace(data_parallel_size=1, data_parallel_rank_local=1)
+        )
+
+    def test_visible_devices_override_full_machine_mesh_preset(self) -> None:
+        assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)
+        assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
 
     def test_removed_gathered_override_is_rejected(
         self,

--- a/plugins/vllm-tt-plugin/tests/test_dp_modes.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_modes.py
@@ -153,18 +153,27 @@ class TestDPModes:
         assert _resolve_mesh_grid("TG", 1, "0") == (1, 1)
         assert _resolve_mesh_grid("TG", 8, "0,1,2,3,4,5,6,7") == (1, 8)
 
-    def test_removed_gathered_override_is_rejected(
+    def test_legacy_gathered_override_is_ignored_by_platform(
         self,
         monkeypatch: pytest.MonkeyPatch,
         vllm_config: SimpleNamespace,
         dummy_model_class: type,
     ) -> None:
-        """The removed TT gathered-DP override should fail fast."""
+        """Legacy TT gathered-DP config should not affect platform routing."""
         vllm_config.additional_config = {"tt": {"tt_data_parallel_size": 4}}
         vllm_config.parallel_config.data_parallel_size = 4
 
-        with pytest.raises(ValueError, match="no longer supported"):
-            self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
+        self.register_dummy_model(monkeypatch, vllm_config, dummy_model_class)
+
+        assert vllm_config.parallel_config.data_parallel_size == 4
+        assert (
+            vllm_config.parallel_config.dp_engine_core_proc_cls
+            == "vllm.v1.engine.core.DPEngineCoreProc"
+        )
+        assert (
+            vllm_config.scheduler_config.scheduler_cls
+            == "vllm_tt_plugin.scheduler.TTScheduler"
+        )
 
     def test_standard_dp_uses_all_device_ranks(
         self,
@@ -239,12 +248,12 @@ class TestDPModes:
         ):
             parse_tt_mpi_params(vllm_config)
 
-    def test_removed_gathered_override_is_rejected_by_launcher(
+    def test_legacy_gathered_override_is_ignored_by_launcher(
         self,
         tmp_path: pathlib.Path,
         vllm_config: SimpleNamespace,
     ) -> None:
-        """Launcher should reject the removed TT gathered-DP override too."""
+        """Launcher should ignore the legacy TT gathered-DP override."""
         rank_binding = tmp_path / "rank_binding.json"
         rank_binding.write_text(
             "rank_bindings:\n"
@@ -278,5 +287,7 @@ class TestDPModes:
         vllm_config.parallel_config.data_parallel_backend = "mp"
         vllm_config.parallel_config.data_parallel_size = 4
 
-        with pytest.raises(ValueError, match="no longer supported"):
-            parse_tt_mpi_params(vllm_config)
+        parsed_rank_binding, non_device_dp_ranks = parse_tt_mpi_params(vllm_config)
+
+        assert parsed_rank_binding == str(rank_binding)
+        assert non_device_dp_ranks == set()


### PR DESCRIPTION
## Purpose

Resolves #401 (and potentially supersedes #408 because it has multiple merge conflicts difficult to handle).

* For DP > 1, non-Galaxy models now follow upstream vLLM standard DP instead of the legacy TT gathered path.

* Galaxy-generator models still use single-process lane mode. We transparently convert `--data_parallel_size N` into `N` in-process TT lanes for *platform.py*.

* The legacy user config `tt_data_parallel_size` no longer drives parallelism. If present, it is ignored; effective TT lane count is derived internally.

* In standard DP, every rank owns its own mesh, loads the model, allocates KV cache, and owns its host sampler state;
see *worker.py*.

* Single-host standard DP no longer needs the TT MPI launcher just to assign chips. We now:

  - discover per-rank TT chip groups from the real TT submesh split
  - expose those groups through `TTPlatform.device_id_to_physical_device_id`
  - let the upstream `CoreEngineLauncher` / `CoreEngineProcManager` assign `TT_VISIBLE_DEVICES` per rank.
  - See *platform.py*.

* That single-host device-group discovery runs in a short-lived spawned helper process, so the main server process does not hold TT chip locks before worker startup; see *platform.py*.

* The TT launcher path is now reserved for explicit MPI / rank-binding / multi-node placement. If rank_binding, mpi_args, nnodes > 1, or node_rank > 0 is provided, we still use `TTCoreEngineLauncher`; see *platform.py*.

* When the explicit TT launcher path is used, one MPI rank must still match one DP rank, and every rank_binding entry must provide `TT_VISIBLE_DEVICES`; see *launcher.py*.

* Rank-local mesh sizing is constrained by `TT_VISIBLE_DEVICES` instead of assuming the full-machine `MESH_DEVICE` preset. We also skip fabric setup when the rank-local mesh has only one device; see *worker.py*.

## Test Plan

1. Ad unit tests checking covering DP class selection, rank mapping, and other related configs.
2. Test DP=1 for any regressions locally. Pay attention to structured-output tests after recent execute-sample changes from `dev`.
3. Run DP=1 nightly CI jobs.
4. Run local DP > 1 on T3K.
5. Run DP > 1 CI jobs.

## Test Results

- [x] Unit tests passing (including new `test_dp_modes.py`).
- [x] DP=1 (P150, blackhole) pass locally for Qwen.
- [x] DP=1 actions pass for [NoOp ](https://github.com/tenstorrent/tt-metal/actions/runs/28355444919)and [Llama](https://github.com/tenstorrent/tt-metal/actions/runs/28358105906/job/84007473821), and [Gemma 3](https://github.com/tenstorrent/tt-metal/actions/runs/28369151364/job/84048343763) and [4](https://github.com/tenstorrent/tt-metal/actions/runs/28501089215).
- [ ] DP > 1 on T3K is pending because it's being used by multiple users from the same user and sometimes needs deep cleanup.
- [x] DP > 1 jobs are successful but
  * sometimes one needs to run WH-GLX jobs multiple times because of sudden server-side errors, which happen in any branch 🆗;
  * with current CI setup, BH-LB and WH-GLX Llama tests have degraded metrics in the proposed branch: compare [ours](https://github.com/tenstorrent/tt-metal/actions/runs/28590386651/job/84936979344#step:12:124) vs [dev](https://github.com/tenstorrent/tt-metal/actions/runs/28557518844/job/84669453509#step:12:119) and [ours](https://github.com/tenstorrent/tt-metal/actions/runs/28778467636/job/85355678686#step:12:124) vs [dev](https://github.com/tenstorrent/tt-metal/actions/runs/28778502352/job/85338622075#step:12:123) ☹️;
  * with current CI setup, WH-GLX Gemma3 tests show significant improvement on all metrics: compare [ours](https://github.com/tenstorrent/tt-metal/actions/runs/28782232091/job/85346487796) vs [dev](https://github.com/tenstorrent/tt-metal/actions/runs/28760554196/job/85340247666) 😮;
  * with increased budget for BH-LB (and potentially heavy-load setup), ours win on throughput; on TTFT, dev wins by a large margin: compare [ours](https://github.com/tenstorrent/tt-metal/actions/runs/28778467636/job/85355679618#step:12:129) vs [dev](https://github.com/tenstorrent/tt-metal/actions/runs/28778502352/job/85338623059#step:12:125) 🤔.
- [x] All jobs are [here](https://github.com/tenstorrent/tt-metal/actions/runs/29560407162). Ignore failures related to device initialization and WH-GLX sampling tests - all of them are expected when running from `dev` and out-of-scope.