### PR TITLE
fix(tt-plugin): return None from sample_tokens when no pending forward

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -2217,7 +2217,7 @@ class TTModelRunner:
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None
-    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput:
+    ) -> ModelRunnerOutput | AsyncTTModelRunnerOutput | None:
         """Sample the forward deferred by a preceding ``execute_model``.
 
         Pops the oldest pending forward (FIFO, matching the engine's
@@ -2225,7 +2225,16 @@ class TTModelRunner:
         produces its output (or an async wrapper for overlapped decode). The
         engine calls this exactly once per ``execute_model`` that returned
         ``None``.
+
+        If the preceding ``execute_model`` failed it enqueued no pending
+        forward, so return ``None`` instead of raising ``IndexError`` on an
+        empty deque. The engine treats ``None`` here as "the original
+        execute_model failed" and re-raises that real exception (see
+        ``EngineCore``'s ``if model_output is None`` path), so the true cause
+        surfaces instead of being masked by the empty-popleft error.
         """
+        if not self._pending_samples:
+            return None
         finish = self._pending_samples.popleft()
         return finish(grammar_output)
 


### PR DESCRIPTION
## Summary
On the TT `uniproc_executor(non_block)` path, when `execute_model()` fails it enqueues no pending forward, so `sample_tokens()` raised `IndexError` on an unconditional `popleft()` of an empty `_pending_samples` deque. That `IndexError` masked the real `execute_model` exception, making failures hard to diagnose.

## Fix
`sample_tokens()` now returns `None` when there is no pending forward, instead of popping an empty deque. The engine already handles this: `EngineCore` treats a `None` from `sample_tokens` as "the original `execute_model` failed" and re-raises the real exception via `exec_model_fut.result()`. So we reuse the existing upstream mechanism and the true error surfaces.

## Scope
- **Contained entirely to the fork's plugin** (`vllm_tt_plugin/model_runner.py`) — no change to upstream `vllm/v1/engine/core.py`.
- Diagnostic/robustness only; the normal (success) path is unchanged — the guard only triggers when a preceding `execute_model` failed.

Thanks @tchedaTT for the steer toward the contained fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
