### PR TITLE
fix(gemma4): stream prose in tools-present requests instead of dropping it

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/gemma4_tool_parser.py
@@ -50,6 +50,13 @@ class Gemma4ToolParser(ToolParser):
         self.prev_tool_call_arr: list[dict] = []
         self.current_tool_id: int = -1
         self.streamed_args_for_tool: list[str] = []
+        # Number of CONFIRMED tool-call regions ("<|tool_call>call:") for which
+        # we have opened per-call state, and how many chars of prose content we
+        # have already surfaced. Tracked so prose in a tools-present request is
+        # streamed as content instead of being swallowed when the model emits a
+        # bare "<|tool_call>" token and then does NOT produce a real call.
+        self.confirmed_calls: int = 0
+        self.streamed_content_len: int = 0
 
         self.tool_call_start_token: str = TOOL_CALL_START
         self.tool_call_end_token: str = TOOL_CALL_END
@@ -245,6 +252,53 @@ class Gemma4ToolParser(ToolParser):
         self.buffered_delta_text = ""
         return combined
 
+    def _open_call_state(self) -> None:
+        self.current_tool_id += 1
+        self.current_tool_name_sent = False
+        self.streamed_args_for_tool.append("")
+        self.prev_tool_call_arr.append({})
+
+    def _content_view(self, text: str) -> str:
+        """The prose-content projection of ``text``: everything the client should
+        see as ``content``, with confirmed tool-call regions removed.
+
+        A ``<|tool_call>`` marker only starts a call region if it is immediately
+        followed by ``call:`` (the wire format). A bare marker that turns out to be
+        prose is dropped as a stray control token; the surrounding prose is kept.
+        An *open* region that is still a growing prefix of ``call:`` is held back
+        (dropped from the tail) until the next delta decides it.
+        """
+        out: list[str] = []
+        i = 0
+        n = len(text)
+        while i <= n:
+            j = text.find(TOOL_CALL_START, i)
+            if j == -1:
+                out.append(text[i:])
+                break
+            out.append(text[i:j])  # text before the marker is always content
+            after = text[j + len(TOOL_CALL_START) :]
+            if after.startswith(CALL_PREFIX):
+                # Confirmed call region: skip to its close (or to end if open).
+                k = text.find(TOOL_CALL_END, j)
+                if k == -1:
+                    break  # open confirmed call: drop the rest (goes to tool_calls)
+                i = k + len(TOOL_CALL_END)
+            elif CALL_PREFIX.startswith(after):
+                # Undecided open region at the tail: hold back for now.
+                break
+            else:
+                # Prose: the marker was not a real call. Drop the stray control
+                # token, keep going so the prose after it still surfaces.
+                i = j + len(TOOL_CALL_START)
+        return "".join(out)
+
+    def _emit_content(self, current_text: str) -> DeltaMessage | None:
+        visible = self._content_view(current_text)
+        new = visible[self.streamed_content_len :]
+        self.streamed_content_len = len(visible)
+        return DeltaMessage(content=new) if new else None
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,
@@ -258,37 +312,42 @@ class Gemma4ToolParser(ToolParser):
         delta_text = self._buffer_delta_text(delta_text)
         current_text = previous_text + delta_text
 
-        # No tool call yet: stream as plain content.
-        if TOOL_CALL_START not in current_text:
-            return DeltaMessage(content=delta_text) if delta_text else None
-
         try:
+            # Open per-call state for any newly-confirmed ("<|tool_call>call:") calls.
+            confirmed = current_text.count(TOOL_CALL_START + CALL_PREFIX)
+            while self.confirmed_calls < confirmed:
+                self._open_call_state()
+                self.confirmed_calls += 1
+
             start_count = current_text.count(TOOL_CALL_START)
             end_count = current_text.count(TOOL_CALL_END)
-            prev_start_count = previous_text.count(TOOL_CALL_START)
             prev_end_count = previous_text.count(TOOL_CALL_END)
 
