### PR TITLE
tt-plugin: stop runtime extra from clobbering the tt-metal env

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -61,21 +61,19 @@ source plugins/vllm-tt-plugin/docs/install-vllm-tt.sh
 
 The script installs base vLLM with `VLLM_TARGET_DEVICE=empty` because `tt` is
 provided by this plugin at runtime, not by the base vLLM build. It then installs
-the plugin with its runtime dependencies.
+the plugin with a few dependencies. Most dependencies come from the
+active tt-metal env.
 
-To install or refresh only the plugin package with runtime dependencies:
+To install or refresh only the plugin package:
 
 ```bash
-uv pip install -e "plugins/vllm-tt-plugin[runtime]" \
-  --extra-index-url https://download.pytorch.org/whl/cpu \
-  --index-strategy unsafe-best-match
+uv pip install -e plugins/vllm-tt-plugin
 ```
 
-If the active tt-metal environment already owns the runtime dependencies, use a
-no-dependency editable install:
+To run the offline Qwen-VL example, also install its extra:
 
 ```bash
-uv pip install -e plugins/vllm-tt-plugin --no-deps
+uv pip install -e "plugins/vllm-tt-plugin[examples]"
 ```
 
 After the first setup, activate the same environment before running vLLM:

--- a/plugins/vllm-tt-plugin/docs/install-vllm-tt.sh
+++ b/plugins/vllm-tt-plugin/docs/install-vllm-tt.sh
@@ -1,2 +1,2 @@
 VLLM_TARGET_DEVICE=empty uv pip install -e . --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
-uv pip install -e "plugins/vllm-tt-plugin[runtime]" --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+uv pip install -e plugins/vllm-tt-plugin

--- a/plugins/vllm-tt-plugin/pyproject.toml
+++ b/plugins/vllm-tt-plugin/pyproject.toml
@@ -18,17 +18,12 @@ license = "Apache-2.0"
 dependencies = ["tblib>=3.1.0"]
 
 [project.optional-dependencies]
-# Standalone-dev convenience: provisions a torch + HF stack when the plugin
-# is installed outside a tt-metal env. On Linux, `pip install torch` from PyPI
-# may select a CUDA wheel; use the PyTorch CPU index if you need CPU-only.
-# In a tt-metal python_env (production), that env owns exact pins; these are floors (numpy capped <2) to avoid downgrades.
-runtime = [
-    "torch>=2.7.0",
-    "torchvision>=0.22.0",
-    "numpy>=1.24.4,<2",
-    "transformers>=5.5.3",
-    "qwen-vl-utils",
-]
+# The plugin runs only inside a tt-metal python_env, which already owns torch,
+# transformers, numpy, and torchvision; restating them here only risks conflicts.
+# qwen-vl-utils is used solely by the offline Qwen-VL example
+# (examples/offline_inference_tt.py), not by the serving path, and the tt-metal
+# env does not provide it.
+examples = ["qwen-vl-utils"]
 
 [project.entry-points."vllm.general_plugins"]
 tt_model_registry = "vllm_tt_plugin.entrypoints:register"

--- a/plugins/vllm-tt-plugin/pyproject.toml
+++ b/plugins/vllm-tt-plugin/pyproject.toml
@@ -18,10 +18,10 @@ license = "Apache-2.0"
 dependencies = ["tblib>=3.1.0"]
 
 [project.optional-dependencies]
-# Standalone-dev convenience: provisions a CPU torch + HF stack when the plugin
-# is installed outside a tt-metal env. Installed into a tt-metal python_env (the
-# production path), that env already owns these and pins exact versions, so these
-# are floors that never downgrade or conflict with it and survive its version bumps.
+# Standalone-dev convenience: provisions a torch + HF stack when the plugin
+# is installed outside a tt-metal env. On Linux, `pip install torch` from PyPI
+# may select a CUDA wheel; use the PyTorch CPU index if you need CPU-only.
+# In a tt-metal python_env (production), that env owns exact pins; these are floors (numpy capped <2) to avoid downgrades.
 runtime = [
     "torch>=2.7.0",
     "torchvision>=0.22.0",

--- a/plugins/vllm-tt-plugin/pyproject.toml
+++ b/plugins/vllm-tt-plugin/pyproject.toml
@@ -9,19 +9,25 @@ description = "Tenstorrent backend plugin for vLLM"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 license = "Apache-2.0"
-dependencies = ["vllm"]
+# vLLM is intentionally absent: it must be the locally built TT `empty` target,
+# which is not the (CUDA) `vllm` on PyPI. Declaring it as a resolvable dependency
+# lets a version conflict silently uninstall the TT build and pull the PyPI wheel.
+# The install order (build vLLM, then this plugin) guarantees it is present.
+# tblib is required at runtime for cross-process traceback serialization and is
+# not provided by the tt-metal env or by vLLM core's runtime requirements.
+dependencies = ["tblib>=3.1.0"]
 
 [project.optional-dependencies]
+# Standalone-dev convenience: provisions a CPU torch + HF stack when the plugin
+# is installed outside a tt-metal env. Installed into a tt-metal python_env (the
+# production path), that env already owns these and pins exact versions, so these
+# are floors that never downgrade or conflict with it and survive its version bumps.
 runtime = [
-    # TT-NN works with older torch versions, but vLLM requires torch >= 2.7.0.
-    "torch==2.10.0+cpu",
-    "torchvision==0.25.0",
-    "torchaudio==2.10.0",
-    # Pinned to exact version to match tt-metal's pyproject.toml and prevent numpy 2.x upgrades.
-    "numpy==1.26.4",
-    "transformers<=4.57.1",
+    "torch>=2.7.0",
+    "torchvision>=0.22.0",
+    "numpy>=1.24.4,<2",
+    "transformers>=5.5.3",
     "qwen-vl-utils",
-    "tblib==3.1.0",
 ]
 
 [project.entry-points."vllm.general_plugins"]


### PR DESCRIPTION
vLLM dropped as a declared dependency so a version conflict can no longer uninstall the local TT empty build and resolve the CUDA wheel from PyPI. Env-owned pins (transformers/torch/torchvision/numpy) become floors matching the tt-metal python_env so installing into it never downgrades or conflicts.

## Test Result

https://github.com/tenstorrent/tt-metal/actions/runs/28425806214
