### PR TITLE
[feature] Enable token-chunked prefill for Gemma4 (#439)

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -75,6 +75,7 @@ class DPGatherHandle:
     is_decode: bool
     overlap_ok: bool
     any_needs_logprobs: bool
+    intermediate_prefill_mask: torch.Tensor | None
     req_ids: list[str]
     req_id_to_index: dict[str, int]
 
@@ -502,6 +503,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             local_reset_batch,
             local_can_sample_device,
             local_needs_logprobs,
+            intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
         ) = all_local_inputs
@@ -713,6 +715,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             is_decode=is_decode,
             overlap_ok=overlap_ok,
             any_needs_logprobs=any_needs_logprobs,
+            intermediate_prefill_mask=intermediate_prefill_mask,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
         )
@@ -753,6 +756,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     my_logprobs_val,
                     handle.req_ids,
                     handle.req_id_to_index,
+                    handle.intermediate_prefill_mask,
                 ),
             )[0]
             return output

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -323,12 +323,19 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         return int(has_requests_t.item()) > 0
 
     def _dp_negotiate_forced_mode(self) -> TTSchedulingMode:
-        has_running = bool(getattr(self.scheduler, "running", []))
+        running = getattr(self.scheduler, "running", [])
+        has_running = bool(running)
         has_waiting = bool(getattr(self.scheduler, "waiting", False))
         max_running = getattr(self.scheduler, "max_num_running_reqs", 0)
-        has_capacity = len(getattr(self.scheduler, "running", [])) < max_running
+        has_partial_prefill = any(request.is_prefill_chunk for request in running)
+        has_capacity = len(running) < max_running
         local_prefill_intent = (
-            1 if (has_waiting and ((not has_running) or has_capacity)) else 0
+            1
+            if (
+                has_partial_prefill
+                or (has_waiting and ((not has_running) or has_capacity))
+            )
+            else 0
         )
         intent_tensor = torch.tensor([local_prefill_intent], dtype=torch.int32)
         self.dlog("before_intent_allreduce intent_tensor=%s", intent_tensor)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -1190,10 +1190,16 @@ class TTLaneInputBatch(InputBatch):
         lane_batch = self
         rows = list(plan.input_rows)
         rows_np = np.asarray(rows, dtype=np.int64)
