### PR TITLE
requirements: lower transformers floor to 4.56.0 (unbreak TT vLLM build)

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -7,7 +7,7 @@ requests >= 2.26.0
 tqdm
 blake3
 py-cpuinfo
-transformers >= 5.5.3
+transformers >= 4.56.0  # keep 4.x-compatible: vllm-tt-plugin & tt-metal pin transformers<=4.57.1; a 5.x floor breaks the TT build (PR #428)
 tokenizers >= 0.21.1  # Required for fast incremental detokenization.
 protobuf >= 5.29.6, !=6.30.*, !=6.31.*, !=6.32.*, !=6.33.0.*, !=6.33.1.*, !=6.33.2.*, !=6.33.3.*, !=6.33.4.* # Required by LlamaTokenizer, gRPC. CVE-2026-0994
 fastapi[standard] >= 0.115.0 # Required by FastAPI's form models in the OpenAI API server's audio transcriptions endpoint.


### PR DESCRIPTION
## Summary

`requirements/common.txt` floors `transformers >= 5.5.3` (introduced by #428, *"allow transformers 5.x"*), but the Tenstorrent stack pins `transformers<=4.57.1` (`plugins/vllm-tt-plugin/pyproject.toml` `runtime` extra, matching tt-metal). In the shared `tt-metal/python_env` these constraints are irreconcilable, and the failure mode is **silent and severe**: the source-built TT vLLM gets replaced by an upstream **CUDA-only** wheel that crashes the server at startup.

This lowers the floor to `transformers >= 4.56.0` — keeping #428's intent (5.x is still *allowed*) while no longer *forbidding* the 4.x that the TT runtime requires.

## Symptom

TT inference-server images built from `dev` start the vLLM server and immediately crash:

```
File ".../tt-metal/python_env/.../vllm/utils.py", line 8, in <module>
    from vllm._C import cuda_utils
ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
```

The server never becomes healthy → the eval/release harness waits 1200s → `inference server not healthy; aborting` → job fails with exit 1. (Example: tt-shield run [28370524822](https://github.com/tenstorrent/tt-shield/actions/runs/28370524822).)

## Root cause

The inference-server Dockerfile builds vLLM correctly for TT, then installs the plugin's runtime extra:

```
VLLM_TARGET_DEVICE=empty uv pip install -e . --extra-index-url .../whl/cpu
uv pip install --index-strategy unsafe-best-match -e 'plugins/vllm-tt-plugin[runtime]' --extra-index-url .../whl/cpu
```

Build log (dev / `68f63d8`):

```
+ vllm==0.1.dev14171+g68f63d873.empty   (from file:///.../vllm)   # correct TT build (no CUDA)
  Building vllm-tt-plugin ...
  Downloading vllm (9.4MiB)
- vllm==0.1.dev14171+g68f63d873.empty                              # UNINSTALLED
+ vllm==0.2.5                                                      # PyPI CUDA wheel
  (+ pydantic 2->1.10, transformers 5.10->4.57, aioprometheus, xformers==0.0.35, ray ...)
```

Mechanism:
1. The editable TT vLLM requires `transformers>=5.5.3` (this file).
2. `vllm-tt-plugin[runtime]` requires `transformers<=4.57.1` and depends on an **unpinned** `vllm`.
3. The two transformers constraints cannot both hold, so uv (with `--index-strategy unsafe-best-match`) discards the editable `.empty` build and resolves `vllm` from PyPI to the only version whose loose deps fit transformers 4.x — `vllm==0.2.5` (Dec 2023).
4. `vllm==0.2.5`'s only PyPI wheel is CUDA-only; its `vllm/_C*.so` links `libcudart.so.12`, which is absent in a TT container → fatal `ImportError` on the first `import vllm`.

The `stable` branch is unaffected because it floors `transformers >= 4.56.0, < 5`, which is compatible with the plugin's `<=4.57.1`; uv keeps the editable TT build and the server runs the proper vLLM v1 engine.

## Why lowering the floor is safe

vLLM `dev`'s own test requirements still pin transformers 4.57.x:

| File | Pin |
|---|---|
| `requirements/test.in` | `transformers==4.57.5` |
| `requirements/test.txt` | `transformers==4.57.5` |
| `requirements/nightly_torch_test.txt` | `transformers==4.57.5` |
| `requirements/rocm-test.txt` | `transformers==4.57.3` |

So `dev` is already tested against transformers 4.57.x; the `>= 5.5.3` floor contradicts that. `>= 4.56.0` permits both 4.x and 5.x.

## The change

```diff
-transformers >= 5.5.3
+transformers >= 4.56.0  # keep 4.x-compatible: vllm-tt-plugin & tt-metal pin transformers<=4.57.1; a 5.x floor breaks the TT build (PR #428)
```

## Suggested follow-ups (not in this PR)

- Harden `vllm-tt-plugin` so it can never silently pull a foreign vLLM (e.g. drop the unpinned `vllm` from `dependencies`, or install the plugin's runtime deps without re-resolving `vllm`). The transformers fix removes today's trigger, but unpinned `vllm` + `unsafe-best-match` remains a latent footgun.
- In tt-inference-server's Dockerfile, assert vLLM is still the source build after the plugin install (e.g. `pip show vllm | grep -q '\.empty'`) so any future regression fails the build in seconds instead of after a ~20-min runtime health timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