-            # A new tool call opened in this delta: set up per-call state.
-            if start_count > prev_start_count:
-                self.current_tool_id += 1
-                self.current_tool_name_sent = False
-                self.streamed_args_for_tool.append("")
-                self.prev_tool_call_arr.append({})
-
-            # The current tool call just closed: emit the complete arguments in a
-            # single delta (concatenated deltas must form valid JSON, so we never
-            # stream a partial object that already carries a closing brace).
-            if end_count > prev_end_count:
+            # A confirmed call just closed: emit its arguments in one delta
+            # (concatenated deltas must form valid JSON).
+            if end_count > prev_end_count and self.current_tool_id >= 0:
                 return self._emit_completed_call(current_text)
 
-            # Mid open call: emit the function name as soon as it is known.
-            if start_count > end_count and not self.current_tool_name_sent:
-                return self._maybe_emit_name(current_text)
+            # An unclosed "<|tool_call>" region: decide call vs prefix vs prose.
+            if start_count > end_count:
+                last_start = current_text.rfind(TOOL_CALL_START)
+                body = current_text[last_start + len(TOOL_CALL_START) :]
+                if body.startswith(CALL_PREFIX):
+                    # Confirmed open call: emit the name once, hold args to close.
+                    if self.current_tool_id >= 0 and not self.current_tool_name_sent:
+                        return self._maybe_emit_name(current_text)
+                    return None
+                if CALL_PREFIX.startswith(body):
+                    # Still a growing prefix of "call:": wait for the next delta.
+                    return None
+                # else: prose that merely contains the marker -> fall through.
 
-            return None
+            # Everything else is prose content.
+            return self._emit_content(current_text)
         except Exception:
             logger.exception("Error in Gemma4 streaming tool call extraction")
-            return None
+            # Never silently drop text: surface whatever prose we can.
+            return self._emit_content(current_text)
 
     def _maybe_emit_name(self, current_text: str) -> DeltaMessage | None:
         start = current_text.rfind(TOOL_CALL_START) + len(TOOL_CALL_START)

--- a/plugins/vllm-tt-plugin/tests/test_gemma4_tool_parser.py
+++ b/plugins/vllm-tt-plugin/tests/test_gemma4_tool_parser.py
@@ -124,11 +124,14 @@ def test_streaming_assembles_name_and_args(parser: Gemma4ToolParser):
             prev, cur, chunk, [], [], [], request=None
         )
         if delta is not None and delta.tool_calls:
-            fn = delta.tool_calls[0].function or {}
-            if fn.get("name"):
-                name = fn["name"]
-            if fn.get("arguments"):
-                args_acc += fn["arguments"]
+            # DeltaToolCall.function is a DeltaFunctionCall model (pydantic coerces
+            # the dict we build), so read fields by attribute, not dict access.
+            fn = delta.tool_calls[0].function
+            if fn is not None:
+                if fn.name:
+                    name = fn.name
+                if fn.arguments:
+                    args_acc += fn.arguments
         prev = cur
 
     assert name == "get_weather"

--- a/plugins/vllm-tt-plugin/tests/test_gemma4_tool_parser.py
+++ b/plugins/vllm-tt-plugin/tests/test_gemma4_tool_parser.py
@@ -136,3 +136,86 @@ def test_streaming_assembles_name_and_args(parser: Gemma4ToolParser):
 
     assert name == "get_weather"
     assert json.loads(args_acc) == {"location": "Paris", "units": "c"}
