### PR TITLE
Fix #436 scheduler livelock

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/config.py
@@ -3,12 +3,12 @@
 
 from typing import TYPE_CHECKING, Any
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 def _extract_tt_config(

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -13,7 +13,6 @@ import torch
 import torch.distributed as dist
 
 from vllm.config import ParallelConfig, VllmConfig
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.utils.network_utils import get_tcp_uri
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.engine import (
@@ -25,6 +24,7 @@ from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.request import Request
 from vllm_tt_plugin.config import get_tt_config, get_tt_per_lane_max_num_seqs
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.scheduler import TTSchedulingMode
 
 logger = init_tt_logger(__name__)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -13,7 +13,7 @@ import torch
 import torch.distributed as dist
 
 from vllm.config import ParallelConfig, VllmConfig
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.utils.network_utils import get_tcp_uri
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.engine import (
@@ -27,7 +27,7 @@ from vllm.v1.request import Request
 from vllm_tt_plugin.config import get_tt_config, get_tt_per_lane_max_num_seqs
 from vllm_tt_plugin.scheduler import TTSchedulingMode
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 _T = TypeVar("_T")
 
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/entrypoints.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/entrypoints.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 def register() -> None:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -15,9 +15,9 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
+from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -15,11 +15,11 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import ToolParser
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 # Gemma4 tool-call wire format (emitted by the model, see the chat template):
 #

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
@@ -33,7 +33,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.sched.interface import SchedulerInterface
 from vllm.v1.core.sched.output import (
@@ -47,6 +46,7 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_per_lane_max_num_seqs,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.scheduler import TTScheduler, TTSchedulingMode
 
 if TYPE_CHECKING:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
@@ -33,7 +33,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.sched.interface import SchedulerInterface
 from vllm.v1.core.sched.output import (
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request, RequestStatus
     from vllm.v1.structured_output import StructuredOutputManager
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 @dataclass(frozen=True)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
@@ -14,13 +14,13 @@ import cloudpickle
 import yaml
 
 from vllm.config import ParallelConfig, VllmConfig
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
 from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPlan
 from vllm.v1.executor.abstract import UniProcExecutor
 from vllm_tt_plugin.config import get_tt_config
+from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/launcher.py
@@ -14,7 +14,7 @@ import cloudpickle
 import yaml
 
 from vllm.config import ParallelConfig, VllmConfig
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_ip
 from vllm.utils.system_utils import kill_process_tree
@@ -22,7 +22,7 @@ from vllm.v1.engine.utils import CoreEngine, CoreEngineLauncher, EngineLaunchPla
 from vllm.v1.executor.abstract import UniProcExecutor
 from vllm_tt_plugin.config import get_tt_config
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 class TTLaunchPlan(EngineLaunchPlan):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py
@@ -4,7 +4,6 @@
 from torch import nn
 
 from vllm.config import ModelConfig, VllmConfig
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.model_executor.model_loader import BaseModelLoader
 from vllm.model_executor.model_loader.utils import get_model_architecture
 from vllm_tt_plugin.config import (
@@ -12,6 +11,7 @@ from vllm_tt_plugin.config import (
     get_tt_data_parallel_size,
     get_tt_max_batch_size,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/loader.py
@@ -4,7 +4,7 @@
 from torch import nn
 
 from vllm.config import ModelConfig, VllmConfig
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.model_executor.model_loader import BaseModelLoader
 from vllm.model_executor.model_loader.utils import get_model_architecture
 from vllm_tt_plugin.config import (
@@ -13,7 +13,7 @@ from vllm_tt_plugin.config import (
     get_tt_max_batch_size,
 )
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 class TTModelLoader(BaseModelLoader):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/logger.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/logger.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import logging
+
+from vllm.logger import init_logger
+
+_VLLM_LOGGER_PREFIX = "vllm."
+
+
+def init_tt_logger(name: str) -> logging.Logger:
+    """Initialize a TT plugin logger under vLLM's configured logger tree."""
+    if name.startswith(_VLLM_LOGGER_PREFIX):
+        return init_logger(name)
+    return init_logger(f"{_VLLM_LOGGER_PREFIX}{name}")

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -15,7 +15,7 @@ import torch
 import ttnn
 
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.utils.math_utils import cdiv
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
 
 import numpy as np
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 # Matches the upstream attention-layer naming convention used by registered
 # vLLM models (e.g. "model.language_model.layers.5.self_attn") as well as

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -15,7 +15,6 @@ import torch
 import ttnn
 
 from vllm.config import VllmConfig
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.tasks import GenerationTask, PoolingTask, SupportedTask
 from vllm.utils.math_utils import cdiv
@@ -55,6 +54,7 @@ from vllm_tt_plugin.input_batch import (
 )
 from vllm_tt_plugin.lane_scheduler import get_tt_step_plan
 from vllm_tt_plugin.loader import TTModelLoader
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.logprobs import build_device_logprobs
 from vllm_tt_plugin.model_input import (
     TTModelInput,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -455,6 +455,11 @@ class TTPlatform(Platform):
         if vllm_config.scheduler_config.enable_chunked_prefill:
             logger.info("Chunked prefill is not yet supported for TT backend")
             vllm_config.scheduler_config.enable_chunked_prefill = False
+            # Check that config is valid with chunked prefill disabled,
+            # for example that full max_model_len prefill can be scheduled.
+            vllm_config.scheduler_config.verify_max_model_len(
+                vllm_config.model_config.max_model_len
+            )
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm_tt_plugin.config import (
     get_tt_config,
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 else:
     FlexibleArgumentParser = object
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 TT_SCHEDULER_CLS = "vllm_tt_plugin.scheduler.TTScheduler"
 TT_LANE_SCHEDULER_CLS = "vllm_tt_plugin.lane_scheduler.TTLaneCoordinator"

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -455,11 +455,25 @@ class TTPlatform(Platform):
         if vllm_config.scheduler_config.enable_chunked_prefill:
             logger.info("Chunked prefill is not yet supported for TT backend")
             vllm_config.scheduler_config.enable_chunked_prefill = False
-            # Check that config is valid with chunked prefill disabled,
-            # for example that full max_model_len prefill can be scheduled.
-            vllm_config.scheduler_config.verify_max_model_len(
-                vllm_config.model_config.max_model_len
-            )
+            # vLLM does this bump silently earlier
+            # if chunked prefill is already disabled,
+            # and max_num_batched_tokens is not explicitly set.
+            # We can't know if it was specified
+            # or the default, hence the warning.
+            if (
+                vllm_config.scheduler_config.max_num_batched_tokens
+                < vllm_config.model_config.max_model_len
+            ):
+                logger.warning(
+                    "max_num_batched_tokens=%d < max_model_len=%d with chunked prefill "
+                    "disabled, bumping max_num_batched_tokens to match.",
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    vllm_config.model_config.max_model_len,
+                )
+                vllm_config.scheduler_config.max_num_batched_tokens = (
+                    vllm_config.model_config.max_model_len
+                )
+
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )
@@ -659,6 +673,10 @@ class TTPlatform(Platform):
         logger.info(
             "Automatic prefix caching is %s",
             "enabled" if vllm_config.cache_config.enable_prefix_caching else "disabled",
+        )
+        # Check that all invariants are satisfied after all rewriting
+        vllm_config.scheduler_config.verify_max_model_len(
+            vllm_config.model_config.max_model_len
         )
 
     @classmethod

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 
 import torch
 
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.platforms.interface import Platform, PlatformEnum
 from vllm_tt_plugin.config import (
     get_tt_config,
@@ -17,6 +16,7 @@ from vllm_tt_plugin.config import (
     uses_tt_lane_coordinator,
     validate_tt_lane_config,
 )
+from vllm_tt_plugin.logger import init_tt_logger
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -4,11 +4,11 @@
 from enum import Enum
 from typing import cast
 
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
 from vllm.v1.request import Request
+from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -4,13 +4,13 @@
 from enum import Enum
 from typing import cast
 
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.request_queue import RequestQueue, create_request_queue
 from vllm.v1.request import Request
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 
 class TTSchedulingMode(Enum):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -12,7 +12,6 @@ import torch
 import ttnn
 
 from vllm.config import VllmConfig
-from vllm_tt_plugin.logger import init_tt_logger
 from vllm.model_executor.model_loader import get_model_architecture
 from vllm.tasks import SupportedTask
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
@@ -24,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.outputs import AsyncModelRunnerOutput, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerBase
+from vllm_tt_plugin.logger import init_tt_logger
 
 try:
     # Newer vLLM has compile_or_warm_up_model return per-worker timings, which

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -81,16 +81,13 @@ def _validate_tt_kv_cache_capacity(
         return
 
     model_config = vllm_config.model_config
-    scheduler_config = vllm_config.scheduler_config
     raise ValueError(
         "TT KV cache cannot hold one request at max_model_len. "
         f"Maximum concurrency for {model_config.max_model_len:,} tokens per "
         f"request is {max_concurrency:.2f}x, but must be at least 1.00x. "
-        f"num_blocks={kv_cache_config.num_blocks}, "
-        f"max_num_batched_tokens={scheduler_config.max_num_batched_tokens}, "
-        f"enable_chunked_prefill={scheduler_config.enable_chunked_prefill}. "
-        "Increase the TT KV-cache token budget, reduce max_model_len, or use "
-        "a supported scheduler configuration with a lower max_num_batched_tokens."
+        f"num_blocks={kv_cache_config.num_blocks}, corresponding to approximately "
+        f"{kv_cache_config.num_blocks * vllm_config.cache_config.block_size:,} tokens, "
+        "Increase max_tokens_all_users or reduce max_model_len."
     )
 
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -12,7 +12,7 @@ import torch
 import ttnn
 
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm.model_executor.model_loader import get_model_architecture
 from vllm.tasks import SupportedTask
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm.v1.outputs import LogprobsLists
 
-logger = init_logger(__name__)
+logger = init_tt_logger(__name__)
 
 # Ensure TT model architectures are registered in this process as early as
 # possible. `WorkerWrapperBase.init_worker` imports the worker class module

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -15,6 +15,7 @@ from vllm.config import VllmConfig
 from vllm.model_executor.model_loader import get_model_architecture
 from vllm.tasks import SupportedTask
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
+from vllm.v1.core.kv_cache_utils import get_max_concurrency_for_kv_cache_config
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -62,6 +63,35 @@ logger = init_tt_logger(__name__)
 # before initializing multimodal caches; without this, early architecture
 # inspection may fail for TT-prefixed architectures.
 register_tt_models(register_test_models=_should_pre_register_tt_test_models_from_cli())
+
+
+def _validate_tt_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> None:
+    """Reject TT KV configs that cannot serve one max_model_len request."""
+    # When rebased to include https://github.com/vllm-project/vllm/pull/41069
+    # verify and remove this check.
+    if not kv_cache_config.kv_cache_groups:
+        return
+
+    max_concurrency = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config
+    )
+    if max_concurrency >= 1.0:
+        return
+
+    model_config = vllm_config.model_config
+    scheduler_config = vllm_config.scheduler_config
+    raise ValueError(
+        "TT KV cache cannot hold one request at max_model_len. "
+        f"Maximum concurrency for {model_config.max_model_len:,} tokens per "
+        f"request is {max_concurrency:.2f}x, but must be at least 1.00x. "
+        f"num_blocks={kv_cache_config.num_blocks}, "
+        f"max_num_batched_tokens={scheduler_config.max_num_batched_tokens}, "
+        f"enable_chunked_prefill={scheduler_config.enable_chunked_prefill}. "
+        "Increase the TT KV-cache token budget, reduce max_model_len, or use "
+        "a supported scheduler configuration with a lower max_num_batched_tokens."
+    )
 
 
 class TTWorker(WorkerBase):
@@ -276,6 +306,7 @@ class TTWorker(WorkerBase):
         """Allocate TT KV cache (only DP rank 0) and initialize persistent
         input batch (all DP ranks) with the specified kv_cache_config.
         """
+        _validate_tt_kv_cache_capacity(self.vllm_config, kv_cache_config)
         self.model_runner.initialize_kv_cache(kv_cache_config)
 
     def initialize_cache(self, num_gpu_blocks: int, num_cpu_blocks: int) -> None:


### PR DESCRIPTION
## Purpose
Fix #436 
Add validation that max_num_scheduled_tokens >= max_model_len, like other platforms that disable chunked prefill
Ideally we'd move the disable before the existing checks, but that would require modifying upstream.

I noticed the warning wasn't present in the logs. On investigation, our loggers weren't picked up by vllm since we factored the plugin out. Some were still getting picked up by ttnn's root logger, but others were missed. Fixed by prepending `vllm.` to `__name__` when setting up loggers
## Test Plan
https://github.com/tenstorrent/tt-metal/actions/runs/28863833006
## Test Result
in flight
