### PR TITLE
Llama 70B Galaxy DP dedup fix

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import threading
 from collections import deque
 from dataclasses import dataclass, fields, replace

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1158,6 +1158,19 @@ class TTModelRunner:
         if not scheduler_output.total_num_scheduled_tokens:
             return None
 
+        # ``_update_states`` may have just discovered a layout change that the
+        # scheduler-output prediction could not see: it predicts the resets caused by
+        # new or resumed requests, but removals, unscheduled requests and batch
+        # condensation only surface here, after the drain decision was already made.
+        # ``_decode_layout_changed_since_last_decode = True`` implies
+        # ``reset_batch=True``: ``_prepare_model_inputs`` below reloads inputs from host
+        # state, which a pending async decode step has not been applied to yet. This
+        # step is therefore not steady-decode eligible, so drain pending decodes to
+        # ensure updated host inputs. No-op when the flag was already set before the
+        # step (the caller's drain decision covered it) or when nothing is pending.
+        if self._decode_layout_changed_since_last_decode:
+            self.async_decode.wait_for_all_pending_async_steps()
+
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output, grammar_output)
         return model_input
@@ -1972,18 +1985,10 @@ class TTModelRunner:
         )
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
-            # A layout change makes this a ``reset_batch`` step: ``build_model_input``
-            # below will reload host-authoritative tokens/positions onto the device
-            # for every slot. Under async overlap the just-submitted decode step is
-            # still pending here, so the host tokens/positions for CONTINUING
-            # device-resident slots lag by one and are stale. Reloading them would
-            # clobber the device's correct ``plus_one``-advanced ``current_pos`` and
-            # make those slots re-decode their previous token (the greedy
-            # "doubling"). The drain decision above (``steady_decode_candidate``) was
-            # made from the *previous* step's layout flag, so a transition step slips
-            # through without draining. Drain the pending step(s) now -- before the
-            # reload -- so the host state is current. This costs the overlap only on
-            # the rare layout-change step; steady decode keeps full overlap.
+            # ``_decode_layout_changed_since_last_decode = True`` implies
+            # ``reset_batch=True``: the model will reload inputs. This step is not
+            # steady-decode eligible, so drain pending decodes to ensure updated
+            # host inputs.
             self.async_decode.wait_for_all_pending_async_steps()
 
         if not scheduler_output.total_num_scheduled_tokens:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1891,8 +1891,6 @@ class TTModelRunner:
                             rank_output_tokens
                         )
 
-        if os.environ.get("DP_GATHER_DEBUG") == "1":
-            logger.info("batch_size_per_dp=%s", batch_size_per_dp)
         merged = TTModelInput(
             input_tokens=input_tokens,
             input_positions=input_positions,
@@ -1974,6 +1972,19 @@ class TTModelRunner:
         )
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
+            # A layout change makes this a ``reset_batch`` step: ``build_model_input``
+            # below will reload host-authoritative tokens/positions onto the device
+            # for every slot. Under async overlap the just-submitted decode step is
+            # still pending here, so the host tokens/positions for CONTINUING
+            # device-resident slots lag by one and are stale. Reloading them would
+            # clobber the device's correct ``plus_one``-advanced ``current_pos`` and
+            # make those slots re-decode their previous token (the greedy
+            # "doubling"). The drain decision above (``steady_decode_candidate``) was
+            # made from the *previous* step's layout flag, so a transition step slips
+            # through without draining. Drain the pending step(s) now -- before the
+            # reload -- so the host state is current. This costs the overlap only on
+            # the rare layout-change step; steady decode keeps full overlap.
+            self.async_decode.wait_for_all_pending_async_steps()
 
         if not scheduler_output.total_num_scheduled_tokens:
             return EMPTY_MODEL_RUNNER_OUTPUT


### PR DESCRIPTION



## Purpose

### Bug
Llama 70B Galaxy runs multi-lane single-process DP decode with async overlap:
each decode step is submitted, and the sampled token is fed back on-device with
`current_pos` advanced in-trace (`plus_one`). The host copy of tokens/positions
is intentionally stale during steady decode.

When the persistent-batch **layout changes** (a slot joins/leaves, new KV block),
the step becomes a `reset_batch`: `build_model_input` reloads host-authoritative
tokens/positions onto the device for *every* slot. But under async overlap the
just-submitted decode step is still pending, so for **continuing** device-resident
slots the host tokens/positions lag by one and are stale. Reloading them clobbers
the device's correct `plus_one`-advanced `current_pos`, so those slots re-decode
their previous token — the greedy "doubling".

The existing drain decision (`steady_decode_candidate`) is computed from the
*previous* step's layout flag, so the transition step slips through without
draining.

### Solution
Drains pending async decode steps before a layout-change reload so
device-resident slots don't re-decode their previous token. This is the
device/runner-side half of the Llama 70B Galaxy greedy "doubling" fix (the
host/model-side half lives in tt-metal's Galaxy generator).

### Fix
On the layout-change branch, drain the pending async step(s) **before** the
reload with `self.async_decode.wait_for_all_pending_async_steps()`, so host state
is current when `build_model_input` reads it.

- Cost is paid **only** on the rare layout-change step; steady-state decode keeps
  full async overlap.
- Genuine (re)inits already take the full-reload path via their own reasons and
  are unaffected.
- Also removes a leftover `DP_GATHER_DEBUG` debug log line.

### Impact
Deterministic greedy decode across layout transitions in 70B Galaxy DP; no
doubled/duplicated tokens. No API or config change; no steady-state perf impact.

### Notice
Pairs with the tt-metal host-side fix (Galaxy `generator.py`: mixed
greedy/random and `page_table_changed` no longer force a per-step host reload),
which preserves the same device-resident tokens/positions on the model side.

## Test Plan

In order to test this fix reliably, the user must pretty much run topK test from "plugins/vllm-tt-plugin/tests/tt/test_seeding_and_variety.py" with vLLM and Llama 70B couple of times with this config: WH Galaxy [8,4] mesh, DP=4 lane mode, on-device sampling, traced decode via vLLM tt-plugin.
If you look at the output from tests, the output will have duplicated tokens in the response.
In order to have this output fixed this fix should be tested with this fix on tt-metal side: https://github.com/tenstorrent/tt-metal/pull/50685

## Test Result

Output will contain replicated tokens and no replicated tokens with this fix and fix on the tt-metal side.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