+
+
+def _stream(chunks: list[str]) -> tuple[str, list[tuple[str | None, str | None]]]:
+    """Feed ``chunks`` through the streaming parser (fresh state) and return the
+    accumulated ``(content, [(name, arguments), ...])``."""
+    parser = Gemma4ToolParser(tokenizer=None)
+    content = ""
+    calls: list[tuple[str | None, str | None]] = []
+    prev = ""
+    for chunk in chunks:
+        cur = prev + chunk
+        delta = parser.extract_tool_calls_streaming(
+            prev, cur, chunk, [], [], [], request=None
+        )
+        if delta is not None:
+            if delta.content:
+                content += delta.content
+            for tc in delta.tool_calls or []:
+                fn = tc.function
+                calls.append((fn.name if fn else None, fn.arguments if fn else None))
+        prev = cur
+    return content, calls
+
+
+def test_streaming_plain_prose_is_content():
+    content, calls = _stream(["Yes, ", "the sky ", "is blue."])
+    assert content == "Yes, the sky is blue."
+    assert calls == []
+
+
+def test_streaming_prose_after_tool_token_is_not_swallowed():
+    # Regression: with tools present the model emits the tool-call START token and
+    # then produces PROSE instead of a real "call:" body. Previously every token
+    # after the marker was dropped (nonzero completion_tokens, empty content, no
+    # tool_calls). All the prose must now surface as content, the stray control
+    # token is dropped, and no spurious tool call is emitted.
+    content, calls = _stream(
+        [
+            "I think I should ",
+            "<|tool_call>",
+            "...actually let me just explain: ",
+            "all gates are green.",
+        ]
+    )
+    assert "I think I should " in content
+    assert "all gates are green." in content
+    assert "<|tool_call>" not in content
+    assert [n for n, _ in calls if n] == []
+
+
+def test_streaming_prose_around_a_call():
+    content, calls = _stream(
+        [
+            "Working on it. ",
+            '<|tool_call>call:run{cmd:<|"|>ls<|"|>}<tool_call|>',
+            " Done.",
+        ]
+    )
+    assert "Working on it. " in content and " Done." in content
+    assert [n for n, _ in calls if n] == ["run"]
+
+
+def test_streaming_two_calls_across_deltas():
+    content, calls = _stream(
+        [
+            "<|tool_call>",
+            "call:a{x:1}",
+            "<tool_call|>",
+            "<|tool_call>",
+            "call:b{y:2}",
+            "<tool_call|>",
+        ]
+    )
+    assert content == ""
+    assert [n for n, _ in calls if n] == ["a", "b"]
+
+
+def test_streaming_prose_with_angle_brackets_is_not_a_marker():
+    content, calls = _stream(
+        ["The condition x < 5 and y > 3 holds; ", "no tool needed."]
+    )
+    assert content == "The condition x < 5 and y > 3 holds; no tool needed."
+    assert calls == []


### PR DESCRIPTION
## Summary
In streaming mode, `Gemma4ToolParser` could silently drop model output. When tools are present and the model emits the `<|tool_call>` start token but then produces **prose** instead of a valid `call:NAME{...}` body, every subsequent delta returned `None` — the tokens were generated (counted in `completion_tokens`) but never surfaced as `content` or `tool_calls`. Clients saw intermittent responses with non-zero `completion_tokens` and empty `content`/`reasoning_content`/`tool_calls`.

This is prose-branch only; valid tool calls and no-tools prose were unaffected — which is why it looked intermittent.

## Root cause
`extract_tool_calls_streaming` committed to tool-call mode as soon as `<|tool_call>` appeared anywhere in the accumulated text. The only exits were a completed call or a confirmed `call:` name; a prose body matched neither, so text after the marker was swallowed with no fallback and no end-of-stream flush.

## Fix
Track confirmed (`<|tool_call>call:`) call regions and the prose already streamed, and project visible content through a new `_content_view` that removes **only** confirmed call regions:
- prose that merely contains the start token now streams as `content` (the stray control token is dropped);
- an undecided `call:` prefix is held exactly one delta until it resolves;
- valid single/multi tool calls are unchanged.

## Tests
`tests/test_gemma4_tool_parser.py` — 14 passed. New streaming regression tests: marker-then-prose no-swallow (the reported failure), plain prose, prose around a call, two calls across deltas, and angle-bracket prose not mistaken for a marker.

Also fixes a **pre-existing** broken test (`test_streaming_assembles_name_and_args`) that read `DeltaToolCall.function` via dict `.get()`; pydantic coerces it to a `DeltaFunctionCall` model, so it raised `AttributeError` independent of parser behavior. Kept as its own commit so it can be reviewed or dropped separately.

## Notes / scope
- Detection assumes `<|tool_call>call:` adjacency — the documented wire format, and the same assumption the original code already made.
- **Client-side guidance** (independent of this fix): for tool-using agents, set `frequency_penalty`/`presence_penalty` to `0` (non-zero values perturb tool-call formatting) and use `tool_choice="required"` for must-call turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