-        input_positions = torch.from_numpy(
-            lane_batch.num_computed_tokens_cpu[rows_np].astype(np.int32)
+        input_positions_np = lane_batch.num_computed_tokens_cpu[rows_np]
+        input_positions = torch.from_numpy(input_positions_np.astype(np.int32))
+        chunk_lens = np.asarray(
+            [
+                scheduler_output.num_scheduled_tokens[lane_batch.req_ids[row]]
+                for row in rows
+            ],
+            dtype=np.int64,
         )
-        prompt_lens = lane_batch.num_tokens[rows_np]
+        prompt_lens = input_positions_np + chunk_lens
         max_prefill = int(prompt_lens.max())
         input_tokens = lane_batch.token_ids_cpu_tensor[rows_np, :max_prefill]
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -104,6 +104,12 @@ def apply_cached_req_state_update(
             block_ids.extend(new_ids)
 
 
+def clone_torch_generator(generator: torch.Generator) -> torch.Generator:
+    clone = torch.Generator(device=generator.device)
+    clone.set_state(generator.get_state())
+    return clone
+
+
 class SamplingInputBatch:
     # Default values for padding sampling parameters in decode mode.
     DEFAULTS = {
@@ -935,7 +941,9 @@ class TTLaneInputBatch(InputBatch):
             logit_proc.update_state(batch_update)
 
     def build_merged_sampling_metadata(
-        self, scheduled_rows: list[int] | None = None
+        self,
+        scheduled_rows: list[int] | None = None,
+        non_sampling_rows: list[int] | None = None,
     ) -> SamplingMetadata:
         """Build one :class:`SamplingMetadata` over every slot row.
 
@@ -957,8 +965,9 @@ class TTLaneInputBatch(InputBatch):
         rows' generators are passed through: a seeded request occupying a slot
         but not scheduled this step (e.g. a running decode request during a
         prefill-only step) must not have its RNG advanced, or its token stream
-        would drift by one draw per step it sat out. ``None`` advances all live
-        generators (whole-batch fallback / tests).
+        would drift by one draw per step it sat out. ``non_sampling_rows`` are
+        scheduled intermediate-prefill rows; their generator clones preserve the
+        fixed slot layout without advancing the request's real RNG state.
         """
         n = self.max_num_reqs
         sampling = self.sampling
@@ -1002,8 +1011,11 @@ class TTLaneInputBatch(InputBatch):
             generators = dict(sampling.generators)
         else:
             scheduled = set(scheduled_rows)
+            non_sampling = set(non_sampling_rows or ())
             generators = {
-                row: gen for row, gen in sampling.generators.items() if row in scheduled
+                row: clone_torch_generator(gen) if row in non_sampling else gen
+                for row, gen in sampling.generators.items()
+                if row in scheduled
             }
         return SamplingMetadata(
             temperature=temperature if not all_greedy else None,
@@ -1200,6 +1212,9 @@ class TTLaneInputBatch(InputBatch):
             dtype=np.int64,
         )
         prompt_lens = input_positions_np + chunk_lens
+        intermediate_prefill_mask = torch.from_numpy(
+            prompt_lens < lane_batch.num_tokens[rows_np]
+        )
         max_prefill = int(prompt_lens.max())
         input_tokens = lane_batch.token_ids_cpu_tensor[rows_np, :max_prefill]
 
@@ -1218,6 +1233,8 @@ class TTLaneInputBatch(InputBatch):
         perform_device_sampling = runner.check_perform_device_sampling(
             is_decode=False, has_structured_outputs=has_structured
         )
+        if intermediate_prefill_mask.any():
+            perform_device_sampling = False
 
         # Device-side penalties only; host sampling rebuilds these in
         # ``build_merged_sampling_metadata`` (over the full slot batch), so
@@ -1261,6 +1278,7 @@ class TTLaneInputBatch(InputBatch):
                 if plan.prefill_empty_slots is not None
                 else None
             ),
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
 
     def extract_output(
@@ -1284,7 +1302,26 @@ class TTLaneInputBatch(InputBatch):
         """
         n = len(scheduled_rows)
         rows_t = torch.as_tensor(scheduled_rows, dtype=torch.long)
+        intermediate_prefill_mask = getattr(
+            model_input, "intermediate_prefill_mask", None
+        )
+        intermediate_rows: list[int] = []
+        if not is_decode and intermediate_prefill_mask is not None:
+            assert intermediate_prefill_mask.numel() == n
+            intermediate_rows = [
+                row
+                for row, is_intermediate in zip(
+                    scheduled_rows, intermediate_prefill_mask.tolist(), strict=True
+                )
+                if is_intermediate
+            ]
+            if len(intermediate_rows) == n:
+                return torch.zeros((n, 1), dtype=torch.int32), None
         if model_input.perform_device_sampling:
+            assert not intermediate_rows, (
+                "Intermediate prefill rows must use host sampling so their "
+                "device RNG state is not advanced."
+            )
             tokens = tt_out.reshape(-1) if isinstance(tt_out, torch.Tensor) else tt_out
             # Decode reads each scheduled slot; prefill returns one token per
             # scheduled request, already in row order.
@@ -1301,7 +1338,9 @@ class TTLaneInputBatch(InputBatch):
         bitmask = model_input.grammar_bitmask[0]
         if bitmask is not None:
             runner.apply_grammar_bitmask(logits, bitmask)
-        sampling_metadata = self.build_merged_sampling_metadata(scheduled_rows)
+        sampling_metadata = self.build_merged_sampling_metadata(
+            scheduled_rows, non_sampling_rows=intermediate_rows
+        )
         sampler_output = runner.host_sampler(
             logits=logits, sampling_metadata=sampling_metadata
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/lane_scheduler.py
@@ -350,14 +350,17 @@ class TTLaneCoordinator(SchedulerInterface):
     def _local_prefill_intent(self, sched: TTScheduler) -> int:
         """Whether this lane *wants* to prefill this step (1) or not (0).
 
-        A lane wants to prefill when it has queued requests and either nothing
-        running (so it must prefill to make progress) or spare capacity to admit
-        more alongside its running decodes.
+        A running prefill continuation must always make progress, even when the
+        lane is at its request capacity. New queued requests need either no
+        running work or spare capacity to be admitted alongside running decodes.
         """
         has_waiting = bool(sched.waiting)
         has_running = bool(sched.running)
+        has_partial_prefill = any(request.is_prefill_chunk for request in sched.running)
         has_capacity = len(sched.running) < self._per_lane_max
-        return int(has_waiting and ((not has_running) or has_capacity))
+        return int(
+            has_partial_prefill or (has_waiting and ((not has_running) or has_capacity))
+        )
 
     def _negotiate_forced_mode(self) -> TTSchedulingMode:
         """Pick the single mode (prefill- or decode-only) all lanes will run.
@@ -502,7 +505,10 @@ class TTLaneCoordinator(SchedulerInterface):
         if (
             forced_mode == TTSchedulingMode.PREFILL_ONLY
             and merged.total_num_scheduled_tokens == 0
-            and any(sched.running for sched in self.lanes)
+            and any(
+                any(not request.is_prefill_chunk for request in sched.running)
+                for sched in self.lanes
+            )
         ):
             # The discarded prefill pass already drained each lane's
             # finished/freed-encoder bookkeeping; carry it onto the decode pass

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -126,3 +126,7 @@ class TTModelInput:
     # Single-process DP prefill only: global stable slots supplied by the
     # scheduler-owned step plan. ``None`` for non-DP, gathered-DP, and decode.
     prefill_empty_slots: list[int] | None = None
+
+    # Prefill-only: rows whose forward contributes KV state but must not
+    # consume a sampling RNG draw because more prompt tokens remain.
+    intermediate_prefill_mask: torch.Tensor | None = None

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -144,9 +144,6 @@ class TTModelRunner:
         if self.request_specific_rope:
             self.previous_req_ids: set[str] = set()
 
-        # Currently, TT model runner doesn't support chunked prefill.
-        assert self.scheduler_config.enable_chunked_prefill is False
-
         self.mesh_device = mesh_device
         self.trace_mode = trace_mode
         self.enable_model_warmup = enable_model_warmup
@@ -891,39 +888,61 @@ class TTModelRunner:
         # NOTE: We assume that all sequences in the group are all prompts or
         # all decodes.
         cached_reqs = scheduler_output.scheduled_cached_reqs
+        num_sched = scheduler_output.num_scheduled_tokens
         # A "prefill" step can contain:
         # - brand new requests (scheduled_new_reqs), and/or
         # - resumed-from-preemption requests (scheduled_cached_reqs with
-        #   resumed_req_ids set) that need to replay tokens to rebuild KV.
-        is_prompt = (len(scheduler_output.scheduled_new_reqs) > 0) or bool(
-            cached_reqs.resumed_req_ids
+        #   resumed_req_ids set) that need to replay tokens to rebuild KV,
+        #   and/or
+        # - chunked-prefill continuations (cached requests with >1 token
+        #   scheduled that are neither new nor resumed).
+        has_chunked_continuation = any(
+            num_sched.get(req_id, 0) > 1
+            for req_id in cached_reqs.req_ids
+            if req_id not in cached_reqs.resumed_req_ids
+        )
+        is_prompt = (
+            len(scheduler_output.scheduled_new_reqs) > 0
+            or bool(cached_reqs.resumed_req_ids)
+            or has_chunked_continuation
         )
         sample_params = input_batch.sampling
         if is_prompt:
             # NOTE: In SchedulerOutput, "cached" means "request data already
             # cached on the worker", not necessarily "decode". During a prefill
             # step we can legitimately see cached requests if they are resumed
-            # from preemption (still prefill work).
+            # from preemption (still prefill work) or are chunked-prefill
+            # continuations (>1 token scheduled).
             if cached_reqs.num_reqs > 0:
-                any_running = any(
+                any_decode_in_prefill = any(
                     req_id not in cached_reqs.resumed_req_ids
+                    and num_sched.get(req_id, 0) <= 1
                     for req_id in cached_reqs.req_ids
                 )
-                assert not any_running, (
-                    "Prefill batch should not include decode/running cached "
-                    "requests (req_id not in resumed_req_ids)."
+                assert not any_decode_in_prefill, (
+                    "Prefill batch should not include decode cached requests "
+                    "(cached req_id that is neither resumed nor chunked-prefill)."
                 )
 
             # num_computed_tokens for each request is the input position
             # (=computed previously and cached)
             input_positions = input_batch.num_computed_tokens_cpu[req_indices]
-            # Prefill length in tokens for each request:
-            # - For new requests: equals prompt length.
-            # - For resumed-from-preemption requests: includes any generated
-            #   output tokens so far, so we can replay the full sequence to
-            #   rebuild KV after preemption freed the cache blocks.
-            prompt_lens = input_batch.num_tokens[req_indices]
-            max_prefill_tokens = max(prompt_lens)
+            # Chunk-aware `prompt_lens`: for each request, the "prompt length"
+            # the generator sees is `start_pos` + `chunk_len`, i.e., the position
+            # up to which tokens should be processed.  The generator slices
+            # `tokens[start_pos : prompt_lens]` and processes that chunk.
+            # - Full prefill (no chunking): `start_pos=0`, `chunk_len=prompt_len`
+            #   => `prompt_lens = prompt_len` (same as before).
+            # - APC hit: `start_pos=cached`, `chunk_len=prompt_len-cached`
+            #   => `prompt_lens = prompt_len` (same as before).
+            # - Chunked continuation: `start_pos=computed`, `chunk_len=budget`
+            #   => `prompt_lens = computed + budget` (the chunk end position).
+            chunk_lens = np.array(
+                [num_sched[input_batch.req_ids[i]] for i in req_indices],
+                dtype=np.int64,
+            )
+            prompt_lens = input_positions + chunk_lens
+            max_prefill_tokens = int(max(prompt_lens))
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
             ]

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -2345,7 +2345,14 @@ class TTModelRunner:
         produces its output (or an async wrapper for overlapped decode). The
         engine calls this exactly once per ``execute_model`` that returned
         ``None``.
+
+        If the deque is empty, ``execute_model`` must have raised an exception
+        that was captured by the executor; return ``None`` so the engine can
+        surface the original error from the execute future.
         """
+        if not self._pending_samples:
+            return None  # type: ignore[return-value]
+
         finish = self._pending_samples.popleft()
         return finish(grammar_output)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -894,10 +894,11 @@ class TTModelRunner:
         # - resumed-from-preemption requests (scheduled_cached_reqs with
         #   resumed_req_ids set) that need to replay tokens to rebuild KV,
         #   and/or
-        # - chunked-prefill continuations (cached requests with >1 token
-        #   scheduled that are neither new nor resumed).
+        # - chunked-prefill continuations (cached requests that haven't
+        #   finished computing all their prompt tokens yet).
         has_chunked_continuation = any(
-            num_sched.get(req_id, 0) > 1
+            input_batch.num_computed_tokens_cpu[input_batch.req_id_to_index[req_id]]
+            < input_batch.num_prompt_tokens[input_batch.req_id_to_index[req_id]]
             for req_id in cached_reqs.req_ids
             if req_id not in cached_reqs.resumed_req_ids
         )
@@ -912,16 +913,21 @@ class TTModelRunner:
             # cached on the worker", not necessarily "decode". During a prefill
             # step we can legitimately see cached requests if they are resumed
             # from preemption (still prefill work) or are chunked-prefill
-            # continuations (>1 token scheduled).
+            # continuations (`num_computed < num_prompt_tokens` - still prefilling).
             if cached_reqs.num_reqs > 0:
                 any_decode_in_prefill = any(
                     req_id not in cached_reqs.resumed_req_ids
-                    and num_sched.get(req_id, 0) <= 1
+                    and input_batch.num_computed_tokens_cpu[
+                        input_batch.req_id_to_index[req_id]
+                    ]
+                    >= input_batch.num_prompt_tokens[
+                        input_batch.req_id_to_index[req_id]
+                    ]
                     for req_id in cached_reqs.req_ids
                 )
                 assert not any_decode_in_prefill, (
                     "Prefill batch should not include decode cached requests "
-                    "(cached req_id that is neither resumed nor chunked-prefill)."
+                    "(cached req_id that has finished its prompt)."
                 )
 
             # num_computed_tokens for each request is the input position
@@ -2095,11 +2101,11 @@ class TTModelRunner:
         if not is_decode and model_input.prompt_lens is not None:
             lane_batch = self.lane_batch
             prompt_lens = np.asarray(model_input.prompt_lens)
-            total_tokens = np.array(
-                [lane_batch.num_tokens[row] for row in scheduled_rows],
+            num_prompt_tokens = np.array(
+                [lane_batch.num_prompt_tokens[row] for row in scheduled_rows],
                 dtype=np.int64,
             )
-            intermediate_mask = prompt_lens < total_tokens
+            intermediate_mask = prompt_lens < num_prompt_tokens
 
             if intermediate_mask.any():
                 num_rows = len(scheduled_rows)
@@ -2288,8 +2294,8 @@ class TTModelRunner:
         if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
             num_reqs = self.input_batch.num_reqs
             prompt_lens = np.asarray(fwd.model_input.prompt_lens)
-            total_tokens = self.input_batch.num_tokens[:num_reqs]
-            intermediate_mask = prompt_lens < total_tokens
+            num_prompt_tokens = self.input_batch.num_prompt_tokens[:num_reqs]
+            intermediate_mask = prompt_lens < num_prompt_tokens
             if intermediate_mask.any():
                 # Apply sampled tokens to state only for final-chunk requests.
                 final_indices = np.where(~intermediate_mask)[0]

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -51,6 +51,7 @@ from vllm_tt_plugin.input_batch import (
     TTLaneInputBatch,
     apply_cached_req_state_update,
     build_cached_request_state,
+    clone_torch_generator,
 )
 from vllm_tt_plugin.lane_scheduler import get_tt_step_plan
 from vllm_tt_plugin.loader import TTModelLoader
@@ -804,6 +805,31 @@ class TTModelRunner:
             enable_log_probs=num_logprobs >= 0,
         )
 
+    @staticmethod
+    def _build_host_generators(
+        input_batch: InputBatch,
+        req_indices: list[int],
+        intermediate_prefill_mask: torch.Tensor | None,
+    ) -> dict[int, torch.Generator]:
+        intermediate_rows = (
+            set(intermediate_prefill_mask.nonzero().view(-1).tolist())
+            if intermediate_prefill_mask is not None
+            else set()
+        )
+        generators: dict[int, torch.Generator] = {}
+        rows_to_advance: list[int] = []
+        for local_row, batch_row in enumerate(req_indices):
+            generator = input_batch.sampling.generators.get(batch_row)
+            if generator is None:
+                continue
+            if local_row in intermediate_rows:
+                generators[local_row] = clone_torch_generator(generator)
+            else:
+                generators[local_row] = generator
+                rows_to_advance.append(batch_row)
+        input_batch.advance_generators(rows_to_advance)
+        return generators
+
     def _prepare_model_inputs(
         self,
         scheduler_output: SchedulerOutput,
@@ -908,6 +934,7 @@ class TTModelRunner:
             or has_chunked_continuation
         )
         sample_params = input_batch.sampling
+        intermediate_prefill_mask: torch.Tensor | None = None
         if is_prompt:
             # NOTE: In SchedulerOutput, "cached" means "request data already
             # cached on the worker", not necessarily "decode". During a prefill
@@ -948,6 +975,9 @@ class TTModelRunner:
                 dtype=np.int64,
             )
             prompt_lens = input_positions + chunk_lens
+            intermediate_prefill_mask = torch.from_numpy(
+                prompt_lens < input_batch.num_tokens[req_indices]
+            )
             max_prefill_tokens = int(max(prompt_lens))
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
@@ -1043,6 +1073,17 @@ class TTModelRunner:
             is_decode=not is_prompt,
             has_structured_outputs=has_structured,
         )
+        if is_prompt and (
+            intermediate_prefill_mask.any()
+            or (
+                self.tt_data_parallel_size > 1
+                and self.scheduler_config.enable_chunked_prefill
+            )
+        ):
+            # A gathered prefill can switch to host sampling when another rank
+            # has an intermediate chunk, so every rank needs host generator
+            # state available before inputs are gathered.
+            perform_device_sampling = False
 
         # Populate prompt_tokens and output_tokens if penalties are needed
         # (decode only).
@@ -1110,27 +1151,11 @@ class TTModelRunner:
         # local batch, so the host sampler reuses them as-is.
         logitsprocs = input_batch.sampling.logitsprocs
 
-        generators = dict()
+        generators: dict[int, torch.Generator] = {}
         if not perform_device_sampling:
-            # Re-key generators (req_index -> Generator) to lane-local rows.
-            # The values are the same Generator objects advanced just below, so
-            # advancing via the shared ``input_batch`` keeps them in step.
-            src_generators = input_batch.sampling.generators
-            generators = {
-                local: src_generators[g]
-                for local, g in enumerate(req_indices)
-                if g in src_generators
-            }
-            # Technically this advances the generator before it is copied,
-            # but it's ok because this happens consistently.
-            #
-            # Each generator belongs to exactly one request (one lane), so we
-            # advance only this build's generators. Non-DP / gathered-DP build
-            # the whole batch once per step, so all generators advance exactly
-            # once; lane builds run once per lane, and passing the lane's
-            # ``req_indices`` keeps each generator advancing exactly once per
-            # step instead of once per lane.
-            input_batch.advance_generators(req_indices)
+            generators = self._build_host_generators(
+                input_batch, req_indices, intermediate_prefill_mask
+            )
             # NOTE: Our sampling paths are different between host and device.
             # Whether a request is sampled on device or host
             # depends also on other requests in the batch.
@@ -1163,6 +1188,7 @@ class TTModelRunner:
             max_num_logprobs=[input_batch.max_num_logprobs],
             logitsprocs_list=[logitsprocs],
             generators_list=[generators],
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
 
     def build_model_input(
@@ -1539,6 +1565,7 @@ class TTModelRunner:
         max_num_logprobs: list[int | None] = []
         generators_list: list[dict[int, torch.Generator]] = []
         slot_remap = None
+        intermediate_prefill_mask = None
 
         if is_decode and isinstance(inputs, dict):
             # For decode, given gathered flattened tensors from all DP ranks.
@@ -1717,6 +1744,7 @@ class TTModelRunner:
             seed_list: list[torch.Tensor] = []
             num_logprobs_list: list[torch.Tensor] = []
             enable_log_probs_list: list[torch.Tensor] = []
+            intermediate_prefill_masks: list[torch.Tensor] = []
             reset_batch = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
@@ -1777,6 +1805,13 @@ class TTModelRunner:
                     seed_list.append(sp.seed)
                     num_logprobs_list.append(sp.num_logprobs)
                     enable_log_probs_list.append(sp.enable_log_probs)
+                    if mi.intermediate_prefill_mask is None:
+                        intermediate_prefill_masks.append(
+                            torch.zeros(toks.shape[0], dtype=torch.bool)
+                        )
+                    else:
+                        assert mi.intermediate_prefill_mask.shape[0] == toks.shape[0]
+                        intermediate_prefill_masks.append(mi.intermediate_prefill_mask)
 
                 # We know it's not a list here before concatenation
                 unpadded_batch_size: int = (
@@ -1822,6 +1857,7 @@ class TTModelRunner:
             seed = torch.cat(seed_list, dim=0)
             num_logprobs = torch.cat(num_logprobs_list, dim=0)
             enable_log_probs = torch.cat(enable_log_probs_list, dim=0)
+            intermediate_prefill_mask = torch.cat(intermediate_prefill_masks, dim=0)
 
         else:
             # Gathered-DP decode passes a dict (handled above) and prefill a
@@ -1946,6 +1982,7 @@ class TTModelRunner:
             logitsprocs_list=logitsprocs_list,
             generators_list=generators_list,
             prefill_empty_slots=None,
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
         return merged
 
@@ -2280,6 +2317,7 @@ class TTModelRunner:
         sampled_token_ids: torch.Tensor,
         logprobs: list | None,
         intermediate_mask: np.ndarray,
+        req_id_to_index: dict[str, int] | None = None,
     ) -> ModelRunnerOutput:
         """Builds output with ``[]`` for intermediate, ``[tokens]`` for final chunks."""
         final_idx_np = np.where(~intermediate_mask)[0]
@@ -2300,7 +2338,11 @@ class TTModelRunner:
 
         return ModelRunnerOutput(
             req_ids=req_ids,
-            req_id_to_index={r_id: idx for idx, r_id in enumerate(req_ids)},
+            req_id_to_index=(
+                dict(req_id_to_index)
+                if req_id_to_index is not None
+                else {r_id: idx for idx, r_id in enumerate(req_ids)}
+            ),
             sampled_token_ids=sampled_token_id_lists,
             logprobs=logprobs,
             prompt_logprobs_dict=dict.fromkeys(req_ids, None),
@@ -2585,6 +2627,7 @@ class TTModelRunner:
         int,
         int,
         int,
+        torch.Tensor | None,
         list[str],
         dict[str, int],
     ]:
@@ -2598,6 +2641,7 @@ class TTModelRunner:
         reset_batch = 0
         can_sample_device = 1
         needs_logprobs = 0
+        intermediate_prefill_mask = None
         req_ids: list[str] = []
         req_id_to_index: dict[str, int] = {}
         if scheduler_output is not None:
@@ -2609,6 +2653,7 @@ class TTModelRunner:
                 max_num_logprobs = model_input.max_num_logprobs[0]
                 # max_num_logprobs=0 still requests the sampled token's logprob.
                 needs_logprobs = int(max_num_logprobs is not None)
+                intermediate_prefill_mask = model_input.intermediate_prefill_mask
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
@@ -2624,6 +2669,7 @@ class TTModelRunner:
             reset_batch,
             can_sample_device,
             needs_logprobs,
+            intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
         )
@@ -2665,6 +2711,7 @@ class TTModelRunner:
         logprobs_lists: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        intermediate_prefill_mask: torch.Tensor | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
@@ -2673,6 +2720,21 @@ class TTModelRunner:
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
+        if intermediate_prefill_mask is not None:
+            intermediate_mask = intermediate_prefill_mask[:num_reqs]
+            if intermediate_mask.any():
+                output_req_ids = (
+                    list(req_ids)
+                    if req_ids is not None
+                    else list(self.input_batch.req_ids[:num_reqs])
+                )
+                return self._build_chunked_prefill_output(
+                    req_ids=output_req_ids,
+                    sampled_token_ids=sampled_token_ids,
+                    logprobs=logprobs_lists,
+                    intermediate_mask=intermediate_mask.cpu().numpy(),
+                    req_id_to_index=req_id_to_index,
+                )
         return self.apply_and_build_runner_output(
             sampled_token_ids,
             logprobs_lists,
@@ -2726,7 +2788,14 @@ class TTModelRunner:
             def _take(tensor: torch.Tensor, _rows: torch.Tensor = rows) -> torch.Tensor:
                 return tensor[_rows]
 
-            if not perform_device_sampling:
+            if (
+                not is_decode
+                and model_input.intermediate_prefill_mask is not None
+                and bool(model_input.intermediate_prefill_mask[rows].all())
+            ):
+                next_token_ids = torch.zeros(sz, dtype=torch.int32)
+                logprobs_per_dp.append(None)
+            elif not perform_device_sampling:
                 logits = tt_out[rows, -1, :]
 
                 grammar_bitmask = model_input.grammar_bitmask[dp_rank]

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -2097,11 +2097,11 @@ class TTModelRunner:
         if not is_decode and model_input.prompt_lens is not None:
             lane_batch = self.lane_batch
             prompt_lens = np.asarray(model_input.prompt_lens)
-            num_prompt_tokens = np.array(
-                [lane_batch.num_prompt_tokens[row] for row in scheduled_rows],
+            num_tokens = np.array(
+                [lane_batch.num_tokens[row] for row in scheduled_rows],
                 dtype=np.int64,
             )
-            intermediate_mask = prompt_lens < num_prompt_tokens
+            intermediate_mask = prompt_lens < num_tokens
 
             if intermediate_mask.any():
                 return self._build_chunked_prefill_output(
@@ -2260,8 +2260,8 @@ class TTModelRunner:
         if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
             num_reqs = self.input_batch.num_reqs
             prompt_lens = np.asarray(fwd.model_input.prompt_lens)
-            num_prompt_tokens = self.input_batch.num_prompt_tokens[:num_reqs]
-            intermediate_mask = prompt_lens < num_prompt_tokens
+            num_tokens = self.input_batch.num_tokens[:num_reqs]
+            intermediate_mask = prompt_lens < num_tokens
 
             if intermediate_mask.any():
                 output_req_ids = list(self.input_batch.req_ids[:num_reqs])

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -2094,10 +2094,6 @@ class TTModelRunner:
         # the canonical merged output order.
         req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
 
-        # region Lane-DP prefill contract
-        # Chunked prefill in lane mode: intermediate chunks produce no valid
-        # output. Same contract as the non-DP path: return `[]` for those
-        # requests and skip applying their tokens to state.
         if not is_decode and model_input.prompt_lens is not None:
             lane_batch = self.lane_batch
             prompt_lens = np.asarray(model_input.prompt_lens)
@@ -2108,36 +2104,12 @@ class TTModelRunner:
             intermediate_mask = prompt_lens < num_prompt_tokens
 
             if intermediate_mask.any():
-                num_rows = len(scheduled_rows)
-                final_indices = np.where(~intermediate_mask)[0]
-                if len(final_indices) > 0:
-                    idx_tensor = torch.from_numpy(final_indices.astype(np.int64))
-                    final_tokens = sampled[idx_tensor]
-                    final_req_ids = [req_ids[int(i)] for i in final_indices]
-                    self._apply_sampled_tokens_to_state(
-                        final_tokens, req_ids=final_req_ids
-                    )
-
-                sampled_np = sampled.view(num_rows).numpy()
-                if sampled_np.dtype != np.int32:
-                    sampled_np = sampled_np.astype(np.int32, copy=False)
-
-                sampled_token_id_lists: list[list[int]] = []
-                for i in range(num_rows):
-                    if intermediate_mask[i]:
-                        sampled_token_id_lists.append([])
-                    else:
-                        sampled_token_id_lists.append([int(sampled_np[i])])
-
-                return ModelRunnerOutput(
+                return self._build_chunked_prefill_output(
                     req_ids=req_ids,
-                    req_id_to_index={rid: idx for idx, rid in enumerate(req_ids)},
-                    sampled_token_ids=sampled_token_id_lists,
+                    sampled_token_ids=sampled,
                     logprobs=logprobs,
-                    prompt_logprobs_dict=dict.fromkeys(req_ids, None),
-                    pooler_output=[],
+                    intermediate_mask=intermediate_mask,
                 )
-        # endregion
 
         return self.apply_and_build_runner_output(sampled, logprobs, req_ids=req_ids)
 
@@ -2283,63 +2255,57 @@ class TTModelRunner:
         sampled_token_ids_per_dp, logprobs_per_dp = self._sample_sync_forward(fwd)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
+        logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
 
-        # region Non-DP prefill contract
-        # Chunked prefill: intermediate chunks (non-final) write KV but
-        # produce no valid output token.  Per the upstream scheduler contract
-        # (`Scheduler._update_request_with_output`), the model runner must return
-        # empty token ids (`[]`) for partial-prefill requests.  We also skip
-        # applying the spurious sampled token to persistent state for those
-        # positions.
         if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
             num_reqs = self.input_batch.num_reqs
             prompt_lens = np.asarray(fwd.model_input.prompt_lens)
             num_prompt_tokens = self.input_batch.num_prompt_tokens[:num_reqs]
             intermediate_mask = prompt_lens < num_prompt_tokens
+
             if intermediate_mask.any():
-                # Apply sampled tokens to state only for final-chunk requests.
-                final_indices = np.where(~intermediate_mask)[0]
-                if len(final_indices) > 0:
-                    idx_tensor = torch.from_numpy(final_indices.astype(np.int64))
-                    final_tokens = sampled_token_ids[idx_tensor]
-                    final_req_ids = [
-                        self.input_batch.req_ids[int(i)] for i in final_indices
-                    ]
-                    self._apply_sampled_tokens_to_state(
-                        final_tokens, req_ids=final_req_ids
-                    )
-
-                # Build output: [] for intermediate chunks, [token] for final.
-                sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
-                if sampled_token_ids_np.dtype != np.int32:
-                    sampled_token_ids_np = sampled_token_ids_np.astype(
-                        np.int32, copy=False
-                    )
-
-                sampled_token_id_lists: list[list[int]] = []
-                for i in range(num_reqs):
-                    if intermediate_mask[i]:
-                        sampled_token_id_lists.append([])
-                    else:
-                        sampled_token_id_lists.append([int(sampled_token_ids_np[i])])
-
-                logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
                 output_req_ids = list(self.input_batch.req_ids[:num_reqs])
-
-                return ModelRunnerOutput(
+                return self._build_chunked_prefill_output(
                     req_ids=output_req_ids,
-                    req_id_to_index={
-                        rid: idx for idx, rid in enumerate(output_req_ids)
-                    },
-                    sampled_token_ids=sampled_token_id_lists,
+                    sampled_token_ids=sampled_token_ids,
                     logprobs=logprobs,
-                    prompt_logprobs_dict=dict.fromkeys(output_req_ids, None),
-                    pooler_output=[],
+                    intermediate_mask=intermediate_mask,
                 )
-        # endregion
 
-        logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
         return self.apply_and_build_runner_output(sampled_token_ids, logprobs)
+
+    def _build_chunked_prefill_output(
+        self,
+        req_ids: list[str],
+        sampled_token_ids: torch.Tensor,
+        logprobs: list | None,
+        intermediate_mask: np.ndarray,
+    ) -> ModelRunnerOutput:
+        """Builds output with ``[]`` for intermediate, ``[tokens]`` for final chunks."""
+        final_idx_np = np.where(~intermediate_mask)[0]
+        if final_idx_np.shape[0] > 0:
+            final_idx_tensor = torch.from_numpy(final_idx_np.astype(np.int64))
+            final_tokens = sampled_token_ids[final_idx_tensor]
+            final_req_ids = [req_ids[int(i)] for i in final_idx_np]
+            self._apply_sampled_tokens_to_state(final_tokens, req_ids=final_req_ids)
+
+        num_reqs = len(req_ids)
+        sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+        if sampled_token_ids_np.dtype != np.int32:
+            sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
+        sampled_token_id_lists = [
+            [] if intermediate_mask[i] else [int(sampled_token_ids_np[i])]
+            for i in range(num_reqs)
+        ]
+
+        return ModelRunnerOutput(
+            req_ids=req_ids,
+            req_id_to_index={r_id: idx for idx, r_id in enumerate(req_ids)},
+            sampled_token_ids=sampled_token_id_lists,
+            logprobs=logprobs,
+            prompt_logprobs_dict=dict.fromkeys(req_ids, None),
+            pooler_output=[],
+        )
 
     def sample_tokens(
         self, grammar_output: GrammarOutput | None

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -2087,6 +2087,52 @@ class TTModelRunner:
         # ``scheduled_rows`` are persistent slots; their req_ids in row order are
         # the canonical merged output order.
         req_ids = [self.lane_batch.req_ids[row] for row in scheduled_rows]
+
+        # region Lane-DP prefill contract
+        # Chunked prefill in lane mode: intermediate chunks produce no valid
+        # output. Same contract as the non-DP path: return `[]` for those
+        # requests and skip applying their tokens to state.
+        if not is_decode and model_input.prompt_lens is not None:
+            lane_batch = self.lane_batch
+            prompt_lens = np.asarray(model_input.prompt_lens)
+            total_tokens = np.array(
+                [lane_batch.num_tokens[row] for row in scheduled_rows],
+                dtype=np.int64,
+            )
+            intermediate_mask = prompt_lens < total_tokens
+
+            if intermediate_mask.any():
+                num_rows = len(scheduled_rows)
+                final_indices = np.where(~intermediate_mask)[0]
+                if len(final_indices) > 0:
+                    idx_tensor = torch.from_numpy(final_indices.astype(np.int64))
+                    final_tokens = sampled[idx_tensor]
+                    final_req_ids = [req_ids[int(i)] for i in final_indices]
+                    self._apply_sampled_tokens_to_state(
+                        final_tokens, req_ids=final_req_ids
+                    )
+
+                sampled_np = sampled.view(num_rows).numpy()
+                if sampled_np.dtype != np.int32:
+                    sampled_np = sampled_np.astype(np.int32, copy=False)
+
+                sampled_token_id_lists: list[list[int]] = []
+                for i in range(num_rows):
+                    if intermediate_mask[i]:
+                        sampled_token_id_lists.append([])
+                    else:
+                        sampled_token_id_lists.append([int(sampled_np[i])])
+
+                return ModelRunnerOutput(
+                    req_ids=req_ids,
+                    req_id_to_index={rid: idx for idx, rid in enumerate(req_ids)},
+                    sampled_token_ids=sampled_token_id_lists,
+                    logprobs=logprobs,
+                    prompt_logprobs_dict=dict.fromkeys(req_ids, None),
+                    pooler_output=[],
+                )
+        # endregion
+
         return self.apply_and_build_runner_output(sampled, logprobs, req_ids=req_ids)
 
     @torch.no_grad()
@@ -2231,6 +2277,61 @@ class TTModelRunner:
         sampled_token_ids_per_dp, logprobs_per_dp = self._sample_sync_forward(fwd)
         sampled_token_ids = sampled_token_ids_per_dp[0]
         logprobs_tensors = logprobs_per_dp[0] if logprobs_per_dp else None
+
+        # region Non-DP prefill contract
+        # Chunked prefill: intermediate chunks (non-final) write KV but
+        # produce no valid output token.  Per the upstream scheduler contract
+        # (`Scheduler._update_request_with_output`), the model runner must return
+        # empty token ids (`[]`) for partial-prefill requests.  We also skip
+        # applying the spurious sampled token to persistent state for those
+        # positions.
+        if not fwd.is_decode and fwd.model_input.prompt_lens is not None:
+            num_reqs = self.input_batch.num_reqs
+            prompt_lens = np.asarray(fwd.model_input.prompt_lens)
+            total_tokens = self.input_batch.num_tokens[:num_reqs]
+            intermediate_mask = prompt_lens < total_tokens
+            if intermediate_mask.any():
+                # Apply sampled tokens to state only for final-chunk requests.
+                final_indices = np.where(~intermediate_mask)[0]
+                if len(final_indices) > 0:
+                    idx_tensor = torch.from_numpy(final_indices.astype(np.int64))
+                    final_tokens = sampled_token_ids[idx_tensor]
+                    final_req_ids = [
+                        self.input_batch.req_ids[int(i)] for i in final_indices
+                    ]
+                    self._apply_sampled_tokens_to_state(
+                        final_tokens, req_ids=final_req_ids
+                    )
+
+                # Build output: [] for intermediate chunks, [token] for final.
+                sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
+                if sampled_token_ids_np.dtype != np.int32:
+                    sampled_token_ids_np = sampled_token_ids_np.astype(
+                        np.int32, copy=False
+                    )
+
+                sampled_token_id_lists: list[list[int]] = []
+                for i in range(num_reqs):
+                    if intermediate_mask[i]:
+                        sampled_token_id_lists.append([])
+                    else:
+                        sampled_token_id_lists.append([int(sampled_token_ids_np[i])])
+
+                logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
+                output_req_ids = list(self.input_batch.req_ids[:num_reqs])
+
+                return ModelRunnerOutput(
+                    req_ids=output_req_ids,
+                    req_id_to_index={
+                        rid: idx for idx, rid in enumerate(output_req_ids)
+                    },
+                    sampled_token_ids=sampled_token_id_lists,
+                    logprobs=logprobs,
+                    prompt_logprobs_dict=dict.fromkeys(output_req_ids, None),
+                    pooler_output=[],
+                )
+        # endregion
+
         logprobs = logprobs_tensors.tolists() if logprobs_tensors else None
         return self.apply_and_build_runner_output(sampled_token_ids, logprobs)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -554,6 +554,11 @@ class TTPlatform(Platform):
         ):
             sched.max_num_batched_tokens = vllm_config.model_config.max_model_len
 
+        # Never split a chunk boundary inside an image's token span. The vision encoder
+        # produces embeddings for the full image atomically; splitting corrupts the
+        # embedding/position alignment.
+        sched.disable_chunked_mm_input = True
+
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -538,6 +538,22 @@ class TTPlatform(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
 
+        # NOTE: Token-chunked prefill: upstream vLLM defaults enable_chunked_prefill
+        # to True and `max_num_batched_tokens` to 2048. The scheduler and model
+        # runner support chunking, but most Metal-side models have only been
+        # validated with full-prompt prefill. Preserve safe defaults by
+        # bumping `max_num_batched_tokens` to `max_model_len` when the user did
+        # not explicitly set it; this makes every prompt fit in a single
+        # step (no chunking). Users who want chunking (e.g., Gemma 4 long-
+        # context) opt in via `--max_num_batched_tokens <budget>`.
+        sched = vllm_config.scheduler_config
+        if (
+            sched.enable_chunked_prefill
+            and sched.max_num_batched_tokens == sched.DEFAULT_MAX_NUM_BATCHED_TOKENS
+            and sched.max_num_batched_tokens < vllm_config.model_config.max_model_len
+        ):
+            sched.max_num_batched_tokens = vllm_config.model_config.max_model_len
+
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -43,7 +43,38 @@ _GALAXY_GENERATOR_VERSIONS = {
 }
 
 # TT model types that have been validated with real chunked prefill.
-_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4"}
+_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4", "gemma4_unified"}
+
+
+def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
+    """Restricts token-chunked prefill to model types Metal has validated."""
+    scheduler_config = vllm_config.scheduler_config
+    model_config = vllm_config.model_config
+    model_type = getattr(model_config.hf_config, "model_type", None)
+
+    if (
+        scheduler_config.enable_chunked_prefill
+        and model_type not in _CHUNKED_PREFILL_MODEL_TYPES
+    ):
+        logger.info(
+            "Chunked prefill is not validated for `model_type=%s` on TT; disabling it.",
+            model_type,
+        )
+
+        max_num_batched_tokens = scheduler_config.max_num_batched_tokens
+        max_model_len = model_config.max_model_len
+        scheduler_config.enable_chunked_prefill = False
+
+        if max_num_batched_tokens < max_model_len:
+            logger.warning(
+                "`max_num_batched_tokens=%d < max_model_len=%d` with chunked prefill "
+                "disabled, bumping `max_num_batched_tokens` to match.",
+                max_num_batched_tokens,
+                max_model_len,
+            )
+
+            max_num_batched_tokens = max_model_len
+            scheduler_config.max_num_batched_tokens = max_num_batched_tokens
 
 
 def _galaxy_generator_version() -> str | None:
@@ -540,27 +571,9 @@ class TTPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
+        _apply_chunked_prefill_policy(vllm_config)
 
-        # NOTE: Token-chunked prefill: upstream vLLM defaults `enable_chunked_prefill`
-        # to True and `max_num_batched_tokens` to 2048. The scheduler and model
-        # runner support chunking, but most Metal-side models have only been
-        # validated with full-prompt prefill. Models that have been validated
-        # with real chunking keep the user/default budget as-is; all others get
-        # bumped to `max_model_len` so every prompt fits in one step (no
-        # chunking). Users can always override via `--max_num_batched_tokens`.
-        sched = vllm_config.scheduler_config
-        model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
-        if (
-            sched.enable_chunked_prefill
-            and model_type not in _CHUNKED_PREFILL_MODEL_TYPES
-            and sched.max_num_batched_tokens < vllm_config.model_config.max_model_len
-        ):
-            sched.max_num_batched_tokens = vllm_config.model_config.max_model_len
-
-        # Never split a chunk boundary inside an image's token span. The vision encoder
-        # produces embeddings for the full image atomically; splitting corrupts the
-        # embedding/position alignment.
-        sched.disable_chunked_mm_input = True
+        vllm_config.scheduler_config.disable_chunked_mm_input = True
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -42,6 +42,9 @@ _GALAXY_GENERATOR_VERSIONS = {
     "TT_QWEN3_TEXT_VER": "qwen3_32b_galaxy",
 }
 
+# TT model types that have been validated with real chunked prefill.
+_CHUNKED_PREFILL_MODEL_TYPES = {"gemma4"}
+
 
 def _galaxy_generator_version() -> str | None:
     """Return the active Galaxy-generator model version, or None.
@@ -538,18 +541,18 @@ class TTPlatform(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
 
-        # NOTE: Token-chunked prefill: upstream vLLM defaults enable_chunked_prefill
+        # NOTE: Token-chunked prefill: upstream vLLM defaults `enable_chunked_prefill`
         # to True and `max_num_batched_tokens` to 2048. The scheduler and model
         # runner support chunking, but most Metal-side models have only been
-        # validated with full-prompt prefill. Preserve safe defaults by
-        # bumping `max_num_batched_tokens` to `max_model_len` when the user did
-        # not explicitly set it; this makes every prompt fit in a single
-        # step (no chunking). Users who want chunking (e.g., Gemma 4 long-
-        # context) opt in via `--max_num_batched_tokens <budget>`.
+        # validated with full-prompt prefill. Models that have been validated
+        # with real chunking keep the user/default budget as-is; all others get
+        # bumped to `max_model_len` so every prompt fits in one step (no
+        # chunking). Users can always override via `--max_num_batched_tokens`.
         sched = vllm_config.scheduler_config
+        model_type = getattr(vllm_config.model_config.hf_config, "model_type", None)
         if (
             sched.enable_chunked_prefill
-            and sched.max_num_batched_tokens == sched.DEFAULT_MAX_NUM_BATCHED_TOKENS
+            and model_type not in _CHUNKED_PREFILL_MODEL_TYPES
             and sched.max_num_batched_tokens < vllm_config.model_config.max_model_len
         ):
             sched.max_num_batched_tokens = vllm_config.model_config.max_model_len

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -537,27 +537,6 @@ class TTPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
-        if vllm_config.scheduler_config.enable_chunked_prefill:
-            logger.info("Chunked prefill is not yet supported for TT backend")
-            vllm_config.scheduler_config.enable_chunked_prefill = False
-            # vLLM does this bump silently earlier
-            # if chunked prefill is already disabled,
-            # and max_num_batched_tokens is not explicitly set.
-            # We can't know if it was specified
-            # or the default, hence the warning.
-            if (
-                vllm_config.scheduler_config.max_num_batched_tokens
-                < vllm_config.model_config.max_model_len
-            ):
-                logger.warning(
-                    "max_num_batched_tokens=%d < max_model_len=%d with chunked prefill "
-                    "disabled, bumping max_num_batched_tokens to match.",
-                    vllm_config.scheduler_config.max_num_batched_tokens,
-                    vllm_config.model_config.max_model_len,
-                )
-                vllm_config.scheduler_config.max_num_batched_tokens = (
-                    vllm_config.model_config.max_model_len
-                )
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -52,29 +52,31 @@ def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
     model_config = vllm_config.model_config
     model_type = getattr(model_config.hf_config, "model_type", None)
 
-    if (
-        scheduler_config.enable_chunked_prefill
-        and model_type not in _CHUNKED_PREFILL_MODEL_TYPES
-    ):
-        logger.info(
-            "Chunked prefill is not validated for `model_type=%s` on TT; disabling it.",
-            model_type,
-        )
-
-        max_num_batched_tokens = scheduler_config.max_num_batched_tokens
-        max_model_len = model_config.max_model_len
-        scheduler_config.enable_chunked_prefill = False
-
-        if max_num_batched_tokens < max_model_len:
-            logger.warning(
-                "`max_num_batched_tokens=%d < max_model_len=%d` with chunked prefill "
-                "disabled, bumping `max_num_batched_tokens` to match.",
-                max_num_batched_tokens,
-                max_model_len,
+    if model_type not in _CHUNKED_PREFILL_MODEL_TYPES:
+        if scheduler_config.enable_chunked_prefill:
+            logger.info(
+                "Chunked prefill is not validated for `model_type=%s`; disabling it.",
+                model_type,
             )
+            scheduler_config.enable_chunked_prefill = False
 
-            max_num_batched_tokens = max_model_len
-            scheduler_config.max_num_batched_tokens = max_num_batched_tokens
+            max_num_batched_tokens = scheduler_config.max_num_batched_tokens
+            max_model_len = model_config.max_model_len
+            if max_num_batched_tokens < max_model_len:
+                logger.warning(
+                    "`max_num_batched_tokens=%d < max_model_len=%d` with "
+                    "chunked prefill "
+                    "disabled, bumping `max_num_batched_tokens` to match.",
+                    max_num_batched_tokens,
+                    max_model_len,
+                )
+
+                scheduler_config.max_num_batched_tokens = max_model_len
+
+        # The scheduler applies this threshold before checking
+        # ``enable_chunked_prefill``. Leaving it nonzero can still split a
+        # prefill despite the disabled flag.
+        scheduler_config.long_prefill_token_threshold = 0
 
 
 def _galaxy_generator_version() -> str | None:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -133,7 +133,7 @@ class TTScheduler(AsyncScheduler):
         try:
             result = super().schedule()
         finally:
-            self.running = pure_decodes + self.running
+            self.running.extend(pure_decodes)
             self.max_num_running_reqs = saved_max
         return result
 
@@ -158,6 +158,6 @@ class TTScheduler(AsyncScheduler):
                 saved_waiting.prepend_requests(self.waiting)
             self.waiting = saved_waiting
             if partial_prefills:
-                self.running = partial_prefills + self.running
+                self.running.extend(partial_prefills)
 
         return result

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -78,7 +78,7 @@ class TTScheduler(AsyncScheduler):
 
     def schedule(self) -> SchedulerOutput:
         has_pending_prefill = self._has_pending_prefill()
-        has_running = bool(self.running)
+        has_running = any(not r.is_prefill_chunk for r in self.running)
         mode = self._forced_mode
 
         if mode == TTSchedulingMode.PREFILL_ONLY:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from enum import Enum
-from typing import cast
 
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -33,7 +32,10 @@ class TTScheduler(AsyncScheduler):
     TT constraints:
     - No mixed prefill+decode batches: each batch is either all-prefill
       or all-decode.
-    - No chunked prefill: each prefill must be scheduled in full.
+    - Token-chunked prefill: a long prefill may be split across scheduler
+      steps.  After a partial chunk the request moves to ``running`` with
+      ``is_prefill_chunk=True``; subsequent steps schedule the next chunk
+      until the prompt is fully computed.
 
     Inherits from AsyncScheduler to get num_output_placeholders support.
     TT uses this scheduler in both sync and async execution modes:
@@ -49,8 +51,9 @@ class TTScheduler(AsyncScheduler):
     - ``TTSchedulingMode.PREFILL_ONLY`` forces prefill-only (and may return an
       empty batch when waiting is empty).
     - ``TTSchedulingMode.DEFAULT`` uses the default policy: prefer prefill
-      when waiting is non-empty, but fall back to decode-only if prefill
-      cannot admit any request and running decode requests exist.
+      when pending prefill work exists (waiting queue or partial-prefill
+      continuations), falling back to decode-only when prefill cannot make
+      progress and running decode requests exist.
     """
 
     waiting: RequestQueue
@@ -64,38 +67,47 @@ class TTScheduler(AsyncScheduler):
     def set_forced_mode(self, mode: TTSchedulingMode) -> None:
         self._forced_mode = mode
 
+    def _has_pending_prefill(self) -> bool:
+        """Whether any request needs prefill work.
+
+        True when the waiting queue is non-empty or any running request
+        is a partial-prefill continuation (``is_prefill_chunk`` set by the
+        base scheduler after the previous step).
+        """
+        return bool(self.waiting) or any(r.is_prefill_chunk for r in self.running)
+
     def schedule(self) -> SchedulerOutput:
-        has_waiting = bool(self.waiting)
+        has_pending_prefill = self._has_pending_prefill()
         has_running = bool(self.running)
         mode = self._forced_mode
 
         if mode == TTSchedulingMode.PREFILL_ONLY:
-            # If waiting is empty, this intentionally returns an empty batch.
             result = self._schedule_prefill_only()
             return self._finalize_scheduler_output(result)
         if mode == TTSchedulingMode.DECODE_ONLY:
-            if has_waiting:
-                # Hide waiting so base scheduler cannot admit prefill.
+            if has_pending_prefill:
+                # Hide waiting and partial-prefill continuations.
                 result = self._schedule_decode_only()
                 return self._finalize_scheduler_output(result)
-            # No waiting requests: base scheduler naturally runs decode-only.
+            # No pending prefill: base scheduler naturally runs decode-only.
             result = super().schedule()
             return self._finalize_scheduler_output(result)
 
         # Default mode:
-        # Prefer prefill whenever waiting is non-empty to admit new requests.
-        if has_waiting:
+        # Prefer prefill whenever there is pending prefill work - either new
+        # requests in the waiting queue or partial-prefill continuations in
+        # the running list.
+        if has_pending_prefill:
             prefill_result = self._schedule_prefill_only()
-            # If waiting is non-empty but prefill cannot be admitted (e.g. KV
-            # pressure and no chunked prefill), do not stall decode progress.
-            # Fall back to decode-only so running requests can advance and free
-            # capacity for later full-prefill admission.
+            # If prefill cannot make progress (e.g., KV pressure) but running
+            # decode requests exist, fall back to decode-only so they can
+            # advance and free capacity.
             if prefill_result.total_num_scheduled_tokens == 0 and has_running:
                 result = self._schedule_decode_only()
                 return self._finalize_scheduler_output(result)
             return self._finalize_scheduler_output(prefill_result)
 
-        # No waiting requests in default mode: run decode-only naturally.
+        # No pending prefill work: run decode-only naturally.
         result = super().schedule()
         return self._finalize_scheduler_output(result)
 
@@ -105,38 +117,47 @@ class TTScheduler(AsyncScheduler):
         return scheduler_output
 
     def _schedule_prefill_only(self) -> SchedulerOutput:
-        """Schedule only waiting (prefill) requests.
+        """Schedule prefill work: waiting requests + partial-prefill continuations.
 
-        Temporarily hides the running (decode) requests so the base
-        scheduler's running loop iterates zero times and only the
-        waiting loop executes.  Adjusts max_num_running_reqs so the
-        waiting loop respects the true capacity.
+        Hides running decode requests (``is_prefill_chunk=False``) so the base
+        scheduler's running loop only processes partial-prefill continuations and
+        the waiting loop admits new prefills.  Adjusts ``max_num_running_reqs`` to
+        account for hidden decode slots.
         """
-        saved_running = self.running
+        pure_decodes = [r for r in self.running if not r.is_prefill_chunk]
+        partial_prefills = [r for r in self.running if r.is_prefill_chunk]
+
         saved_max = self.max_num_running_reqs
-        self.running = cast(list[Request], [])
-        self.max_num_running_reqs = max(0, saved_max - len(saved_running))
+        self.running = partial_prefills
+        self.max_num_running_reqs = max(0, saved_max - len(pure_decodes))
         try:
             result = super().schedule()
         finally:
-            self.running = saved_running + self.running
+            self.running = pure_decodes + self.running
             self.max_num_running_reqs = saved_max
         return result
 
     def _schedule_decode_only(self) -> SchedulerOutput:
-        """Schedule only running (decode) requests.
+        """Schedule only running decode requests.
 
-        Temporarily hides the waiting queue so the base scheduler's
-        waiting loop is a no-op.  Any requests that get preempted
-        during decode scheduling are merged back into the original
-        waiting queue afterwards.
+        Hides the waiting queue **and** any partial-prefill continuations
+        so the base scheduler only sees decode-phase requests.  Preempted
+        requests are merged back into the original waiting queue afterwards.
         """
+        partial_prefills = [r for r in self.running if r.is_prefill_chunk]
+
         saved_waiting = self.waiting
         self.waiting = create_request_queue(self.policy)
+        if partial_prefills:
+            self.running = [r for r in self.running if not r.is_prefill_chunk]
+
         try:
             result = super().schedule()
         finally:
             if self.waiting:
                 saved_waiting.prepend_requests(self.waiting)
             self.waiting = saved_waiting
+            if partial_prefills:
+                self.running = partial_prefills + self.running
+
         return result

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/scheduler.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
 from enum import Enum
+from typing import ClassVar
 
 from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -10,6 +12,59 @@ from vllm.v1.request import Request
 from vllm_tt_plugin.logger import init_tt_logger
 
 logger = init_tt_logger(__name__)
+
+
+@dataclass
+class _PendingOutputs:
+    """Counts a request's decode tokens that are still in the pipeline.
+
+    Async scheduling starts new decode steps before the tokens from earlier
+    steps have come back. If a request is preempted, it has to redo its prefill
+    from scratch, and we have to throw the tokens still in the pipeline away instead
+    of adding them to the output.
+
+    ``outstanding`` counts tokens that were scheduled but have not come back
+    yet. ``stale`` counts how many of those we have decided to throw away.
+    """
+
+    PENDING_ATTR: ClassVar[str] = "_tt_pending_outputs"
+
+    outstanding: int = 0
+    stale: int = 0
+
+    def record(self) -> None:
+        """Count one decode step; its token comes back a few steps later.
+
+        A step counts once even if it speculates several tokens, because it
+        still sends back a single output.
+        """
+        self.outstanding += 1
+
+    def discard_outstanding(self) -> None:
+        """On preempt, mark every token now in the pipeline to be thrown away."""
+        self.stale = self.outstanding
+
+    def is_next_stale(self) -> bool:
+        """Take the next returned token; True means throw it away.
+
+        Tokens come back in the order they were scheduled, so the stale ones
+        always arrive before any fresh token from after the preempt.
+        """
+        if not self.outstanding:
+            return False
+        self.outstanding -= 1
+        if not self.stale:
+            return False
+        self.stale -= 1
+        return True
+
+    @classmethod
+    def for_request(cls, request: Request) -> "_PendingOutputs":
+        pending = getattr(request, cls.PENDING_ATTR, None)
+        if pending is None:
+            pending = cls()
+            setattr(request, cls.PENDING_ATTR, pending)
+        return pending
 
 
 class TTSchedulingMode(Enum):
@@ -44,6 +99,8 @@ class TTScheduler(AsyncScheduler):
     - with async_scheduling=True, placeholders allow decode requests to be
       re-scheduled before update_from_output processes the previous step's
       results, enabling host/device overlap
+    - under async_scheduling, preemption invalidates that request's
+      scheduled-but-unreturned outputs (see ``_preempt_request``)
 
     Supports ``set_forced_mode`` for DP-gather coordination:
     - ``TTSchedulingMode.DECODE_ONLY`` forces decode-only (even if waiting
@@ -161,3 +218,53 @@ class TTScheduler(AsyncScheduler):
                 self.running.extend(partial_prefills)
 
         return result
+
+    def _preempt_request(self, request: Request, timestamp: float) -> None:
+        """Preempt a request and drop any decode tokens still in the pipeline.
+
+        The base class frees the request's KV cache and queues it to redo its
+        prefill. Under async scheduling, the tokens it already scheduled are
+        still on their way back; those were built on the now-freed cache, so we
+        mark them to be thrown away and reset the placeholder count so the base
+        scheduler treats the request as a fresh prefill.
+        """
+        super()._preempt_request(request, timestamp)
+
+        if not self.scheduler_config.async_scheduling:
+            return
+
+        _PendingOutputs.for_request(request).discard_outstanding()
+        request.num_output_placeholders = 0
+
+    def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
+        """After scheduling, count the decode tokens this step put in the pipeline.
+
+        Only decode steps produce a token to track; prefill chunks do not. This
+        running count is what lets a later preempt know how many in-flight
+        tokens it has to throw away.
+        """
+        super()._update_after_schedule(scheduler_output)
+
+        if self.scheduler_config.async_scheduling:
+            for req_id in scheduler_output.num_scheduled_tokens:
+                request = self.requests[req_id]
+                if not request.is_prefill_chunk:
+                    _PendingOutputs.for_request(request).record()
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int]
+    ) -> tuple[list[int], bool]:
+        """Add a returned token to the request, unless a preempt invalidated it.
+
+        When a token comes back for a request that was preempted while the token
+        was in the pipeline, adding it would corrupt the output, so we throw it
+        away here instead of handing it to the base class.
+        """
+        if not self.scheduler_config.async_scheduling:
+            return super()._update_request_with_output(request, new_token_ids)
+
+        if _PendingOutputs.for_request(request).is_next_stale():
+            request.discard_latest_async_tokens = False
+            return [], False
+
+        return super()._update_request_with_output(request, new_token_ids)

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -374,6 +374,7 @@ class TTWorker(WorkerBase):
         int,
         int,
         int,
+        torch.Tensor | None,
         list[str],
         dict[str, int],
     ]:
@@ -381,7 +382,8 @@ class TTWorker(WorkerBase):
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, reset_batch, can_sample_device, needs_logprobs,
-        req_ids, req_id_to_index)`, where `local_input` is this rank's
+        intermediate_prefill_mask, req_ids, req_id_to_index)`, where
+        `local_input` is this rank's
         TT model input (or `None`) and the remaining fields are the
         per-rank metadata consumed by gathered-DP orchestration.
         """
@@ -476,6 +478,7 @@ class TTWorker(WorkerBase):
         logprobs_lists: Optional["LogprobsLists"] = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        intermediate_prefill_mask: torch.Tensor | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
@@ -487,6 +490,7 @@ class TTWorker(WorkerBase):
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            intermediate_prefill_mask=intermediate_prefill_mask,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/tests/test_dp_engine.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_engine.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-only tests for gathered-DP mode negotiation."""
+
+from types import SimpleNamespace
+
+import vllm_tt_plugin.engine as engine_module
+from vllm_tt_plugin.engine import TTDPEngineCoreProc
+from vllm_tt_plugin.scheduler import TTSchedulingMode
+
+
+def _core_with_scheduler(scheduler):
+    core = TTDPEngineCoreProc.__new__(TTDPEngineCoreProc)
+    core.scheduler = scheduler
+    core.dp_group = object()
+    core.dlog = lambda *args, **kwargs: None
+    return core
+
+
+def test_dp_negotiation_prefers_running_prefill_continuation(monkeypatch):
+    scheduler = SimpleNamespace(
+        waiting=[],
+        running=[SimpleNamespace(is_prefill_chunk=True)],
+        max_num_running_reqs=1,
+    )
+    core = _core_with_scheduler(scheduler)
+
+    def all_reduce(tensor, *, op, group):
+        assert tensor.tolist() == [1]
+        assert op == engine_module.dist.ReduceOp.MAX
+        assert group is core.dp_group
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+
+    assert core._dp_negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
+    assert core._dp_gather_forced_mode == TTSchedulingMode.PREFILL_ONLY

--- a/plugins/vllm-tt-plugin/tests/test_lane_input_batch.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_input_batch.py
@@ -243,6 +243,50 @@ def test_apply_step_plan_finished_request_releases_slot():
     assert b.occupied_rows() == []
 
 
+def test_lane_prefill_input_ends_at_scheduled_chunk_boundary():
+    from vllm_tt_plugin.lane_scheduler import TTStepPlan
+
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    batch = _lane_batch(num_lanes=1, per_lane=1)
+    request = _make_req(
+        "request",
+        list(range(8)),
+        [],
+        dict(temperature=0.0),
+    )
+    row = _add_to_lane(batch, request, lane=0)
+    batch.num_computed_tokens_cpu[row] = 2
+
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.num_scheduled_tokens = {"request": 1}
+    scheduler_output.total_num_scheduled_tokens = 1
+    plan = TTStepPlan(
+        is_decode=False,
+        capacity=1,
+        scheduled_req_ids=("request",),
+        scheduled_rows=(row,),
+        input_rows=(row,),
+        req_id_to_row={"request": row},
+        batch_size_per_dp=(1,),
+        prefill_empty_slots=(row,),
+    )
+    runner = SimpleNamespace(
+        max_num_blocks_per_req=MAX_MODEL_LEN // BLOCK,
+        _block_tables_per_layer=lambda _: None,
+        check_perform_device_sampling=lambda **_: True,
+        model_config=SimpleNamespace(is_multimodal_model=False),
+        requests={"request": request},
+    )
+
+    model_input = batch.build_model_input(runner, scheduler_output, None, plan)
+
+    assert model_input.input_positions.tolist() == [2]
+    assert model_input.prompt_lens.tolist() == [3]
+    assert model_input.input_tokens.tolist() == [[0, 1, 2]]
+    assert model_input.perform_device_sampling is False
+
+
 def test_lane_full_raises():
     b = _lane_batch(num_lanes=1, per_lane=2)
     _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.0)), 0)
@@ -475,6 +519,22 @@ def test_merged_sampling_metadata_filters_generators_to_scheduled_rows():
 
     assert set(metadata.generators) == {row4}
     assert metadata.generators[row4] is b.sampling.generators[row4]
+
+
+def test_merged_sampling_metadata_clones_intermediate_generators():
+    b = _lane_batch(num_lanes=1, per_lane=1, with_custom=False)
+    row = _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.7), seed=11), 0)
+    generator = b.sampling.generators[row]
+    before = generator.get_state().clone()
+
+    metadata = b.build_merged_sampling_metadata(
+        scheduled_rows=[row], non_sampling_rows=[row]
+    )
+
+    assert metadata.generators[row] is not generator
+    assert torch.equal(metadata.generators[row].get_state(), before)
+    Sampler()(torch.randn(1, VOCAB), metadata)
+    assert torch.equal(generator.get_state(), before)
 
 
 def test_scheduled_seeded_row_isolated_from_unscheduled_random_row():

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -144,7 +144,9 @@ def test_extract_output_device_prefill_returns_front_packed_tokens():
 def test_extract_output_host_decode_samples_full_slot_then_picks_rows():
     captured: dict = {}
     batch = _lane_batch()
-    batch.build_merged_sampling_metadata = lambda rows: None  # sampler ignores it
+    batch.build_merged_sampling_metadata = (
+        lambda rows, non_sampling_rows=None: None
+    )  # sampler ignores it
     runner = SimpleNamespace(host_sampler=_capturing_host_sampler(captured))
     # Full slot logits: row r's argmax is token r (vocab>=5).
     logits = torch.full((5, VOCAB), -10.0)
@@ -164,7 +166,7 @@ def test_extract_output_host_decode_samples_full_slot_then_picks_rows():
 def test_extract_output_host_prefill_scatters_logits_to_stable_rows():
     captured: dict = {}
     batch = _lane_batch()
-    batch.build_merged_sampling_metadata = lambda rows: None
+    batch.build_merged_sampling_metadata = lambda rows, non_sampling_rows=None: None
     runner = SimpleNamespace(host_sampler=_capturing_host_sampler(captured))
     # Prefill logits: one row per scheduled request (front-packed, plan order).
     prefill_logits = torch.full((2, VOCAB), -10.0)
@@ -188,6 +190,143 @@ def test_extract_output_host_prefill_scatters_logits_to_stable_rows():
     for gap in (0, 2, 3):
         assert torch.all(full[gap] == 0)  # unscheduled rows left empty
     assert sampled.tolist() == [[3], [6]]
+
+
+def test_extract_output_skips_all_intermediate_prefill_rows():
+    batch = _lane_batch()
+    runner = SimpleNamespace(
+        host_sampler=lambda *args, **kwargs: pytest.fail("sampler must not run")
+    )
+    model_input = SimpleNamespace(
+        perform_device_sampling=False,
+        grammar_bitmask=[None],
+        intermediate_prefill_mask=torch.tensor([True]),
+    )
+
+    sampled, logprobs = batch.extract_output(
+        runner,
+        torch.zeros((1, VOCAB)),
+        None,
+        model_input,
+        scheduled_rows=[0],
+        is_decode=False,
+    )
+
+    assert sampled.tolist() == [[0]]
+    assert logprobs is None
+
+
+def test_build_host_generators_preserves_intermediate_request_rng():
+    intermediate = torch.Generator().manual_seed(11)
+    final = torch.Generator().manual_seed(22)
+    intermediate_before = intermediate.get_state().clone()
+    final_before = final.get_state().clone()
+
+    class FakeInputBatch:
+        sampling = SimpleNamespace(generators={0: intermediate, 1: final})
+
+        def advance_generators(self, rows):
+            for row in rows:
+                torch.rand(1, generator=self.sampling.generators[row])
+
+    generators = TTModelRunner._build_host_generators(
+        FakeInputBatch(), [0, 1], torch.tensor([True, False])
+    )
+
+    assert generators[0] is not intermediate
+    assert torch.equal(generators[0].get_state(), intermediate_before)
+    assert generators[1] is final
+    assert torch.equal(intermediate.get_state(), intermediate_before)
+    assert not torch.equal(final.get_state(), final_before)
+
+
+def test_get_output_tokens_skips_all_intermediate_prefill_rows():
+    runner = SimpleNamespace(
+        host_sampler=lambda *args, **kwargs: pytest.fail("sampler must not run")
+    )
+    model_input = SimpleNamespace(intermediate_prefill_mask=torch.tensor([True]))
+
+    sampled, logprobs = TTModelRunner._get_output_tokens(
+        runner,
+        torch.zeros((1, 1, VOCAB)),
+        None,
+        SimpleNamespace(),
+        model_input,
+        [1],
+        False,
+        False,
+    )
+
+    assert sampled[0].tolist() == [[0]]
+    assert logprobs == [None]
+
+
+def test_apply_dp_result_suppresses_intermediate_prefill_rows():
+    captured: dict = {}
+    runner = SimpleNamespace(
+        _build_chunked_prefill_output=lambda **kwargs: captured.update(kwargs)
+        or "intermediate",
+        apply_and_build_runner_output=lambda *args, **kwargs: pytest.fail(
+            "intermediate rows must not be applied"
+        ),
+    )
+
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        torch.tensor([[17], [23]], dtype=torch.int32),
+        req_ids=["intermediate", "final"],
+        req_id_to_index={"intermediate": 0, "final": 1},
+        intermediate_prefill_mask=torch.tensor([True, False]),
+    )
+
+    assert output == "intermediate"
+    assert captured["sampled_token_ids"].tolist() == [[17], [23]]
+    assert captured["intermediate_mask"].tolist() == [True, False]
+
+
+def test_finish_lane_sync_suppresses_intermediate_prefill_output():
+    model_input = SimpleNamespace(prompt_lens=[3])
+
+    def extract_output(
+        runner, tt_out, tt_log_probs, model_input, scheduled_rows, *, is_decode
+    ):
+        assert is_decode is False
+        return torch.tensor([[42]], dtype=torch.int32), None
+
+    def unexpected_final_output(*args, **kwargs):
+        raise AssertionError("intermediate prefill must not emit a sampled token")
+
+    runner = SimpleNamespace(
+        _apply_grammar_to_input=lambda model_input,
+        grammar_output,
+        *,
+        lane_total: model_input,
+        lane_batch=SimpleNamespace(
+            extract_output=extract_output,
+            req_ids={0: "request"},
+            num_tokens=[8],
+        ),
+        apply_and_build_runner_output=unexpected_final_output,
+    )
+
+    def build_chunked_prefill_output(**kwargs):
+        return TTModelRunner._build_chunked_prefill_output(runner, **kwargs)
+
+    runner._build_chunked_prefill_output = build_chunked_prefill_output
+
+    output = TTModelRunner._finish_lane_sync(
+        runner,
+        None,
+        tt_out=object(),
+        tt_log_probs=None,
+        model_input=model_input,
+        scheduled_rows=[0],
+        is_decode=False,
+        lane_total=1,
+    )
+
+    assert output.req_ids == ["request"]
+    assert output.sampled_token_ids == [[]]
 
 
 # --------------------------------------------------------------------------

--- a/plugins/vllm-tt-plugin/tests/test_lane_scheduler.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_scheduler.py
@@ -32,9 +32,11 @@ class FakeLane:
     fallback.
     """
 
-    def __init__(self, waiting=0, running=0, pending_finished=()):
+    def __init__(self, waiting=0, running=0, partial_prefills=0, pending_finished=()):
         self.waiting = [object()] * waiting
-        self.running = [object()] * running
+        self.running = [
+            SimpleNamespace(is_prefill_chunk=False) for _ in range(running)
+        ] + [SimpleNamespace(is_prefill_chunk=True) for _ in range(partial_prefills)]
         self._pending_finished = set(pending_finished)
         self._mode = TTSchedulingMode.DEFAULT
         self.scheduled_modes: list[TTSchedulingMode] = []
@@ -50,9 +52,10 @@ class FakeLane:
         self._pending_finished = set()
         out = SchedulerOutput.make_empty()
         out.finished_req_ids = set(finished)
-        if self._mode == TTSchedulingMode.DECODE_ONLY and self.running:
-            out.num_scheduled_tokens = {f"dec-{id(self)}": len(self.running)}
-            out.total_num_scheduled_tokens = len(self.running)
+        pure_decodes = [r for r in self.running if not r.is_prefill_chunk]
+        if self._mode == TTSchedulingMode.DECODE_ONLY and pure_decodes:
+            out.num_scheduled_tokens = {f"dec-{id(self)}": len(pure_decodes)}
+            out.total_num_scheduled_tokens = len(pure_decodes)
         return out
 
     def update_from_output(self, scheduler_output, model_runner_output):
@@ -92,6 +95,12 @@ def test_negotiate_prefill_when_any_lane_wants_prefill():
 def test_negotiate_decode_when_no_lane_wants_prefill():
     coordinator = _make_coordinator([FakeLane(running=2), FakeLane(running=1)])
     assert coordinator._negotiate_forced_mode() == TTSchedulingMode.DECODE_ONLY
+
+
+def test_negotiate_prefill_for_running_continuation_without_waiting():
+    coordinator = _make_coordinator([FakeLane(partial_prefills=1)], per_lane_max=1)
+
+    assert coordinator._negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
 
 
 def test_idle_step_propagates_finished_req_ids():
@@ -145,6 +154,17 @@ def test_no_fallback_when_no_running_requests():
     assert get_tt_step_plan(output).is_decode is False
     # Only the prefill pass ran (no decode fallback).
     assert lane0.scheduled_modes == [TTSchedulingMode.PREFILL_ONLY]
+
+
+def test_no_decode_fallback_when_only_continuations_are_running():
+    lane = FakeLane(partial_prefills=1)
+    coordinator = _make_coordinator([lane])
+
+    output = coordinator.schedule()
+
+    assert output.total_num_scheduled_tokens == 0
+    assert get_tt_step_plan(output).is_decode is False
+    assert lane.scheduled_modes == [TTSchedulingMode.PREFILL_ONLY]
 
 
 def test_update_from_output_routes_and_merges_per_lane():


### PR DESCRIPTION
## Purpose

Enables token-chunked prefill. Resolves #439

## Modifications

- Remove forced `enable_chunked_prefill = False` and associated `max_num_batched_tokens` bump to `max_model_len` (see **platform.py**).
- Make `TTScheduler` aware of partial prefills (see **scheduler.py**). `_schedule_prefill_only` now partitions `self.running` into partial-prefill continuations (kept visible) and pure decodes (hidden). `_schedule_decode_only` symmetrically hides partial prefills from decode batches. The schedule decision uses `_has_pending_prefill` which checks both the waiting queue and `is_prefill_chunk` on running requests.
- Fix `is_prompt` detection in **model_runner.py** to recognize chunked-prefill continuations, i.e., cached requests with `num_scheduled_tokens > 1` that are neither new nor resumed.
- Relax the cached-requests assertion to allow continuation chunks alongside new/resumed requests (was previously a hard reject of any non-resumed cached request in a prefill batch).
- Compute chunk-bounded `prompt_lens = start_pos + chunk_len` instead of the full sequence length, so the generator's `prefill_forward_text` processes exactly the scheduled chunk via its existing `tokens[start_pos : prompt_lens]` slicing.
- Remove the `assert self.scheduler_config.enable_chunked_prefill is False` guard in model runner init.

## Test Plan

1. Run plugin unit tests.
2. Run Gemma4 nightly CI entries.
3. Run Gemma4 with chunked prefill.
4. Run Llama-3.1-8B-Instruct nightly (prefix caching + sampling tests) to verify non-Gemma models are unaffected.

## Test Result

- [x] Unit tests passing
- [x] One more [job](https://github.com/tenstorrent/tt-metal/actions/runs/30529876964/job/90831165803#step:12:151) in a temporary branch tests Gemma4-12B with chunked prefill and the following parameters:

```bash
{
    ...
    "additional-benchmark-args": "--random-input-len 16384 --num-prompts 32 --max_num_seqs 1" \ 
                                 "--max_num_batched_tokens 2048"  # 8 chunks
    ...
}
```
   and finishes with mean TPOT 40 ms and output token throughput 14 tok/s.
- [x] Gemma4 nightly CI [passing](https://github.com/tenstorrent/tt-metal/actions/runs/30101342098).
- [x] Others are ([passing](https://github.com/tenstorrent/tt-metal/actions/runs/30104486214)).
- [x] Latest (08/04) CI run ([passing](https://github.com/tenstorrent/tt-metal/actions/runs/30915622167)).

---

**Important**: tenstorrent/tt-metal#51041 also needs to be merged. **Update**: merged!