### PR TITLE
[Model-Bringup] Register Qwen 3.6 in vLLM

### DIFF
--- a/plugins/vllm-tt-plugin/pyproject.toml
+++ b/plugins/vllm-tt-plugin/pyproject.toml
@@ -19,7 +19,9 @@ runtime = [
     "torchaudio==2.10.0",
     # Pinned to exact version to match tt-metal's pyproject.toml and prevent numpy 2.x upgrades.
     "numpy==1.26.4",
-    "transformers<=4.57.1",
+    # Qwen3.5/3.6 (Qwen3_5Config) requires transformers 5.x; align with
+    # requirements/common.txt (transformers >= 5.5.3, merged in 7402941df).
+    "transformers>=5.5.3",
     "qwen-vl-utils",
     "tblib==3.1.0",
 ]

--- a/plugins/vllm-tt-plugin/pyproject.toml
+++ b/plugins/vllm-tt-plugin/pyproject.toml
@@ -19,9 +19,7 @@ runtime = [
     "torchaudio==2.10.0",
     # Pinned to exact version to match tt-metal's pyproject.toml and prevent numpy 2.x upgrades.
     "numpy==1.26.4",
-    # Qwen3.5/3.6 (Qwen3_5Config) requires transformers 5.x; align with
-    # requirements/common.txt (transformers >= 5.5.3, merged in 7402941df).
-    "transformers>=5.5.3",
+    "transformers<=4.57.1",
     "qwen-vl-utils",
     "tblib==3.1.0",
 ]

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -271,6 +271,23 @@ def register_tt_models(register_test_models=False) -> None:
 
     _register_model_if_missing(ModelRegistry, "TTQwen3ForCausalLM", path_qwen3_text)
 
+    qwen35_text_version = os.getenv("TT_QWEN35_TEXT_VER", "qwen36_blackhole")
+    if qwen35_text_version == "qwen36_blackhole":
+        path_qwen35_text = (
+            "models.demos.blackhole.qwen36.tt.qwen36_vllm:Qwen36ForCausalLM"
+        )
+    else:
+        raise ValueError(
+            f"Unsupported TT Qwen3.5 version: {qwen35_text_version}, "
+            "pick one of [qwen36_blackhole]"
+        )
+
+    # Only register the "TT"-prefixed alias that check_and_update_config produces;
+    # the bare arch stays mapped to the upstream class for the runner gate.
+    _register_model_if_missing(
+        ModelRegistry, "TTQwen3_5ForConditionalGeneration", path_qwen35_text
+    )
+
     # Qwen2.5 - Vision
     _register_model_if_missing(
         ModelRegistry,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -271,6 +271,7 @@ def register_tt_models(register_test_models=False) -> None:
 
     _register_model_if_missing(ModelRegistry, "TTQwen3ForCausalLM", path_qwen3_text)
 
+    # Qwen3.5 - Text
     qwen35_text_version = os.getenv("TT_QWEN35_TEXT_VER", "qwen36_blackhole")
     if qwen35_text_version == "qwen36_blackhole":
         path_qwen35_text = (
@@ -282,8 +283,6 @@ def register_tt_models(register_test_models=False) -> None:
             "pick one of [qwen36_blackhole]"
         )
 
-    # Only register the "TT"-prefixed alias that check_and_update_config produces;
-    # the bare arch stays mapped to the upstream class for the runner gate.
     _register_model_if_missing(
         ModelRegistry, "TTQwen3_5ForConditionalGeneration", path_qwen35_text
     )


### PR DESCRIPTION
Registers Qwen 3.5 / Qwen 3.6 with vLLM.

This is a PR as a part of a broader Model Bring-up effort:
- https://github.com/tenstorrent/tt-inference-server/issues/2995