### PR TITLE
[TT] Centralize async decode reload planning

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -36,6 +36,9 @@ plugins/vllm-tt-plugin/
 +-- tests/tt/                # Server-facing TT plugin tests
 ```
 
+The async input-ownership rules and generator API are documented in
+[docs/decode-reload-contract.md](docs/decode-reload-contract.md).
+
 ## Requirements
 
 If testing a specific model, check the

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,11 +42,7 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. The version-0 compatibility path can leave a remap pending after a
-host-sampling decode because legacy adapters receive remaps only during device
-sampling. If every remaining request departs before that later device decode,
-empty-batch handling discards the obsolete mapping so it cannot be replayed
-after unrelated requests reuse the slots.
+not. Version-0 adapters retain their historical remap behavior unchanged.
 
 ## Mode definitions
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -2,8 +2,9 @@
 
 Async device sampling deliberately lets vLLM's host token state trail the TT
 device by one decode step. Consequently, only the vLLM runner can decide
-whether host tensors are authoritative. The paired tt-metal generator receives
-four independent boolean commands on every decode:
+whether host tensors are authoritative. A contract-aware tt-metal generator
+(`decode_input_update_contract >= 1`) receives four independent boolean
+commands on every decode:
 
 | Command | Effect |
 | --- | --- |
@@ -12,11 +13,12 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`decode_layout_changed` is an internal vLLM lifecycle signal: the planner
-translates it into the four commands, but it is not forwarded to tt-metal. `slot_remap`
-remains data: it is composed by vLLM until a device-sampling submission
-consumes it, then tt-metal applies it once before sampling state is reset or
-advanced.
+`decode_layout_changed` is an internal vLLM lifecycle signal: for an explicit
+contract adapter, the planner translates it into the four commands without
+forwarding the signal itself. For a legacy adapter, vLLM translates it to the
+old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
+it is composed by vLLM until a device-sampling submission consumes it, then
+tt-metal applies it once before sampling state is reset or advanced.
 
 ## Mode definitions
 
@@ -84,8 +86,9 @@ work cannot append runner state or emit an extra client token.
 
 ## Requirements for `supports_async_decode`
 
-Set `model_capabilities["supports_async_decode"] = True` only when the model
-adapter satisfies every requirement below:
+For a version-1 adapter, set
+`model_capabilities["supports_async_decode"] = True` only when the adapter
+satisfies every requirement below:
 
 1. **Split submission and readback**: `decode_forward(...,
    read_from_device=False)` submits decode without synchronizing the result, and
@@ -115,21 +118,46 @@ adapter satisfies every requirement below:
 The capability is fail-closed. If any requirement is not met, leave
 `supports_async_decode` absent or `False`. vLLM disables async scheduling for
 that model and requests a full forward-input reload on every decode, while
-still using the same four-command interface.
+still using the negotiated generator interface. A legacy adapter may already
+advertise `supports_async_decode`; vLLM preserves that adapter's existing
+reload and overlap behavior, but warns that correctness is not guaranteed
+until the adapter also implements and advertises contract version 1.
 
-## Deployment coupling
+## Contract negotiation
 
-The vLLM and tt-metal changes are one required contract and should be deployed
-as a pinned pair. vLLM always sends all four commands; there is no per-model
-contract-version negotiation or fallback to an older tt-metal generator.
-The paired tt-metal change includes the unconditional decode-only seed
-initialization also addressed by
+Model adapters opt in by setting `decode_input_update_contract = 1`. vLLM sends
+the four explicit commands only to adapters advertising version 1 or newer.
+Adapters without the attribute, or with version 0, receive the legacy
+`reset_batch` keyword on device-sampling calls and never receive unknown
+command keywords. Their reload and overlap behavior remains unchanged from the
+pre-contract path, including any model-local heuristics. vLLM logs a warning
+because those heuristics may observe stale host state under async decode and
+cannot provide the version-1 correctness guarantees. This compatibility path
+allows the vLLM change to land before individual tt-metal adapters are
+refactored.
+
+| vLLM | tt-metal adapter | Result |
+| --- | --- | --- |
+| Old | Legacy / version 0 | Supported: existing behavior |
+| New | Legacy / version 0 | Compatibility path: legacy behavior with a warning |
+| New | Version 1+ | Supported: explicit commands and eligible resident overlap |
+| Old | Strict version 1 | Unsupported: old vLLM omits the required commands |
+
+The supported rollout order is therefore vLLM first, followed by tt-metal
+adapter migrations. Advertising version 1 before implementing every command
+is an adapter bug and should fail loudly rather than silently falling back.
+Versions greater than 1 must remain backward-compatible supersets of version 1;
+a breaking interface requires a distinct negotiation key or supported range.
+
+`model_capabilities["supports_async_decode"]` remains independent of contract
+versioning. It controls async scheduling and certifies that sampled-token
+feedback can remain device-resident between decode steps. A version-1 model
+without that capability receives a conservative full-input reload command on
+every decode.
+
+The refactored tt-metal implementation includes the unconditional decode-only
+seed initialization also addressed by
 [tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556):
 `reset_sampling_state=True` forces seed initialization for first-decode and
 layout transitions even when both the requested and cached seed are `None`.
-The paired change implements this directly and does not depend on that PR.
-`model_capabilities["supports_async_decode"]` remains the sole per-model gate.
-It both controls async scheduling and certifies that sampled-token feedback can
-remain device-resident between decode steps. Models without it still receive
-the explicit four-command contract, but vLLM conservatively requests a full
-forward-input reload on every step.
+The implementation does not depend on that PR.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,7 +42,10 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. Empty-batch handling resets the composed layout to identity.
+not. A condense performed for a prefill/resume step records a remap without
+delivering it, because only decode consumes remaps. If every remaining request
+then departs before a later decode, empty-batch handling discards that obsolete
+mapping so it cannot be replayed after unrelated requests reuse the slots.
 
 ## Mode definitions
 
@@ -86,9 +89,9 @@ the persistent token slot contains sampled token `t_k`, and the persistent
 position is the position at which `t_k` must be consumed by step `k+1`.
 
 The base case is a full reload. vLLM first finalizes the prior non-steady step,
-filters finished, resumed, and replaced request identities, updates continuing
-host state (including a live request temporarily unscheduled this step), and
-copies authoritative token/position/layout tensors.
+filters finished and resumed requests, updates continuing host state (including
+a live request temporarily unscheduled this step), and copies authoritative
+token/position/layout tensors.
 
 For the induction step, a steady device decode issues no full or sampling-state
 reload. The trace therefore consumes the device-resident `t_k` and position,
@@ -101,12 +104,14 @@ Host sampling always performs a full reload from the accepted host token.
 Layout, resume, prefill, and sampling-mode transitions break the steady
 invariant and therefore drain and re-establish the base case.
 
-A completed async result is applied only to the captured request object when it
-is still live and was not finished/resumed. Reused request IDs fail the
-object-identity check, and their cached runner-output rows are replaced with an
-empty token list before scheduler update. vLLM's scheduler independently
-ignores outputs for requests that no longer exist, so cancelled speculative
-work cannot append runner state or emit an extra client token.
+A completed async result is applied only when its captured internal request ID
+is still live and was not finished/resumed. vLLM assigns a fresh internal ID to
+every accepted request, so aborting and resubmitting the same external ID cannot
+attach an old result to the new request. Cached runner-output rows for explicitly
+finished/resumed requests are replaced with an empty token list before scheduler
+update. vLLM's scheduler independently ignores outputs for requests that no
+longer exist, so cancelled speculative work cannot append runner state or emit
+an extra client token.
 
 ## Requirements for `supports_async_decode`
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,10 +42,11 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. A condense performed for a prefill/resume step records a remap without
-delivering it, because only decode consumes remaps. If every remaining request
-then departs before a later decode, empty-batch handling discards that obsolete
-mapping so it cannot be replayed after unrelated requests reuse the slots.
+not. The version-0 compatibility path can leave a remap pending after a
+host-sampling decode because legacy adapters receive remaps only during device
+sampling. If every remaining request departs before that later device decode,
+empty-batch handling discards the obsolete mapping so it cannot be replayed
+after unrelated requests reuse the slots.
 
 ## Mode definitions
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -120,6 +120,12 @@ still using the same four-command interface.
 The vLLM and tt-metal changes are one required contract and should be deployed
 as a pinned pair. vLLM always sends all four commands; there is no per-model
 contract-version negotiation or fallback to an older tt-metal generator.
+The paired tt-metal change includes the unconditional decode-only seed
+initialization also addressed by
+[tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556):
+`reset_sampling_state=True` forces seed initialization for first-decode and
+layout transitions even when both the requested and cached seed are `None`.
+The paired change implements this directly and does not depend on that PR.
 `model_capabilities["supports_async_decode"]` remains the sole per-model gate.
 It both controls async scheduling and certifies that sampled-token feedback can
 remain device-resident between decode steps. Models without it still receive

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -19,9 +19,30 @@ forwarding the signal itself. For a legacy adapter, vLLM translates it to the
 old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
 for a version-1 adapter it is composed by vLLM until the next accepted decode
 submission in either sampling mode. tt-metal applies it once before the decode
-reads any persistent per-slot state. This includes model-owned recurrent or
-convolution state as well as device sampling state. Version-0 adapters retain
-the legacy device-sampling-only delivery and consumption behavior.
+reads any persistent per-slot state. Dormant state that the decode cannot read,
+such as a device sampler during host sampling, may be remapped immediately
+after successful submission; applying its non-idempotent remap before a call
+that can fail would corrupt a retry. Persistent state includes model-owned
+recurrent or convolution state as well as device sampling state. Version-0
+adapters retain the legacy device-sampling-only delivery and consumption
+behavior.
+
+Two superficially reasonable implementations are incorrect:
+
+1. **Deliver the remap only for device sampling.** A host-sampling decode can
+   still change the vLLM slot layout. Withholding `slot_remap` leaves
+   model-owned slot state, such as recurrent/conv buffers or cached RoPE
+   deltas, attached to the prior request.
+2. **Apply a delivered remap only inside the active device-sampling call.** A
+   model may retain slot-indexed sampler state even while that decode samples
+   on the host. Skipping the dormant sampler leaves seed/RNG/penalty state in
+   the old slots, so a later return to device sampling resumes the wrong
+   request's state.
+
+The rule is therefore delivery on every version-1 decode and exactly-once
+application by every slot-owning subsystem. An authoritative rebuild may
+replace a subsystem's remap, but merely not using that subsystem this step may
+not. Empty-batch handling resets the composed layout to identity.
 
 ## Mode definitions
 
@@ -117,7 +138,8 @@ satisfies every requirement below:
 7. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
    to all persistent state indexed by the vLLM batch slot, even when that step
    samples on the host. This includes model-internal recurrent/convolution
-   state; a full forward-input reload does not implicitly repair such state.
+   state and dormant device-sampler state; a full forward-input reload does
+   not implicitly repair either one.
 8. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -1,0 +1,70 @@
+# TT Decode Reload Contract
+
+Async device sampling deliberately lets vLLM's host token state trail the TT
+device by one decode step. Consequently, only the vLLM runner can decide
+whether host tensors are authoritative. A contract-aware tt-metal generator
+(`decode_input_update_contract >= 1`) receives four independent boolean
+commands on every decode:
+
+| Command | Effect |
+| --- | --- |
+| `reload_inputs` | Copy all forward inputs: token, position, RoPE inputs, and page tables. |
+| `reload_page_table` | Copy only page-table inputs. Ignored when `reload_inputs` is true. |
+| `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
+| `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
+
+`reset_batch` and generator-local tensor/mode comparisons are legacy fallback
+only. `slot_remap` remains data: it is composed by vLLM until a device-sampling
+submission consumes it, then tt-metal applies it once before sampling state is
+reset or advanced.
+
+## Transition table
+
+| Transition | Inputs | Page only | Sampling params | Sampling state |
+| --- | ---: | ---: | ---: | ---: |
+| First decode or prefill → decode | reload | no | reload on device | reset on device |
+| Batch add/remove/reuse/condense or resume | reload | no | reload on device | reset on device |
+| Host → device sampling | reload | no | reload | reset |
+| Steady host sampling | reload every step | no | n/a | n/a |
+| Steady device sampling | keep resident | only if changed | keep | keep |
+
+Any transition requiring a full input or sampling-state update drains pending
+decode work first. Page-table-only refresh is overlap-safe because page tables
+are scheduler-authoritative even while host token/position tensors are stale.
+
+## Correctness argument
+
+The device invariant immediately after a device-sampling decode step `k` is:
+the persistent token slot contains sampled token `t_k`, and the persistent
+position is the position at which `t_k` must be consumed by step `k+1`.
+
+The base case is a full reload. vLLM first finalizes the prior non-steady step,
+filters finished, resumed, and replaced request identities, updates continuing
+host state (including a live request temporarily unscheduled this step), and
+copies authoritative token/position/layout tensors.
+
+For the induction step, a steady device decode issues no full or sampling-state
+reload. The trace therefore consumes the device-resident `t_k` and position,
+writes exactly one KV position, advances position exactly once, and sampling
+writes `t_(k+1)` back to the persistent token slot. A page-table-only copy can
+change KV address mapping but cannot overwrite token or position state.
+Readback is observational and may complete later.
+
+Host sampling always performs a full reload from the accepted host token.
+Layout, resume, prefill, and sampling-mode transitions break the steady
+invariant and therefore drain and re-establish the base case.
+
+A completed async result is applied only to the captured request object when it
+is still live and was not finished/resumed. Reused request IDs fail the
+object-identity check, and their cached runner-output rows are replaced with an
+empty token list before scheduler update. vLLM's scheduler independently
+ignores outputs for requests that no longer exist, so cancelled speculative
+work cannot append runner state or emit an extra client token.
+
+## Compatibility
+
+New vLLM checks `decode_input_update_contract` before sending the four kwargs
+or allowing host-stale overlap. Old tt-metal generators continue on the
+drain-before-next-step legacy path. New tt-metal generators keep their previous
+heuristics only when all four kwargs are absent, allowing the tt-metal change to
+land before the vLLM change.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -17,8 +17,11 @@ commands on every decode:
 contract adapter, the planner translates it into the four commands without
 forwarding the signal itself. For a legacy adapter, vLLM translates it to the
 old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
-it is composed by vLLM until a device-sampling submission consumes it, then
-tt-metal applies it once before sampling state is reset or advanced.
+for a version-1 adapter it is composed by vLLM until the next accepted decode
+submission in either sampling mode. tt-metal applies it once before the decode
+reads any persistent per-slot state. This includes model-owned recurrent or
+convolution state as well as device sampling state. Version-0 adapters retain
+the legacy device-sampling-only delivery and consumption behavior.
 
 ## Mode definitions
 
@@ -111,7 +114,11 @@ satisfies every requirement below:
 6. **Sampling-state ordering**: slot remaps are applied before parameter/state
    reset; RNG and penalty state are reset only when requested; seed advancement
    happens exactly once per sampled token.
-7. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
+7. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
+   to all persistent state indexed by the vLLM batch slot, even when that step
+   samples on the host. This includes model-internal recurrent/convolution
+   state; a full forward-input reload does not implicitly repair such state.
+8. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.
 
@@ -129,12 +136,12 @@ Model adapters opt in by setting `decode_input_update_contract = 1`. vLLM sends
 the four explicit commands only to adapters advertising version 1 or newer.
 Adapters without the attribute, or with version 0, receive the legacy
 `reset_batch` keyword on device-sampling calls and never receive unknown
-command keywords. Their reload and overlap behavior remains unchanged from the
-pre-contract path, including any model-local heuristics. vLLM logs a warning
-because those heuristics may observe stale host state under async decode and
-cannot provide the version-1 correctness guarantees. This compatibility path
-allows the vLLM change to land before individual tt-metal adapters are
-refactored.
+command keywords. They also retain device-sampling-only `slot_remap` delivery.
+Their reload and overlap behavior remains unchanged from the pre-contract path,
+including any model-local heuristics. vLLM logs a warning because those
+heuristics may observe stale host state under async decode and cannot provide
+the version-1 correctness guarantees. This compatibility path allows the vLLM
+change to land before individual tt-metal adapters are refactored.
 
 | vLLM | tt-metal adapter | Result |
 | --- | --- | --- |

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -12,8 +12,8 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` is an internal vLLM lifecycle signal: the planner translates it
-into the four commands, but it is not forwarded to tt-metal. `slot_remap`
+`decode_layout_changed` is an internal vLLM lifecycle signal: the planner
+translates it into the four commands, but it is not forwarded to tt-metal. `slot_remap`
 remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -12,7 +12,8 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` no longer decides reload behavior in the vLLM path. `slot_remap`
+`reset_batch` is an internal vLLM lifecycle signal: the planner translates it
+into the four commands, but it is not forwarded to tt-metal. `slot_remap`
 remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.
@@ -45,6 +46,7 @@ advanced.
 | Host → device sampling | reload | no | reload | reset |
 | Steady host sampling | reload every step | no | n/a | n/a |
 | Steady device sampling | keep resident | only if changed | keep | keep |
+| Decode tracing disabled | reload every step | no | on transition | on transition |
 | Model without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring a full input or sampling-state update drains pending

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -2,9 +2,8 @@
 
 Async device sampling deliberately lets vLLM's host token state trail the TT
 device by one decode step. Consequently, only the vLLM runner can decide
-whether host tensors are authoritative. A contract-aware tt-metal generator
-(`decode_input_update_contract >= 1`) receives four independent boolean
-commands on every decode:
+whether host tensors are authoritative. The paired tt-metal generator receives
+four independent boolean commands on every decode:
 
 | Command | Effect |
 | --- | --- |
@@ -13,10 +12,10 @@ commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` and generator-local tensor/mode comparisons are legacy fallback
-only. `slot_remap` remains data: it is composed by vLLM until a device-sampling
-submission consumes it, then tt-metal applies it once before sampling state is
-reset or advanced.
+`reset_batch` no longer decides reload behavior in the vLLM path. `slot_remap`
+remains data: it is composed by vLLM until a device-sampling submission
+consumes it, then tt-metal applies it once before sampling state is reset or
+advanced.
 
 ## Transition table
 
@@ -27,6 +26,7 @@ reset or advanced.
 | Host → device sampling | reload | no | reload | reset |
 | Steady host sampling | reload every step | no | n/a | n/a |
 | Steady device sampling | keep resident | only if changed | keep | keep |
+| Model without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring a full input or sampling-state update drains pending
 decode work first. Page-table-only refresh is overlap-safe because page tables
@@ -61,10 +61,13 @@ empty token list before scheduler update. vLLM's scheduler independently
 ignores outputs for requests that no longer exist, so cancelled speculative
 work cannot append runner state or emit an extra client token.
 
-## Compatibility
+## Deployment coupling
 
-New vLLM checks `decode_input_update_contract` before sending the four kwargs
-or allowing host-stale overlap. Old tt-metal generators continue on the
-drain-before-next-step legacy path. New tt-metal generators keep their previous
-heuristics only when all four kwargs are absent, allowing the tt-metal change to
-land before the vLLM change.
+The vLLM and tt-metal changes are one required contract and should be deployed
+as a pinned pair. vLLM always sends all four commands; there is no per-model
+contract-version negotiation or fallback to an older tt-metal generator.
+`model_capabilities["supports_async_decode"]` remains the sole per-model gate.
+It both controls async scheduling and certifies that sampled-token feedback can
+remain device-resident between decode steps. Models without it still receive
+the explicit four-command contract, but vLLM conservatively requests a full
+forward-input reload on every step.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -17,6 +17,25 @@ remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.
 
+## Mode definitions
+
+- **Host sampling**: tt-metal returns logits and vLLM selects the token. Host
+  token and position tensors are authoritative, so every decode performs a
+  full input reload.
+- **Device sampling**: tt-metal selects the token. A supporting model writes
+  that token directly into the persistent input buffer used by the next decode
+  and advances its persistent position in the forward trace.
+- **Transition decode**: the first decode, the first decode after prefill, a
+  batch-layout or sampling-mode change, or a resume. Host state is
+  authoritative again; pending work drains before a full reload and any
+  required sampling-state reset.
+- **Steady device decode**: the request layout and sampling mode are unchanged
+  after a valid device-sampling decode. Token and position remain
+  device-resident, so no full reload occurs.
+- **Page-table-only refresh**: a steady device decode whose KV block mapping
+  changed. Only page-table trace inputs are copied; token, position, and RoPE
+  state must remain untouched.
+
 ## Transition table
 
 | Transition | Inputs | Page only | Sampling params | Sampling state |
@@ -60,6 +79,41 @@ object-identity check, and their cached runner-output rows are replaced with an
 empty token list before scheduler update. vLLM's scheduler independently
 ignores outputs for requests that no longer exist, so cancelled speculative
 work cannot append runner state or emit an extra client token.
+
+## Requirements for `supports_async_decode`
+
+Set `model_capabilities["supports_async_decode"] = True` only when the model
+adapter satisfies every requirement below:
+
+1. **Split submission and readback**: `decode_forward(...,
+   read_from_device=False)` submits decode without synchronizing the result, and
+   `read_decode_output(..., async_read=True)` can read that exact submission
+   later. Readback must be observational: it cannot advance position, sample
+   another token, or otherwise mutate decode state.
+2. **Persistent token feedback**: device sampling writes the selected token into
+   the same persistent token buffer consumed by the next decode. Writing only
+   to a separate output tensor is insufficient.
+3. **Single position advance**: each successful decode forward advances the
+   persistent position exactly once. Sampling and readback must not advance it.
+   After step `k`, the resident token and position must describe the input to
+   step `k+1`.
+4. **Independent page-table refresh**: the model can copy changed page-table
+   inputs without copying or rebinding token, position, or RoPE inputs.
+5. **Exact command handling**: the adapter honors `reload_inputs`,
+   `reload_page_table`, `reload_sampling_params`, and
+   `reset_sampling_state` independently. It must not add model-local mode or
+   tensor comparisons that turn a page-table-only update into a full reload.
+6. **Sampling-state ordering**: slot remaps are applied before parameter/state
+   reset; RNG and penalty state are reset only when requested; seed advancement
+   happens exactly once per sampled token.
+7. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
+   valid until the submitted step is read back and until the next command
+   explicitly replaces their contents.
+
+The capability is fail-closed. If any requirement is not met, leave
+`supports_async_decode` absent or `False`. vLLM disables async scheduling for
+that model and requests a full forward-input reload on every decode, while
+still using the same four-command interface.
 
 ## Deployment coupling
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -13,6 +13,7 @@ import ttnn
 
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOutput
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from vllm_tt_plugin.input_batch import CachedRequestState
     from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
+
+logger = init_tt_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -220,6 +223,7 @@ class TTAsyncDecodeController:
         self._decode_chain_valid = False
         self._previous_device_sampling: bool | None = None
         self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
+        self._legacy_contract_warning_emitted = False
 
     @staticmethod
     def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
@@ -754,17 +758,33 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
-        # vLLM owns reload decisions because it alone knows when host tensors
-        # are authoritative under async scheduling. The paired tt-metal
-        # revision is therefore required and receives all four commands on
-        # every non-empty decode submission.
-        reload_plan = self.plan_decode_reload(model_input)
-        kwargs.update(
-            reload_inputs=reload_plan.reload_inputs,
-            reload_page_table=reload_plan.reload_page_table,
-            reload_sampling_params=reload_plan.reload_sampling_params,
-            reset_sampling_state=reload_plan.reset_sampling_state,
-        )
+        # Versioned compatibility seam. Refactored tt-metal generators opt in
+        # to the explicit contract. Existing generators retain their legacy
+        # reset_batch interface and never receive unknown command kwargs.
+        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
+        reload_plan = None
+        if contract_version >= 1:
+            reload_plan = self.plan_decode_reload(model_input)
+            kwargs.update(
+                reload_inputs=reload_plan.reload_inputs,
+                reload_page_table=reload_plan.reload_page_table,
+                reload_sampling_params=reload_plan.reload_sampling_params,
+                reset_sampling_state=reload_plan.reset_sampling_state,
+            )
+        elif perform_device_sampling:
+            # Keep the lifecycle hint internal under the explicit contract,
+            # but translate it back to the legacy API while old adapters are
+            # still being migrated.
+            kwargs["reset_batch"] = model_input.decode_layout_changed
+        if contract_version < 1 and not self._legacy_contract_warning_emitted:
+            self._legacy_contract_warning_emitted = True
+            logger.warning(
+                "TT model %s does not advertise decode_input_update_contract "
+                ">= 1; preserving its legacy reset_batch reload behavior. "
+                "Async decode correctness is not guaranteed until the model "
+                "adapter implements and advertises the explicit contract.",
+                type(runner.model).__name__,
+            )
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
@@ -789,7 +809,14 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
-        self.commit_decode_submission(model_input, reload_plan)
+        if reload_plan is not None:
+            self.commit_decode_submission(model_input, reload_plan)
+        else:
+            # Preserve legacy overlap eligibility. The old adapter remains the
+            # owner of reload decisions; this only records that submission
+            # succeeded so the plugin does not introduce a new forced drain.
+            self._decode_chain_valid = True
+            self._previous_device_sampling = perform_device_sampling
         if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -18,7 +18,6 @@ from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-    from vllm_tt_plugin.input_batch import CachedRequestState
     from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
 
@@ -61,7 +60,6 @@ class SubmittedStepContext:
 
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-    request_states: tuple[CachedRequestState, ...]
     submit_time_ns: int
 
 
@@ -352,7 +350,6 @@ class TTAsyncDecodeController:
         return SubmittedStepContext(
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_states=tuple(runner.requests[req_id] for req_id in req_ids),
             submit_time_ns=time.perf_counter_ns(),
         )
 
@@ -594,17 +591,9 @@ class TTAsyncDecodeController:
         skip_req_ids: set[str] | None = None,
     ) -> None:
         invalid_req_ids = set(skip_req_ids or ())
-        invalid_req_ids.update(
-            req_id
-            for req_id, captured_state in zip(
-                completed.context.req_ids,
-                completed.context.request_states,
-            )
-            if self.runner.requests.get(req_id) is not captured_state
-        )
         # The batch queue schedules/builds the current step before consuming
         # the prior future. Mutating the cached prior output here therefore
-        # prevents an aborted/reused request ID from receiving its old token
+        # prevents a finished or resumed request from receiving its old token
         # in scheduler.update_from_output, not just in runner host state.
         if completed.runner_output is not None:
             for req_id in invalid_req_ids:
@@ -614,7 +603,6 @@ class TTAsyncDecodeController:
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
-            request_states=completed.context.request_states,
             skip_req_ids=invalid_req_ids,
         )
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -714,6 +714,9 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
+        contract_version = int(
+            getattr(runner.model, "decode_input_update_contract", 0)
+        )
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,
@@ -755,13 +758,20 @@ class TTAsyncDecodeController:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
-            if model_input.slot_remap is not None:
-                kwargs["slot_remap"] = model_input.slot_remap
+
+        # Under the explicit contract, slot_remap is decode-layout data and is
+        # delivered even when this step samples on the host: adapters may own
+        # persistent per-slot state outside their device sampler. Preserve the
+        # legacy device-sampling-only call shape for version-0 adapters.
+        slot_remap_consumed = model_input.slot_remap is not None and (
+            contract_version >= 1 or perform_device_sampling
+        )
+        if slot_remap_consumed:
+            kwargs["slot_remap"] = model_input.slot_remap
 
         # Versioned compatibility seam. Refactored tt-metal generators opt in
         # to the explicit contract. Existing generators retain their legacy
         # reset_batch interface and never receive unknown command kwargs.
-        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
         reload_plan = None
         if contract_version >= 1:
             reload_plan = self.plan_decode_reload(model_input)
@@ -788,7 +798,7 @@ class TTAsyncDecodeController:
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
-            if any(
+            if model_input.decode_layout_changed or any(
                 req_id not in runner.previous_req_ids
                 for req_id in runner.input_batch.req_ids
             ):
@@ -817,7 +827,7 @@ class TTAsyncDecodeController:
             # succeeded so the plugin does not introduce a new forced drain.
             self._decode_chain_valid = True
             self._previous_device_sampling = perform_device_sampling
-        if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
+        if slot_remap_consumed and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -281,7 +281,7 @@ class TTAsyncDecodeController:
         )
         transition = (
             not self._decode_chain_valid
-            or model_input.reset_batch
+            or model_input.decode_layout_changed
             or sampling_mode_changed
         )
         reload_inputs = (
@@ -445,7 +445,7 @@ class TTAsyncDecodeController:
             return False
         if not model_input.perform_device_sampling:
             return False
-        if model_input.reset_batch:
+        if model_input.decode_layout_changed:
             return False
         if model_input.grammar_bitmask[0] is not None:
             return False

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -18,7 +18,7 @@ from vllm_tt_plugin.structured_output import has_structured_outputs
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm_tt_plugin.input_batch import CachedRequestState
-    from vllm_tt_plugin.model_input import TTModelInput
+    from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
 
 
@@ -31,6 +31,7 @@ class TTDecodeSubmission:
     batch_size_per_dp: list[int]
     sampling_params: Any
     perform_device_sampling: bool
+    reload_plan: TTDecodeReloadPlan | None = None
 
 
 @dataclass(frozen=True)
@@ -61,7 +62,7 @@ class SubmittedStepContext:
     submit_time_ns: int
 
 
-@dataclass(frozen=True)
+@dataclass
 class CompletedDecodeStep:
     """Decode output that has completed readback but is not yet applied."""
 
@@ -69,6 +70,7 @@ class CompletedDecodeStep:
     logprobs: LogprobsLists | None
     context: SubmittedStepContext
     completion_time_ns: int
+    runner_output: ModelRunnerOutput | None = None
 
 
 class DeferredDecodeOutput(AsyncModelRunnerOutput):
@@ -160,8 +162,12 @@ class AsyncTTModelRunnerOutput(DeferredDecodeOutput):
             context=self._context,
             scheduled_rows=self._scheduled_rows,
         )
+        runner_output = self._controller.build_runner_output_from_completed_step(
+            completed
+        )
+        completed.runner_output = runner_output
         self._controller.enqueue_completed_decode_step(completed)
-        return self._controller.build_runner_output_from_completed_step(completed)
+        return runner_output
 
 
 class AsyncTTDPGatherOutput(DeferredDecodeOutput):
@@ -207,6 +213,103 @@ class TTAsyncDecodeController:
 
     def __init__(self, runner: TTModelRunner):
         self.runner = runner
+        # Decode-residency state is committed at submission, not readback. An
+        # overlapped device decode may deliberately leave host tokens one step
+        # behind, so only this submitted-device history can decide what is safe
+        # to reload on the next step.
+        self._decode_chain_valid = False
+        self._previous_device_sampling: bool | None = None
+        self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
+
+    @staticmethod
+    def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            table.detach().clone() for table in model_input.block_tables_per_group
+        )
+
+    def note_prefill_submitted(self) -> None:
+        """Invalidate decode-resident token/position state after a prefill."""
+        self._decode_chain_valid = False
+
+    def note_dp_decode_submitted(self, device_sampling: bool) -> None:
+        """Mirror the merged device submission on every DP rank controller.
+
+        Only the device rank executes ``decode_forward`` and owns page-table
+        snapshots, but every rank participates in the pre-submit overlap vote.
+        Mirroring chain/mode state keeps that vote from treating a first decode
+        or host→device transition as steady.
+        """
+        self._decode_chain_valid = True
+        self._previous_device_sampling = device_sampling
+
+    def _page_tables_changed(self, model_input: TTModelInput) -> bool:
+        current = model_input.block_tables_per_group
+        previous = self._submitted_page_tables
+        return (
+            previous is None
+            or len(previous) != len(current)
+            or any(not torch.equal(old, new) for old, new in zip(previous, current))
+        )
+
+    def plan_decode_reload(self, model_input: TTModelInput) -> TTDecodeReloadPlan:
+        """Return the explicit update plan for the next device submission.
+
+        Host sampling always reloads host-authoritative forward inputs. Device
+        sampling retains token/position state only across an uninterrupted,
+        layout-stable decode chain. Page tables are tracked independently so a
+        newly allocated KV block can be copied without clobbering the
+        device-produced token and advanced position.
+        """
+        from vllm_tt_plugin.model_input import TTDecodeReloadPlan
+
+        device_sampling = model_input.perform_device_sampling
+        sampling_mode_changed = (
+            self._previous_device_sampling is not None
+            and self._previous_device_sampling != device_sampling
+        )
+        transition = (
+            not self._decode_chain_valid
+            or model_input.reset_batch
+            or sampling_mode_changed
+        )
+        reload_inputs = (not device_sampling) or transition
+        sampling_reset = device_sampling and transition
+        return TTDecodeReloadPlan(
+            reload_inputs=reload_inputs,
+            reload_page_table=(
+                not reload_inputs and self._page_tables_changed(model_input)
+            ),
+            reload_sampling_params=sampling_reset,
+            reset_sampling_state=sampling_reset,
+        )
+
+    def commit_decode_submission(
+        self,
+        model_input: TTModelInput,
+        reload_plan: TTDecodeReloadPlan,
+    ) -> None:
+        """Commit residency state after ``decode_forward`` accepted the step."""
+        self._decode_chain_valid = True
+        self._previous_device_sampling = model_input.perform_device_sampling
+        if (
+            reload_plan.reload_inputs
+            or reload_plan.reload_page_table
+            or self._submitted_page_tables is None
+        ):
+            self._submitted_page_tables = self._clone_page_tables(model_input)
+
+    def scheduler_preserves_decode_layout(
+        self, scheduler_output: SchedulerOutput
+    ) -> bool:
+        """Whether scheduling this step leaves every persistent decode row intact.
+
+        This prediction happens before ``_update_states``. It closes the old
+        gap where a new/finished/preempted request was only noticed after the
+        next decode had already been allowed to overlap with stale host input.
+        """
+        current_req_ids = set(self.runner.input_batch.req_id_to_index)
+        scheduled_req_ids = set(scheduler_output.num_scheduled_tokens)
+        return current_req_ids == scheduled_req_ids
 
     def capture_submitted_step_context(
         self, req_ids: list[str] | None = None
@@ -234,6 +337,25 @@ class TTAsyncDecodeController:
 
     def steady_decode_base_enabled(self, *, dp_gather: bool) -> bool:
         runner = self.runner
+        contract_version = int(
+            getattr(
+                getattr(runner, "model", None),
+                "decode_input_update_contract",
+                0,
+            )
+        )
+        is_non_device_dp_rank = (
+            dp_gather
+            and runner.parallel_config.data_parallel_rank_local != 0
+        )
+        if contract_version < 1 and not is_non_device_dp_rank:
+            # Legacy generators may still run asynchronously, but must drain
+            # each result before building the next host input because their
+            # model-local reload heuristics cannot be proven host-stale-safe.
+            # Gathered non-device ranks deliberately have no model; their vote
+            # covers scheduler/layout state while each device-local rank 0
+            # supplies the capability vote.
+            return False
         if dp_gather:
             if not runner.scheduler_config.async_scheduling:
                 return False
@@ -257,6 +379,13 @@ class TTAsyncDecodeController:
             cached_reqs.resumed_req_ids
         )
         if is_prompt or runner._decode_layout_changed_since_last_decode:
+            return False
+        if (
+            not self._decode_chain_valid
+            or self._previous_device_sampling is not True
+        ):
+            return False
+        if not self.scheduler_preserves_decode_layout(scheduler_output):
             return False
         # Structured outputs are detected from the scheduler state, not from a
         # prepared bitmask: the non-DP/lane paths now defer grammar to sample
@@ -337,7 +466,7 @@ class TTAsyncDecodeController:
         max_num_logprobs = model_input.max_num_logprobs[0]
         if max_num_logprobs is not None:  # noqa: SIM103
             return False
-        return True
+        return self.plan_decode_reload(model_input).overlap_safe
 
     def enqueue_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
         with self.runner._steady_decode_lock:
@@ -369,12 +498,14 @@ class TTAsyncDecodeController:
                 completed.append(self.runner._completed_decode_steps.popleft())
         return completed
 
-    def apply_ready_completed_decode_steps(self) -> None:
+    def apply_ready_completed_decode_steps(
+        self, *, skip_req_ids: set[str] | None = None
+    ) -> None:
         for completed in self.drain_completed_decode_steps():
-            self.apply_completed_decode_step(completed)
+            self.apply_completed_decode_step(completed, skip_req_ids=skip_req_ids)
         self.prune_finished_async_events()
 
-    def wait_for_all_pending_async_steps(self) -> None:
+    def wait_for_all_pending_async_steps(self, *, apply_completed: bool = True) -> None:
         # Drive each pending readback to completion here rather than blocking on
         # its event: the engine has not popped these futures yet (and on 0.22
         # will not until after this returns), so nothing else will set the
@@ -384,7 +515,8 @@ class TTAsyncDecodeController:
             steps = list(self.runner._pending_async_steps)
         for step in steps:
             step.ensure_finalized()
-        self.apply_ready_completed_decode_steps()
+        if apply_completed:
+            self.apply_ready_completed_decode_steps()
 
     def must_drain_pending_async_steps(
         self,
@@ -456,11 +588,35 @@ class TTAsyncDecodeController:
             req_id_to_index=completed.context.req_id_to_index,
         )
 
-    def apply_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
+    def apply_completed_decode_step(
+        self,
+        completed: CompletedDecodeStep,
+        *,
+        skip_req_ids: set[str] | None = None,
+    ) -> None:
+        invalid_req_ids = set(skip_req_ids or ())
+        invalid_req_ids.update(
+            req_id
+            for req_id, captured_state in zip(
+                completed.context.req_ids,
+                completed.context.request_states,
+            )
+            if self.runner.requests.get(req_id) is not captured_state
+        )
+        # The batch queue schedules/builds the current step before consuming
+        # the prior future. Mutating the cached prior output here therefore
+        # prevents an aborted/reused request ID from receiving its old token
+        # in scheduler.update_from_output, not just in runner host state.
+        if completed.runner_output is not None:
+            for req_id in invalid_req_ids:
+                req_idx = completed.runner_output.req_id_to_index.get(req_id)
+                if req_idx is not None:
+                    completed.runner_output.sampled_token_ids[req_idx] = []
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
             request_states=completed.context.request_states,
+            skip_req_ids=invalid_req_ids,
         )
 
     def submit_async_non_dp_decode(
@@ -566,6 +722,7 @@ class TTAsyncDecodeController:
                 batch_size_per_dp=batch_size_per_dp,
                 sampling_params=sampling_params,
                 perform_device_sampling=perform_device_sampling,
+                reload_plan=None,
             )
 
         kwargs: dict[str, Any] = {
@@ -603,6 +760,22 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
+        # Versioned compatibility seam. New tt-metal generators advertise the
+        # explicit contract; old generators keep their existing reset_batch
+        # heuristics and never see unknown kwargs.
+        contract_version = int(
+            getattr(runner.model, "decode_input_update_contract", 0)
+        )
+        reload_plan = None
+        if contract_version >= 1:
+            reload_plan = self.plan_decode_reload(model_input)
+            kwargs.update(
+                reload_inputs=reload_plan.reload_inputs,
+                reload_page_table=reload_plan.reload_page_table,
+                reload_sampling_params=reload_plan.reload_sampling_params,
+                reset_sampling_state=reload_plan.reset_sampling_state,
+            )
+
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
             if any(
@@ -626,6 +799,13 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
+        if reload_plan is not None:
+            self.commit_decode_submission(model_input, reload_plan)
+        if (
+            perform_device_sampling
+            and runner.parallel_config.data_parallel_size == 1
+        ):
+            runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:
             if hasattr(runner.model, "read_decode_output"):
@@ -650,6 +830,7 @@ class TTAsyncDecodeController:
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
+            reload_plan=reload_plan,
         )
 
     def finalize_decode(

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -263,14 +263,18 @@ class TTAsyncDecodeController:
         from vllm_tt_plugin.model_input import TTDecodeReloadPlan
 
         device_sampling = model_input.perform_device_sampling
-        model_capabilities = getattr(
-            getattr(self.runner, "model", None),
-            "model_capabilities",
-            {},
-        ) or {}
+        model_capabilities = (
+            getattr(
+                getattr(self.runner, "model", None),
+                "model_capabilities",
+                {},
+            )
+            or {}
+        )
         supports_resident_decode = bool(
             model_capabilities.get("supports_async_decode", False)
         )
+        decode_trace_enabled = self.runner.trace_mode in ("all", "decode_only")
         sampling_mode_changed = (
             self._previous_device_sampling is not None
             and self._previous_device_sampling != device_sampling
@@ -284,6 +288,7 @@ class TTAsyncDecodeController:
             not device_sampling
             or transition
             or not supports_resident_decode
+            or not decode_trace_enabled
         )
         sampling_reset = device_sampling and transition
         return TTDecodeReloadPlan(
@@ -373,10 +378,7 @@ class TTAsyncDecodeController:
         )
         if is_prompt or runner._decode_layout_changed_since_last_decode:
             return False
-        if (
-            not self._decode_chain_valid
-            or self._previous_device_sampling is not True
-        ):
+        if not self._decode_chain_valid or self._previous_device_sampling is not True:
             return False
         if not self.scheduler_preserves_decode_layout(scheduler_output):
             return False
@@ -749,7 +751,6 @@ class TTAsyncDecodeController:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
-            kwargs["reset_batch"] = model_input.reset_batch
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
@@ -789,10 +790,7 @@ class TTAsyncDecodeController:
             read_from_device=read_from_device,
         )
         self.commit_decode_submission(model_input, reload_plan)
-        if (
-            perform_device_sampling
-            and runner.parallel_config.data_parallel_size == 1
-        ):
+        if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -702,9 +702,7 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
-        contract_version = int(
-            getattr(runner.model, "decode_input_update_contract", 0)
-        )
+        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -263,6 +263,14 @@ class TTAsyncDecodeController:
         from vllm_tt_plugin.model_input import TTDecodeReloadPlan
 
         device_sampling = model_input.perform_device_sampling
+        model_capabilities = getattr(
+            getattr(self.runner, "model", None),
+            "model_capabilities",
+            {},
+        ) or {}
+        supports_resident_decode = bool(
+            model_capabilities.get("supports_async_decode", False)
+        )
         sampling_mode_changed = (
             self._previous_device_sampling is not None
             and self._previous_device_sampling != device_sampling
@@ -272,7 +280,11 @@ class TTAsyncDecodeController:
             or model_input.reset_batch
             or sampling_mode_changed
         )
-        reload_inputs = (not device_sampling) or transition
+        reload_inputs = (
+            not device_sampling
+            or transition
+            or not supports_resident_decode
+        )
         sampling_reset = device_sampling and transition
         return TTDecodeReloadPlan(
             reload_inputs=reload_inputs,
@@ -337,25 +349,6 @@ class TTAsyncDecodeController:
 
     def steady_decode_base_enabled(self, *, dp_gather: bool) -> bool:
         runner = self.runner
-        contract_version = int(
-            getattr(
-                getattr(runner, "model", None),
-                "decode_input_update_contract",
-                0,
-            )
-        )
-        is_non_device_dp_rank = (
-            dp_gather
-            and runner.parallel_config.data_parallel_rank_local != 0
-        )
-        if contract_version < 1 and not is_non_device_dp_rank:
-            # Legacy generators may still run asynchronously, but must drain
-            # each result before building the next host input because their
-            # model-local reload heuristics cannot be proven host-stale-safe.
-            # Gathered non-device ranks deliberately have no model; their vote
-            # covers scheduler/layout state while each device-local rank 0
-            # supplies the capability vote.
-            return False
         if dp_gather:
             if not runner.scheduler_config.async_scheduling:
                 return False
@@ -760,21 +753,17 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
-        # Versioned compatibility seam. New tt-metal generators advertise the
-        # explicit contract; old generators keep their existing reset_batch
-        # heuristics and never see unknown kwargs.
-        contract_version = int(
-            getattr(runner.model, "decode_input_update_contract", 0)
+        # vLLM owns reload decisions because it alone knows when host tensors
+        # are authoritative under async scheduling. The paired tt-metal
+        # revision is therefore required and receives all four commands on
+        # every non-empty decode submission.
+        reload_plan = self.plan_decode_reload(model_input)
+        kwargs.update(
+            reload_inputs=reload_plan.reload_inputs,
+            reload_page_table=reload_plan.reload_page_table,
+            reload_sampling_params=reload_plan.reload_sampling_params,
+            reset_sampling_state=reload_plan.reset_sampling_state,
         )
-        reload_plan = None
-        if contract_version >= 1:
-            reload_plan = self.plan_decode_reload(model_input)
-            kwargs.update(
-                reload_inputs=reload_plan.reload_inputs,
-                reload_page_table=reload_plan.reload_page_table,
-                reload_sampling_params=reload_plan.reload_sampling_params,
-                reset_sampling_state=reload_plan.reset_sampling_state,
-            )
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
@@ -799,8 +788,7 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
-        if reload_plan is not None:
-            self.commit_decode_submission(model_input, reload_plan)
+        self.commit_decode_submission(model_input, reload_plan)
         if (
             perform_device_sampling
             and runner.parallel_config.data_parallel_size == 1

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -77,7 +77,6 @@ class DPGatherHandle:
     any_needs_logprobs: bool
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-    request_state_snapshot_id: int | None
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):
@@ -505,7 +504,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             local_needs_logprobs,
             req_ids,
             req_id_to_index,
-            request_state_snapshot_id,
         ) = all_local_inputs
         max_blocks_decode = None
         any_structured_inputs = False
@@ -735,7 +733,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             any_needs_logprobs=any_needs_logprobs,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
@@ -774,7 +771,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     my_logprobs_val,
                     handle.req_ids,
                     handle.req_id_to_index,
-                    handle.request_state_snapshot_id,
                 ),
             )[0]
             return output

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -500,7 +500,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             local_max_blocks,
             local_has_structured,
             local_has_penalties,
-            local_reset_batch,
+            local_decode_layout_changed,
             local_can_sample_device,
             local_needs_logprobs,
             req_ids,
@@ -518,7 +518,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     local_max_blocks,
                     local_has_structured,
                     local_has_penalties,
-                    local_reset_batch,
+                    local_decode_layout_changed,
                     1 - local_can_sample_device,
                     local_needs_logprobs,
                 ],
@@ -528,7 +528,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             max_blocks_decode = int(input_info_t[0].item())
             any_structured_inputs = input_info_t[1].item() > 0
             any_penalties_inputs = input_info_t[2].item() > 0
-            any_reset_batch = input_info_t[3].item() > 0
+            any_decode_layout_changed = input_info_t[3].item() > 0
             all_sample_device = input_info_t[4].item() == 0
             any_needs_logprobs = input_info_t[5].item() > 0
 
@@ -577,7 +577,9 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     dist.recv(stacked_float, src=0, group=group)
 
             gathered_tokens_inputs = None
-            if any_penalties_inputs and (not all_sample_device or any_reset_batch):
+            if any_penalties_inputs and (
+                not all_sample_device or any_decode_layout_changed
+            ):
                 if rank == 0:
                     gathered_tokens_inputs = [None for _ in range(world)]
                 local_tokens_inputs = decode_inputs["sampling_tokens_inputs"]
@@ -653,7 +655,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     "float_inputs": stacked_float,
                     "sampling_tokens_inputs": gathered_tokens_inputs,
                     "host_only_sample_params": gathered_host_only_sample_params,
-                    "reset_batch": any_reset_batch,
+                    "decode_layout_changed": any_decode_layout_changed,
                     "all_sample_device": all_sample_device,
                 }
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -714,12 +714,14 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 )
             else:
                 self.model_executor.collective_rpc("note_dp_prefill_submitted")
-            if is_decode and all_sample_device:
-                # Each DP rank built its remap from local persistent state.
-                # Consume it only after the globally merged device-sampling
-                # submission has been accepted.
+            if is_decode and local_input is not None:
+                # Each participating DP rank built its remap from local
+                # persistent state. Commit it only after the globally merged
+                # submission has accepted it. The worker preserves v0's
+                # historical device-sampling-only consumption rule.
                 self.model_executor.collective_rpc(
-                    "commit_device_sampling_slot_updates"
+                    "commit_dp_slot_updates",
+                    args=(all_sample_device,),
                 )
         else:
             future = self._completed_dp_gather_future()

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -77,6 +77,7 @@ class DPGatherHandle:
     any_needs_logprobs: bool
     req_ids: list[str]
     req_id_to_index: dict[str, int]
+    request_state_snapshot_id: int | None
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):
@@ -404,21 +405,21 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             model_output = self.dp_gather_finalize(handle)
             if handle.scheduler_output is None:
                 return {}
+            # Match the synchronous/upstream engine ordering: aborts that
+            # arrived while the device step was in flight must update
+            # scheduler membership before its old output is applied.
+            self._process_aborts_queue()
             return self.scheduler.update_from_output(
                 handle.scheduler_output, model_output
             )
 
-        # Always finalize the previous step before submitting the next one.
-        #
-        # The submit reads ``input_batch.token_ids_cpu`` to build the decode
-        # input for the next step; that table is only updated once
-        # ``apply_dp_execution_result`` runs inside ``_finalize_previous``. The
-        # original overlap path (submit-next then finalize-prev) therefore
-        # built the next step's input from stale token state, so the device
-        # re-sampled the previous step's near-deterministic position — most
-        # visibly as doubled ``<|end|>`` and ``<|start|>assistant`` tokens,
-        # which break harmony parsing and silently null out chat responses.
-        finalize_before_submit = prev_handle is not None
+        # A contract-aware steady device decode deliberately builds the next
+        # step while host token/position state is one step behind: its explicit
+        # update plan preserves device-resident token/position buffers (and may
+        # refresh only page tables). Every transition requiring host inputs or
+        # sampling-state changes reports ``current_overlap_ok=False`` and
+        # drains first, re-establishing host authority before submission.
+        finalize_before_submit = prev_handle is not None and not current_overlap_ok
 
         engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
         if finalize_before_submit:
@@ -504,6 +505,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             local_needs_logprobs,
             req_ids,
             req_id_to_index,
+            request_state_snapshot_id,
         ) = all_local_inputs
         max_blocks_decode = None
         any_structured_inputs = False
@@ -703,6 +705,20 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 ),
             )
             future = _unwrap_single_worker_future(collective_future)
+            if is_decode:
+                self.model_executor.collective_rpc(
+                    "note_dp_decode_submitted",
+                    args=(all_sample_device,),
+                )
+            else:
+                self.model_executor.collective_rpc("note_dp_prefill_submitted")
+            if is_decode and all_sample_device:
+                # Each DP rank built its remap from local persistent state.
+                # Consume it only after the globally merged device-sampling
+                # submission has been accepted.
+                self.model_executor.collective_rpc(
+                    "commit_device_sampling_slot_updates"
+                )
         else:
             future = self._completed_dp_gather_future()
 
@@ -715,6 +731,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             any_needs_logprobs=any_needs_logprobs,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
@@ -753,6 +770,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     my_logprobs_val,
                     handle.req_ids,
                     handle.req_id_to_index,
+                    handle.request_state_snapshot_id,
                 ),
             )[0]
             return output

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -256,6 +256,10 @@ class InputBatch:
 
     def commit_slot_remap(self) -> None:
         """Mark the pending remap as consumed by an accepted decode submit."""
+        self.reset_slot_remap()
+
+    def reset_slot_remap(self) -> None:
+        """Discard the pending remap because no continuing slot state remains."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -373,8 +377,8 @@ class InputBatch:
         )
 
         # Update fast-path bookkeeping sets.
-        # NOTE: Use `discard()` because `req_id` can be reused (abort+resubmit)
-        # and slots can be overwritten.
+        # Use `discard()` because slots can be overwritten and the request may
+        # not currently be present in a particular fast-path set.
         if sampling_params.temperature == 0.0:
             self.random_reqs.discard(req_id)
         else:
@@ -475,10 +479,7 @@ class InputBatch:
             # No continuing request state remains to remap. A non-identity
             # mapping composed before the last removal must not be replayed
             # onto slots initialized later by unrelated requests.
-            self._slot_remap = torch.arange(
-                self.max_num_reqs,
-                dtype=torch.int32,
-            )
+            self.reset_slot_remap()
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -1157,7 +1157,7 @@ class TTLaneInputBatch(InputBatch):
         if perform_device_sampling and not lane_batch.no_penalties:
             prompt_tokens = lane_batch.make_prompt_token_ids_tensor(rows_all)
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
-        reset_batch = runner._decode_layout_changed_since_last_decode
+        decode_layout_changed = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
         # Device-sampling state owns this remap. Merely building a host-sampling
         # input must not consume it; submit_decode commits it after a successful
@@ -1181,7 +1181,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host sampling reads the merged batch directly (see
             # ``extract_output``); the per-rank sidecars are unused here.
@@ -1263,7 +1263,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=False,
+            decode_layout_changed=False,
             slot_remap=None,
             allowed_token_ids_mask_list=[None],
             bad_words_token_ids_list=[{}],

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -1162,9 +1162,7 @@ class TTLaneInputBatch(InputBatch):
         # Device-sampling state owns this remap. Merely building a host-sampling
         # input must not consume it; submit_decode commits it after a successful
         # contract-aware device-sampling submission.
-        slot_remap = (
-            lane_batch.peek_slot_remap() if perform_device_sampling else None
-        )
+        slot_remap = lane_batch.peek_slot_remap() if perform_device_sampling else None
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -241,21 +241,21 @@ class InputBatch:
         # Sampling-related.
         self.sampling = SamplingInputBatch(max_num_reqs, logitsprocs=logitsprocs)
 
-        # Slot remap for seed manager: remap[i] = j means slot i's data came
-        # from slot j after condense.  Identity when nothing moved.
+        # Pending persistent-state remap: remap[i] = j means slot i's data
+        # came from slot j after condense. This covers sampler state and any
+        # model-owned per-slot decode state. Identity when nothing moved.
         self._slot_remap = torch.arange(max_num_reqs, dtype=torch.int32)
 
     def peek_slot_remap(self) -> torch.Tensor:
         """Return the pending slot remap without consuming it.
 
-        A batch may temporarily fall back to host sampling. In that case the
-        device sampler has not consumed the remap, so clearing it would lose the
-        RNG/state move required when device sampling resumes.
+        Building an input does not prove that the model accepted it. Keep the
+        composed remap pending until the successful decode-submission boundary.
         """
         return self._slot_remap.clone()
 
     def commit_slot_remap(self) -> None:
-        """Mark the pending remap as consumed by a device-sampling submit."""
+        """Mark the pending remap as consumed by an accepted decode submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -472,6 +472,13 @@ class InputBatch:
             # The batched states are empty.
             self._req_ids.clear()
             self.req_output_token_ids.clear()
+            # No continuing request state remains to remap. A non-identity
+            # mapping composed before the last removal must not be replayed
+            # onto slots initialized later by unrelated requests.
+            self._slot_remap = torch.arange(
+                self.max_num_reqs,
+                dtype=torch.int32,
+            )
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices
@@ -1159,10 +1166,10 @@ class TTLaneInputBatch(InputBatch):
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
         decode_layout_changed = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
-        # Device-sampling state owns this remap. Merely building a host-sampling
-        # input must not consume it; submit_decode commits it after a successful
-        # contract-aware device-sampling submission.
-        slot_remap = lane_batch.peek_slot_remap() if perform_device_sampling else None
+        # The remap covers any persistent per-slot model state, not just the
+        # device sampler. Merely building the input does not consume it;
+        # submit_decode commits after a contract-aware decode accepts it.
+        slot_remap = lane_batch.peek_slot_remap()
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -245,10 +245,27 @@ class InputBatch:
         # from slot j after condense.  Identity when nothing moved.
         self._slot_remap = torch.arange(max_num_reqs, dtype=torch.int32)
 
-    def pop_slot_remap(self) -> torch.Tensor:
-        """Return pending slot remap and reset to identity."""
-        remap = self._slot_remap
+    def peek_slot_remap(self) -> torch.Tensor:
+        """Return the pending slot remap without consuming it.
+
+        A batch may temporarily fall back to host sampling. In that case the
+        device sampler has not consumed the remap, so clearing it would lose the
+        RNG/state move required when device sampling resumes.
+        """
+        return self._slot_remap.clone()
+
+    def commit_slot_remap(self) -> None:
+        """Mark the pending remap as consumed by a device-sampling submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
+
+    def pop_slot_remap(self) -> torch.Tensor:
+        """Legacy eager-consume helper.
+
+        New decode submission code uses :meth:`peek_slot_remap` and commits only
+        after device sampling actually accepts the update.
+        """
+        remap = self.peek_slot_remap()
+        self.commit_slot_remap()
         return remap
 
     @property
@@ -1142,7 +1159,12 @@ class TTLaneInputBatch(InputBatch):
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
         reset_batch = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
-        slot_remap = lane_batch.pop_slot_remap()  # identity for stable slots
+        # Device-sampling state owns this remap. Merely building a host-sampling
+        # input must not consume it; submit_decode commits it after a successful
+        # contract-aware device-sampling submission.
+        slot_remap = (
+            lane_batch.peek_slot_remap() if perform_device_sampling else None
+        )
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -256,10 +256,6 @@ class InputBatch:
 
     def commit_slot_remap(self) -> None:
         """Mark the pending remap as consumed by an accepted decode submit."""
-        self.reset_slot_remap()
-
-    def reset_slot_remap(self) -> None:
-        """Discard the pending remap because no continuing slot state remains."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -476,10 +472,6 @@ class InputBatch:
             # The batched states are empty.
             self._req_ids.clear()
             self.req_output_token_ids.clear()
-            # No continuing request state remains to remap. A non-identity
-            # mapping composed before the last removal must not be replayed
-            # onto slots initialized later by unrelated requests.
-            self.reset_slot_remap()
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -21,6 +21,38 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 
 
 @dataclass(frozen=True)
+class TTDecodeReloadPlan:
+    """Explicit host-to-device updates for one decode submission.
+
+    The TT runner is the sole owner of these decisions because it knows whether
+    the host token/position tensors are authoritative or intentionally one step
+    behind an overlapped device-sampling decode. Contract-aware generators must
+    execute these flags as commands and must not infer additional reloads from
+    tensor equality, sampling mode, or their own previous-call state.
+
+    ``reload_inputs`` is a full forward-input copy (tokens, positions, RoPE
+    inputs and page tables). ``reload_page_table`` is the cheaper page-table-only
+    copy and is only meaningful when ``reload_inputs`` is false. Sampling
+    parameters and mutable sampling state are separate so forward and sampling
+    can be split without coupling either update to the batch-layout hint.
+    """
+
+    reload_inputs: bool
+    reload_page_table: bool
+    reload_sampling_params: bool
+    reset_sampling_state: bool
+
+    @property
+    def overlap_safe(self) -> bool:
+        """Whether a device-resident decode may be submitted host-stale."""
+        return not (
+            self.reload_inputs
+            or self.reload_sampling_params
+            or self.reset_sampling_state
+        )
+
+
+@dataclass(frozen=True)
 class TTSamplingParams:
     """Sampling parameters for TT model execution.
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -150,9 +150,10 @@ class TTModelInput:
     # previous step (used by on-device sampling).
     decode_layout_changed: bool = False
 
-    # Per-rank slot remap from condense - remap[i]=j means slot i's data came
-    # from slot j. Identity when nothing moved. Shape: [total_B] (concat of
-    # per-rank [B] tensors for DP).
+    # Per-rank persistent-state remap from condense - remap[i]=j means slot i's
+    # data came from slot j. Applies to model-owned decode state as well as
+    # sampler state, including during host sampling. Identity when nothing
+    # moved. Shape: [total_B] (concat of per-rank [B] tensors for DP).
     slot_remap: torch.Tensor | None = None
 
     # Single-process DP prefill only: global stable slots supplied by the

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -148,7 +148,7 @@ class TTModelInput:
 
     # Decode-only: indicates the padded decode-batch layout changed since the
     # previous step (used by on-device sampling).
-    reset_batch: bool = False
+    decode_layout_changed: bool = False
 
     # Per-rank slot remap from condense - remap[i]=j means slot i's data came
     # from slot j. Identity when nothing moved. Shape: [total_B] (concat of

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -932,7 +932,7 @@ class TTModelRunner:
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
             ]
-            reset_batch = False
+            decode_layout_changed = False
         else:
             positions_np = input_batch.num_tokens[req_indices] - 1
             input_positions = torch.from_numpy(positions_np)
@@ -942,7 +942,7 @@ class TTModelRunner:
             prompt_lens = None
             # For on-device decode sampling, tell the backend if the padded
             # decode batch layout changed since the previous step.
-            reset_batch = self._decode_layout_changed_since_last_decode
+            decode_layout_changed = self._decode_layout_changed_since_last_decode
             self._decode_layout_changed_since_last_decode = False
 
             # TODO: Remove once TT models can support arbitrary batch sizes.
@@ -1142,7 +1142,7 @@ class TTModelRunner:
             grammar_bitmask=[bitmask],  # wrap to match DP case
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
@@ -1526,7 +1526,7 @@ class TTModelRunner:
             Only provided when there are requests with penalties.
             One dict per DP rank, each with keys "prompt_tokens" and
             "output_tokens" (tensors padded with -1).
-          - "reset_batch": bool for if the batch layout changed
+          - "decode_layout_changed": bool for if the batch layout changed
             since the previous step.
           - "all_sample_device": bool for if all ranks can sample on device.
         """
@@ -1568,7 +1568,7 @@ class TTModelRunner:
             )
             B = self.tt_per_lane_max_num_seqs
             W = max_blocks_decode_batch
-            reset_batch = inputs["reset_batch"]
+            decode_layout_changed = inputs["decode_layout_changed"]
             perform_device_sampling = inputs["all_sample_device"]
             stacked_int: torch.Tensor = inputs["int_inputs"]
             stacked_float: torch.Tensor = inputs["float_inputs"]
@@ -1730,7 +1730,7 @@ class TTModelRunner:
             seed_list: list[torch.Tensor] = []
             num_logprobs_list: list[torch.Tensor] = []
             enable_log_probs_list: list[torch.Tensor] = []
-            reset_batch = False
+            decode_layout_changed = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
             if not active_inputs:
@@ -1950,7 +1950,7 @@ class TTModelRunner:
             grammar_bitmask=grammar_bitmask_list,
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host-only sampling params (per-rank lists)
             allowed_token_ids_mask_list=allowed_token_ids_mask_list,
@@ -2539,7 +2539,7 @@ class TTModelRunner:
         """
         model_input = None
         has_penalties = 0
-        reset_batch = 0
+        decode_layout_changed = 0
         can_sample_device = 1
         needs_logprobs = 0
         req_ids: list[str] = []
@@ -2549,7 +2549,7 @@ class TTModelRunner:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
                 has_penalties = int(not self.input_batch.no_penalties)
-                reset_batch = int(model_input.reset_batch)
+                decode_layout_changed = int(model_input.decode_layout_changed)
                 can_sample_device = int(model_input.perform_device_sampling)
                 max_num_logprobs = model_input.max_num_logprobs[0]
                 # max_num_logprobs=0 still requests the sampled token's logprob.
@@ -2571,7 +2571,7 @@ class TTModelRunner:
             max_blocks,
             has_structured_input,
             has_penalties,
-            reset_batch,
+            decode_layout_changed,
             can_sample_device,
             needs_logprobs,
             req_ids,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -211,11 +211,6 @@ class TTModelRunner:
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
         self.async_decode = TTAsyncDecodeController(self)
-        # Gathered-DP results cross the engine/worker boundary as tensors.
-        # Keep the corresponding request-object identities local so an
-        # abort+resubmit that reuses a request ID cannot accept an old result.
-        self._next_dp_request_state_snapshot_id = 0
-        self._dp_request_state_snapshots: dict[int, tuple[CachedRequestState, ...]] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -617,12 +612,9 @@ class TTModelRunner:
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
 
-        # Remove the finished requests from the persistent batch.
-        # NOTE(woosuk): There could be an edge case where finished_req_ids and
-        # scheduled_req_ids overlap. This happens when a request is aborted and
-        # then resubmitted with the same ID. In this case, we treat them as two
-        # distinct requests - clearing the cached states for the first request
-        # and handling the second as a new request.
+        # Remove the finished requests from the persistent batch. vLLM gives
+        # each accepted request a fresh internal ID, including when a client
+        # aborts and resubmits the same external ID.
         removed_req_indices: list[int] = []
         for req_id in scheduler_output.finished_req_ids:
             req_index = self.input_batch.remove_request(req_id)
@@ -651,6 +643,12 @@ class TTModelRunner:
             assert req_index is not None
             removed_req_indices.append(req_index)
             persistent_batch_layout_changed = True
+
+        # A pending remap refers only to continuing occupants of the old
+        # layout. If removals empty the batch, discard it before this same
+        # scheduler update can refill every freed slot and bypass condense().
+        if removed_req_indices and self.input_batch.num_reqs == 0:
+            self.input_batch.reset_slot_remap()
 
         req_ids_to_add: list[str] = []
         # Add new requests to the cached states.
@@ -1173,8 +1171,6 @@ class TTModelRunner:
         # continuing requests need the accepted token appended before current
         # host tensors are built. A request may remain live while unscheduled,
         # so its captured request state must still receive the accepted token.
-        # Captured request-object identity separately protects abort+resubmit
-        # with the same request ID.
         self._update_states(scheduler_output)
         skipped = set(scheduler_output.finished_req_ids)
         skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
@@ -2533,7 +2529,6 @@ class TTModelRunner:
         int,
         list[str],
         dict[str, int],
-        int | None,
     ]:
         """Build the per-rank DP payload consumed by gather orchestration.
 
@@ -2547,7 +2542,6 @@ class TTModelRunner:
         needs_logprobs = 0
         req_ids: list[str] = []
         req_id_to_index: dict[str, int] = {}
-        request_state_snapshot_id: int | None = None
         if scheduler_output is not None:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
@@ -2560,11 +2554,6 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
-                request_state_snapshot_id = self._next_dp_request_state_snapshot_id
-                self._next_dp_request_state_snapshot_id += 1
-                self._dp_request_state_snapshots[request_state_snapshot_id] = tuple(
-                    self.requests[req_id] for req_id in req_ids
-                )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (
             int(model_input.grammar_bitmask[0] is not None) if model_input else 0
@@ -2579,7 +2568,6 @@ class TTModelRunner:
             needs_logprobs,
             req_ids,
             req_id_to_index,
-            request_state_snapshot_id,
         )
 
     def submit_dp_execution(
@@ -2619,7 +2607,6 @@ class TTModelRunner:
         logprobs_lists: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
-        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
@@ -2628,34 +2615,12 @@ class TTModelRunner:
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        request_states = (
-            self._dp_request_state_snapshots.pop(request_state_snapshot_id)
-            if request_state_snapshot_id is not None
-            else None
-        )
-        invalid_req_ids = (
-            {
-                req_id
-                for req_id, captured_state in zip(req_ids or (), request_states)
-                if self.requests.get(req_id) is not captured_state
-            }
-            if request_states is not None
-            else set()
-        )
-        output = self.apply_and_build_runner_output(
+        return self.apply_and_build_runner_output(
             sampled_token_ids,
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_states=request_states,
         )
-        # Identity-invalid rows belong to an aborted/replaced request. Keep
-        # their wire positions, but expose no generated token so the scheduler
-        # cannot apply an old in-flight result to a new request with the same
-        # string ID.
-        for req_id in invalid_req_ids:
-            output.sampled_token_ids[output.req_id_to_index[req_id]] = []
-        return output
 
     def _get_output_tokens(
         self,
@@ -2936,14 +2901,13 @@ class TTModelRunner:
         self,
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
-        request_states: tuple[CachedRequestState, ...] | None = None,
         skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
-        # time: lane mode pins each request to a stable slot for its lifetime
-        # and the ``request_states`` identity check guards slot reuse, so the
-        # live row equals the captured one. ``req_id_to_index`` is therefore the
+        # time. vLLM assigns a fresh internal ID to every accepted request, so
+        # a live lookup by captured ID cannot resolve to a later request that
+        # reused the same external ID. ``req_id_to_index`` is therefore the
         # single source of truth for the target row.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
@@ -2986,8 +2950,6 @@ class TTModelRunner:
             req_state = self.requests.get(req_id)
             if req_state is None:
                 continue
-            if request_states is not None and req_state is not request_states[req_idx]:
-                continue
 
             current_row = self.input_batch.req_id_to_index.get(req_id)
             if current_row is not None:
@@ -3011,7 +2973,6 @@ class TTModelRunner:
         logprobs: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
-        request_states: tuple[CachedRequestState, ...] | None = None,
     ):
         """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
@@ -3021,7 +2982,6 @@ class TTModelRunner:
         self._apply_sampled_tokens_to_state(
             sampled_token_ids=sampled_token_ids,
             req_ids=req_ids,
-            request_states=request_states,
         )
         return self._build_runner_output(
             sampled_token_ids=sampled_token_ids,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -834,8 +834,9 @@ class TTModelRunner:
                 structured-output bitmasks.
             grammar_output: Structured-output bitmasks for this step, or
                 ``None`` when no request uses guided decoding.
-            capture_slot_remap: Whether to pop and attach the input batch's
-                pending slot remap.
+            capture_slot_remap: Whether to attach the input batch's pending
+                slot remap. The remap is committed only after a decode accepts
+                it.
 
         Returns:
             A ``TTModelInput`` with tokens, positions, block tables, sampling
@@ -1119,12 +1120,14 @@ class TTModelRunner:
 
         block_tables_per_group = [bt.contiguous() for bt in block_tables_per_group]
         block_tables = block_tables_per_group[0]
-        # Slot remap belongs to mutable device-sampling state. Keep it sticky
-        # across host-sampling steps and consume it only after an actual
-        # device-sampling decode submission.
+        # Slot remap describes the whole persistent decode layout, not only
+        # sampling state: a model may also own per-slot recurrent/conv state.
+        # Contract-v1 adapters therefore receive it for host- and
+        # device-sampling decodes. Legacy delivery is filtered at the model
+        # call boundary so version-0 adapters keep their old call shape.
         slot_remap = (
             input_batch.peek_slot_remap()
-            if capture_slot_remap and not is_prompt and perform_device_sampling
+            if capture_slot_remap and not is_prompt
             else None
         )
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -215,9 +215,7 @@ class TTModelRunner:
         # Keep the corresponding request-object identities local so an
         # abort+resubmit that reuses a request ID cannot accept an old result.
         self._next_dp_request_state_snapshot_id = 0
-        self._dp_request_state_snapshots: dict[
-            int, tuple[CachedRequestState, ...]
-        ] = {}
+        self._dp_request_state_snapshots: dict[int, tuple[CachedRequestState, ...]] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -1251,6 +1249,24 @@ class TTModelRunner:
         tail = torch.arange(n, max_batch, dtype=torch.int32, device=flat.device)
         return torch.cat([flat, tail])
 
+    @staticmethod
+    def _globalize_dp_slot_remap(raw_remap: torch.Tensor) -> torch.Tensor:
+        """Convert rank-local seed slots into the merged DP slot namespace."""
+        if raw_remap.dim() != 2:
+            raise ValueError(
+                "DP slot remap must have shape [world_size, per_rank_batch]"
+            )
+        per_rank_batch = raw_remap.shape[1]
+        offsets = (
+            torch.arange(
+                raw_remap.shape[0],
+                dtype=raw_remap.dtype,
+                device=raw_remap.device,
+            ).unsqueeze(1)
+            * per_rank_batch
+        )
+        return (raw_remap + offsets).reshape(-1)
+
     def build_dp_decode_gather_input(
         self,
         model_input: TTModelInput | None,
@@ -1627,8 +1643,7 @@ class TTModelRunner:
             # the row-sharded SeedManager uses global indices [0, total_B).
             # Offset each rank's remap values by rank * B.
             raw_remap = stacked_int[:, off : off + B]  # [world, B]
-            offsets = torch.arange(world, dtype=torch.int32).unsqueeze(1) * B
-            slot_remap = (raw_remap + offsets).reshape(total_B)
+            slot_remap = self._globalize_dp_slot_remap(raw_remap)
             off += B
 
             # Optional structured inputs: keep as list[Optional[tensor]]
@@ -1989,9 +2004,7 @@ class TTModelRunner:
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps(
-                apply_completed=False
-            )
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
@@ -2127,9 +2140,7 @@ class TTModelRunner:
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps(
-                apply_completed=False
-            )
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -2546,12 +2557,10 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
-                request_state_snapshot_id = (
-                    self._next_dp_request_state_snapshot_id
-                )
+                request_state_snapshot_id = self._next_dp_request_state_snapshot_id
                 self._next_dp_request_state_snapshot_id += 1
-                self._dp_request_state_snapshots[request_state_snapshot_id] = (
-                    tuple(self.requests[req_id] for req_id in req_ids)
+                self._dp_request_state_snapshots[request_state_snapshot_id] = tuple(
+                    self.requests[req_id] for req_id in req_ids
                 )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -211,6 +211,13 @@ class TTModelRunner:
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
         self.async_decode = TTAsyncDecodeController(self)
+        # Gathered-DP results cross the engine/worker boundary as tensors.
+        # Keep the corresponding request-object identities local so an
+        # abort+resubmit that reuses a request ID cannot accept an old result.
+        self._next_dp_request_state_snapshot_id = 0
+        self._dp_request_state_snapshots: dict[
+            int, tuple[CachedRequestState, ...]
+        ] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -1114,7 +1121,14 @@ class TTModelRunner:
 
         block_tables_per_group = [bt.contiguous() for bt in block_tables_per_group]
         block_tables = block_tables_per_group[0]
-        slot_remap = input_batch.pop_slot_remap() if capture_slot_remap else None
+        # Slot remap belongs to mutable device-sampling state. Keep it sticky
+        # across host-sampling steps and consume it only after an actual
+        # device-sampling decode submission.
+        slot_remap = (
+            input_batch.peek_slot_remap()
+            if capture_slot_remap and not is_prompt and perform_device_sampling
+            else None
+        )
 
         return TTModelInput(
             input_tokens=input_tokens,
@@ -1153,8 +1167,17 @@ class TTModelRunner:
         For data parallel, this function is called by each DP rank to build
         TTModelInput from it's own scheduler output.
         """
-        # Update cached state
+        # Update scheduler-owned membership before applying a drained async
+        # output. Finished/resumed requests must reject the speculative token;
+        # continuing requests need the accepted token appended before current
+        # host tensors are built. A request may remain live while unscheduled,
+        # so its captured request state must still receive the accepted token.
+        # Captured request-object identity separately protects abort+resubmit
+        # with the same request ID.
         self._update_states(scheduler_output)
+        skipped = set(scheduler_output.finished_req_ids)
+        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if not scheduler_output.total_num_scheduled_tokens:
             return None
 
@@ -1960,18 +1983,22 @@ class TTModelRunner:
             )
 
         lane_batch = self.lane_batch
-        self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_dp_decode_from_scheduler(
                 scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(
+                apply_completed=False
+            )
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
         )
+        skipped = set(scheduler_output.finished_req_ids)
+        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
 
@@ -2094,14 +2121,15 @@ class TTModelRunner:
         # thread. In steady decode mode we intentionally allow one step of
         # lag between host application and device submission, but we never let
         # completed work pile up unbounded.
-        self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_decode_from_scheduler(
                 scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(
+                apply_completed=False
+            )
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -2373,8 +2401,11 @@ class TTModelRunner:
             # Store rope_deltas for each prefilled request
             for i, req_id in enumerate(self.input_batch.req_ids):
                 self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
+            self.async_decode.note_prefill_submitted()
             return tt_out
-        return self.model.prefill_forward(**kwargs)
+        tt_out = self.model.prefill_forward(**kwargs)
+        self.async_decode.note_prefill_submitted()
+        return tt_out
 
     def _forward_with_model_input(
         self,
@@ -2488,6 +2519,7 @@ class TTModelRunner:
         int,
         list[str],
         dict[str, int],
+        int | None,
     ]:
         """Build the per-rank DP payload consumed by gather orchestration.
 
@@ -2501,6 +2533,7 @@ class TTModelRunner:
         needs_logprobs = 0
         req_ids: list[str] = []
         req_id_to_index: dict[str, int] = {}
+        request_state_snapshot_id: int | None = None
         if scheduler_output is not None:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
@@ -2513,6 +2546,13 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
+                request_state_snapshot_id = (
+                    self._next_dp_request_state_snapshot_id
+                )
+                self._next_dp_request_state_snapshot_id += 1
+                self._dp_request_state_snapshots[request_state_snapshot_id] = (
+                    tuple(self.requests[req_id] for req_id in req_ids)
+                )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (
             int(model_input.grammar_bitmask[0] is not None) if model_input else 0
@@ -2527,6 +2567,7 @@ class TTModelRunner:
             needs_logprobs,
             req_ids,
             req_id_to_index,
+            request_state_snapshot_id,
         )
 
     def submit_dp_execution(
@@ -2566,6 +2607,7 @@ class TTModelRunner:
         logprobs_lists: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
@@ -2574,12 +2616,34 @@ class TTModelRunner:
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        return self.apply_and_build_runner_output(
+        request_states = (
+            self._dp_request_state_snapshots.pop(request_state_snapshot_id)
+            if request_state_snapshot_id is not None
+            else None
+        )
+        invalid_req_ids = (
+            {
+                req_id
+                for req_id, captured_state in zip(req_ids or (), request_states)
+                if self.requests.get(req_id) is not captured_state
+            }
+            if request_states is not None
+            else set()
+        )
+        output = self.apply_and_build_runner_output(
             sampled_token_ids,
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            request_states=request_states,
         )
+        # Identity-invalid rows belong to an aborted/replaced request. Keep
+        # their wire positions, but expose no generated token so the scheduler
+        # cannot apply an old in-flight result to a new request with the same
+        # string ID.
+        for req_id in invalid_req_ids:
+            output.sampled_token_ids[output.req_id_to_index[req_id]] = []
+        return output
 
     def _get_output_tokens(
         self,
@@ -2861,6 +2925,7 @@ class TTModelRunner:
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
         request_states: tuple[CachedRequestState, ...] | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
@@ -2904,6 +2969,8 @@ class TTModelRunner:
         assert req_ids is not None
         captured_req_ids = req_ids
         for req_idx, req_id in enumerate(captured_req_ids):
+            if skip_req_ids is not None and req_id in skip_req_ids:
+                continue
             req_state = self.requests.get(req_id)
             if req_state is None:
                 continue
@@ -2932,6 +2999,7 @@ class TTModelRunner:
         logprobs: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        request_states: tuple[CachedRequestState, ...] | None = None,
     ):
         """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
@@ -2941,6 +3009,7 @@ class TTModelRunner:
         self._apply_sampled_tokens_to_state(
             sampled_token_ids=sampled_token_ids,
             req_ids=req_ids,
+            request_states=request_states,
         )
         return self._build_runner_output(
             sampled_token_ids=sampled_token_ids,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -644,12 +644,6 @@ class TTModelRunner:
             removed_req_indices.append(req_index)
             persistent_batch_layout_changed = True
 
-        # A pending remap refers only to continuing occupants of the old
-        # layout. If removals empty the batch, discard it before this same
-        # scheduler update can refill every freed slot and bypass condense().
-        if removed_req_indices and self.input_batch.num_reqs == 0:
-            self.input_batch.reset_slot_remap()
-
         req_ids_to_add: list[str] = []
         # Add new requests to the cached states.
         for new_req_data in scheduler_output.scheduled_new_reqs:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -690,10 +690,10 @@ class TTPlatform(Platform):
                 "Unset sample_on_device_mode or use a model that supports it."
             )
 
-        # Model-gated async scheduling. Async overlap requires generators that
-        # support split decode submission via `decode_forward(...,
-        # read_from_device=False)` followed by `read_decode_output(...,
-        # async_read=True)`.
+        # Model-gated async scheduling. The capability certifies both split
+        # decode submission/readback and device-resident sampled-token feedback
+        # between decode steps. Models without it use conservative full input
+        # reloads and cannot enable scheduler overlap.
         supports_async_decode = (
             model_capabilities.get("supports_async_decode", False)
             if model_capabilities

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -376,14 +376,16 @@ class TTWorker(WorkerBase):
         int,
         list[str],
         dict[str, int],
+        int | None,
     ]:
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, reset_batch, can_sample_device, needs_logprobs,
-        req_ids, req_id_to_index)`, where `local_input` is this rank's
-        TT model input (or `None`) and the remaining fields are the
-        per-rank metadata consumed by gathered-DP orchestration.
+        req_ids, req_id_to_index, request_state_snapshot_id)`, where
+        `local_input` is this rank's TT model input (or `None`) and the
+        remaining fields are the per-rank metadata consumed by gathered-DP
+        orchestration.
         """
         return self.model_runner.prepare_dp_model_input(
             scheduler_output, grammar_output
@@ -412,6 +414,18 @@ class TTWorker(WorkerBase):
         return self.model_runner.can_attempt_steady_decode_from_scheduler(
             scheduler_output, grammar_output
         )
+
+    def commit_device_sampling_slot_updates(self) -> None:
+        """Commit the local remap after a gathered device-sampling submit."""
+        self.model_runner.input_batch.commit_slot_remap()
+
+    def note_dp_decode_submitted(self, device_sampling: bool) -> None:
+        """Mirror merged decode residency on this rank's overlap controller."""
+        self.model_runner.async_decode.note_dp_decode_submitted(device_sampling)
+
+    def note_dp_prefill_submitted(self) -> None:
+        """Invalidate this rank's decode residency after merged prefill."""
+        self.model_runner.async_decode.note_prefill_submitted()
 
     def build_dp_decode_gather_input(
         self,
@@ -476,6 +490,7 @@ class TTWorker(WorkerBase):
         logprobs_lists: Optional["LogprobsLists"] = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
@@ -487,6 +502,7 @@ class TTWorker(WorkerBase):
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -376,13 +376,12 @@ class TTWorker(WorkerBase):
         int,
         list[str],
         dict[str, int],
-        int | None,
     ]:
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, decode_layout_changed, can_sample_device, needs_logprobs,
-        req_ids, req_id_to_index, request_state_snapshot_id)`, where
+        req_ids, req_id_to_index)`, where
         `local_input` is this rank's TT model input (or `None`) and the
         remaining fields are the per-rank metadata consumed by gathered-DP
         orchestration.
@@ -503,7 +502,6 @@ class TTWorker(WorkerBase):
         logprobs_lists: Optional["LogprobsLists"] = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
-        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
@@ -515,7 +513,6 @@ class TTWorker(WorkerBase):
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -381,7 +381,7 @@ class TTWorker(WorkerBase):
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
-        has_penalties, reset_batch, can_sample_device, needs_logprobs,
+        has_penalties, decode_layout_changed, can_sample_device, needs_logprobs,
         req_ids, req_id_to_index, request_state_snapshot_id)`, where
         `local_input` is this rank's TT model input (or `None`) and the
         remaining fields are the per-rank metadata consumed by gathered-DP

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -415,9 +415,22 @@ class TTWorker(WorkerBase):
             scheduler_output, grammar_output
         )
 
-    def commit_device_sampling_slot_updates(self) -> None:
-        """Commit the local remap after a gathered device-sampling submit."""
-        self.model_runner.input_batch.commit_slot_remap()
+    def commit_dp_slot_updates(self, device_sampling: bool) -> None:
+        """Commit a local remap consumed by the gathered decode submit.
+
+        Contract-v1 adapters consume layout remaps in both sampling modes.
+        Version-0 adapters retain their historical device-sampling-only call
+        shape, so a host-sampling step must leave their remap pending.
+        """
+        contract_version = int(
+            getattr(
+                self.model_runner.model,
+                "decode_input_update_contract",
+                0,
+            )
+        )
+        if contract_version >= 1 or device_sampling:
+            self.model_runner.input_batch.commit_slot_remap()
 
     def note_dp_decode_submitted(self, device_sampling: bool) -> None:
         """Mirror merged decode residency on this rank's overlap controller."""

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -21,7 +21,10 @@ def _controller(current_req_ids=("req-0",)):
     runner = SimpleNamespace(
         input_batch=SimpleNamespace(
             req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
-        )
+        ),
+        model=SimpleNamespace(
+            model_capabilities={"supports_async_decode": True}
+        ),
     )
     return TTAsyncDecodeController(runner)
 
@@ -65,6 +68,20 @@ def test_steady_device_decode_reuses_resident_inputs():
     assert not plan.reset_sampling_state
     assert plan.overlap_safe
     assert controller._submitted_page_tables is submitted_page_tables
+
+
+def test_model_without_async_decode_support_reloads_inputs_every_step():
+    controller = _controller()
+    controller.runner.model.model_capabilities["supports_async_decode"] = False
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert not plan.overlap_safe
 
 
 def test_page_table_only_refresh_is_overlap_safe():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -227,81 +227,19 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
-def test_empty_batch_discards_remap_from_previous_request_lifetimes():
+def test_empty_batch_does_not_consume_pending_slot_remap():
     batch = SimpleNamespace(
         num_reqs=0,
-        max_num_reqs=4,
         _req_ids=[None],
         req_output_token_ids=[None],
         _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
     )
-    batch.reset_slot_remap = lambda: InputBatch.reset_slot_remap(batch)
 
     InputBatch.condense(batch, [0])
 
     assert batch._req_ids == []
     assert batch.req_output_token_ids == []
-    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
-
-
-def test_remove_all_discards_pending_remap_before_same_step_refill(monkeypatch):
-    class FakeBatch:
-        max_num_reqs = 4
-
-        def __init__(self):
-            self.req_id_to_index = {"old": 0}
-            self._slot_remap = torch.tensor([3, 1, 2, 3], dtype=torch.int32)
-            self.remap_seen_at_add = None
-
-        @property
-        def num_reqs(self):
-            return len(self.req_id_to_index)
-
-        def remove_request(self, req_id):
-            return self.req_id_to_index.pop(req_id, None)
-
-        def reset_slot_remap(self):
-            InputBatch.reset_slot_remap(self)
-
-        def add_request(self, req_state, req_index):
-            self.remap_seen_at_add = self._slot_remap.clone()
-            self.req_id_to_index[req_state.req_id] = req_index
-
-        def condense(self, empty_req_indices):
-            raise AssertionError("same-step refill should consume every freed slot")
-
-        def refresh_logitsprocs(self):
-            pass
-
-    batch = FakeBatch()
-    runner = SimpleNamespace(
-        requests={"old": object()},
-        input_batch=batch,
-        encoder_cache={},
-        _decode_layout_changed_since_last_decode=False,
-    )
-    scheduler_output = SimpleNamespace(
-        finished_req_ids={"old"},
-        free_encoder_mm_hashes=[],
-        num_scheduled_tokens={"new": 1},
-        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
-        scheduled_cached_reqs=SimpleNamespace(
-            req_ids=[],
-            num_computed_tokens=[],
-            new_block_ids=[],
-            resumed_req_ids=set(),
-        ),
-    )
-    monkeypatch.setattr(
-        "vllm_tt_plugin.model_runner.build_cached_request_state",
-        lambda new_req: SimpleNamespace(req_id=new_req.req_id),
-    )
-
-    TTModelRunner._update_states(runner, scheduler_output)
-
-    assert batch.req_id_to_index == {"new": 0}
-    assert batch.remap_seen_at_add.tolist() == [0, 1, 2, 3]
-    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+    assert batch._slot_remap.tolist() == [3, 1, 2, 3]
 
 
 def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-only tests for the explicit TT decode reload contract.
+
+These tests exercise only controller state and plain torch tensors. Importing
+the plugin still requires the normal ttnn-enabled test environment.
+"""
+
+from types import SimpleNamespace
+
+import torch
+from vllm_tt_plugin.async_decode import (
+    CompletedDecodeStep,
+    SubmittedStepContext,
+    TTAsyncDecodeController,
+)
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+
+def _controller(current_req_ids=("req-0",)):
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(
+            req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
+        )
+    )
+    return TTAsyncDecodeController(runner)
+
+
+def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
+    return SimpleNamespace(
+        perform_device_sampling=device_sampling,
+        reset_batch=reset_batch,
+        block_tables_per_group=[
+            torch.tensor([[page, 0]], dtype=torch.int32)
+        ],
+    )
+
+
+def _submit(controller, model_input):
+    plan = controller.plan_decode_reload(model_input)
+    controller.commit_decode_submission(model_input, plan)
+    return plan
+
+
+def test_first_device_decode_fully_initializes_forward_and_sampling_state():
+    plan = _submit(_controller(), _decode_input())
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert plan.reload_sampling_params
+    assert plan.reset_sampling_state
+    assert not plan.overlap_safe
+
+
+def test_steady_device_decode_reuses_resident_inputs():
+    controller = _controller()
+    _submit(controller, _decode_input(page=1))
+    submitted_page_tables = controller._submitted_page_tables
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert not plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert plan.overlap_safe
+    assert controller._submitted_page_tables is submitted_page_tables
+
+
+def test_page_table_only_refresh_is_overlap_safe():
+    controller = _controller()
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=2))
+
+    assert not plan.reload_inputs
+    assert plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert plan.overlap_safe
+
+
+def test_host_sampling_reloads_every_step_and_device_switch_reinitializes():
+    controller = _controller()
+    first_host = _submit(controller, _decode_input(device_sampling=False))
+    second_host = _submit(controller, _decode_input(device_sampling=False))
+    device = _submit(controller, _decode_input(device_sampling=True))
+
+    assert first_host.reload_inputs
+    assert second_host.reload_inputs
+    assert not second_host.reload_sampling_params
+    assert device.reload_inputs
+    assert device.reload_sampling_params
+    assert device.reset_sampling_state
+
+
+def test_prefill_and_layout_change_break_the_decode_chain():
+    controller = _controller()
+    _submit(controller, _decode_input())
+    controller.note_prefill_submitted()
+
+    after_prefill = _submit(controller, _decode_input())
+    layout_change = _submit(controller, _decode_input(reset_batch=True))
+
+    assert after_prefill.reload_inputs and after_prefill.reset_sampling_state
+    assert layout_change.reload_inputs and layout_change.reset_sampling_state
+
+
+def test_scheduler_layout_prediction_detects_add_remove_and_preemption():
+    controller = _controller(("req-0", "req-1"))
+
+    same = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1})
+    removed = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
+    added = SimpleNamespace(
+        num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1}
+    )
+
+    assert controller.scheduler_preserves_decode_layout(same)
+    assert not controller.scheduler_preserves_decode_layout(removed)
+    assert not controller.scheduler_preserves_decode_layout(added)
+
+
+def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
+    captured = []
+    controller = _controller()
+    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
+        kwargs
+    )
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(object(),),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+    )
+
+    controller.apply_completed_decode_step(
+        completed, skip_req_ids={"req-0"}
+    )
+
+    assert captured[0]["skip_req_ids"] == {"req-0"}
+
+
+def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    captured = []
+    runner_output = SimpleNamespace(
+        sampled_token_ids=[[7]],
+        req_id_to_index={"req-0": 0},
+    )
+    controller = _controller()
+    controller.runner.requests = {"req-0": new_req_state}
+    controller.runner._apply_sampled_tokens_to_state = (
+        lambda **kwargs: captured.append(kwargs)
+    )
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(old_req_state,),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+        runner_output=runner_output,
+    )
+
+    controller.apply_completed_decode_step(completed)
+
+    assert runner_output.sampled_token_ids == [[]]
+    assert captured[0]["skip_req_ids"] == {"req-0"}
+
+
+def test_unscheduled_live_request_keeps_completed_token_in_cached_state():
+    req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": req_state},
+        input_batch=SimpleNamespace(req_id_to_index={}),
+        model_config=SimpleNamespace(max_model_len=32),
+    )
+
+    TTModelRunner._apply_sampled_tokens_to_state(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        request_states=(req_state,),
+        skip_req_ids=set(),
+    )
+
+    assert req_state.output_token_ids == [7]
+
+
+def test_reused_request_id_rejects_captured_dp_request_identity():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": new_req_state},
+        input_batch=SimpleNamespace(req_id_to_index={"req-0": 0}),
+        model_config=SimpleNamespace(max_model_len=32),
+    )
+
+    TTModelRunner._apply_sampled_tokens_to_state(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        request_states=(old_req_state,),
+    )
+
+    assert old_req_state.output_token_ids == []
+    assert new_req_state.output_token_ids == []
+
+
+def test_reused_request_id_suppresses_old_dp_scheduler_output():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": new_req_state},
+        input_batch=SimpleNamespace(num_reqs=1),
+        _dp_request_state_snapshots={4: (old_req_state,)},
+        apply_and_build_runner_output=lambda *args, **kwargs: SimpleNamespace(
+            sampled_token_ids=[[7]],
+            req_id_to_index={"req-0": 0},
+        ),
+    )
+
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        req_id_to_index={"req-0": 0},
+        request_state_snapshot_id=4,
+    )
+
+    assert output.sampled_token_ids == [[]]
+    assert runner._dp_request_state_snapshots == {}

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -199,10 +199,11 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
-def test_submit_decode_keeps_layout_hint_inside_planner():
+def test_explicit_contract_keeps_layout_hint_inside_planner():
     captured = {}
 
     class FakeModel:
+        decode_input_update_contract = 1
         model_capabilities = {"supports_async_decode": True}
 
         def decode_forward(self, **kwargs):
@@ -245,10 +246,101 @@ def test_submit_decode_keeps_layout_hint_inside_planner():
 
     controller.submit_decode(model_input, read_from_device=False, async_read=False)
 
+    assert "reset_batch" not in captured
     assert "decode_layout_changed" not in captured
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True
+
+
+def test_legacy_contract_receives_reset_batch_without_explicit_commands(
+    monkeypatch,
+):
+    captured = {}
+    warnings = []
+    monkeypatch.setattr(
+        "vllm_tt_plugin.async_decode.logger.warning",
+        lambda *args: warnings.append(args),
+    )
+
+    class FakeLegacyModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeLegacyModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = SimpleNamespace(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.tensor([1.0]),
+            top_k=torch.tensor([32]),
+            top_p=torch.tensor([1.0]),
+            presence_penalty=torch.tensor([0.0]),
+            frequency_penalty=torch.tensor([0.0]),
+            repetition_penalty=torch.tensor([1.0]),
+            seed=torch.tensor([-1]),
+            num_logprobs=torch.tensor([-2]),
+            enable_log_probs=torch.tensor([False]),
+        ),
+        perform_device_sampling=True,
+        prompt_tokens=None,
+        output_tokens=None,
+        decode_layout_changed=True,
+        slot_remap=torch.tensor([0], dtype=torch.int32),
+    )
+
+    first_submission = controller.submit_decode(
+        model_input, read_from_device=False, async_read=False
+    )
+    second_submission = controller.submit_decode(
+        model_input, read_from_device=False, async_read=False
+    )
+
+    assert captured["reset_batch"] is True
+    assert "decode_layout_changed" not in captured
+    assert "reload_inputs" not in captured
+    assert "reload_page_table" not in captured
+    assert "reload_sampling_params" not in captured
+    assert "reset_sampling_state" not in captured
+    assert first_submission.reload_plan is None
+    assert second_submission.reload_plan is None
+    assert controller._decode_chain_valid
+    assert controller._previous_device_sampling is True
+    assert len(warnings) == 1
+
+
+def test_contract_version_does_not_change_steady_decode_eligibility():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        non_dp_async_scheduling=True,
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_rank_local=0,
+        ),
+        trace_mode="decode_only",
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    assert controller.steady_decode_base_enabled(dp_gather=False)
+
+    runner.model.decode_input_update_contract = 1
+
+    assert controller.steady_decode_base_enabled(dp_gather=False)
 
 
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -8,23 +8,24 @@ the plugin still requires the normal ttnn-enabled test environment.
 
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 from vllm_tt_plugin.async_decode import (
     CompletedDecodeStep,
     SubmittedStepContext,
     TTAsyncDecodeController,
 )
+from vllm_tt_plugin.model_input import TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
 
 
-def _controller(current_req_ids=("req-0",)):
+def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
     runner = SimpleNamespace(
         input_batch=SimpleNamespace(
             req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
         ),
-        model=SimpleNamespace(
-            model_capabilities={"supports_async_decode": True}
-        ),
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        trace_mode=trace_mode,
     )
     return TTAsyncDecodeController(runner)
 
@@ -33,9 +34,7 @@ def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
     return SimpleNamespace(
         perform_device_sampling=device_sampling,
         reset_batch=reset_batch,
-        block_tables_per_group=[
-            torch.tensor([[page, 0]], dtype=torch.int32)
-        ],
+        block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
     )
 
 
@@ -73,6 +72,19 @@ def test_steady_device_decode_reuses_resident_inputs():
 def test_model_without_async_decode_support_reloads_inputs_every_step():
     controller = _controller()
     controller.runner.model.model_capabilities["supports_async_decode"] = False
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert not plan.overlap_safe
+
+
+def test_decode_without_trace_reloads_inputs_every_step():
+    controller = _controller(trace_mode="none")
     _submit(controller, _decode_input(page=1))
 
     plan = _submit(controller, _decode_input(page=1))
@@ -123,14 +135,128 @@ def test_prefill_and_layout_change_break_the_decode_chain():
     assert layout_change.reload_inputs and layout_change.reset_sampling_state
 
 
+def test_drained_decode_updates_next_host_token_and_position_before_transition():
+    req_state = SimpleNamespace(output_token_ids=[])
+    input_batch = SimpleNamespace(
+        req_id_to_index={"req-0": 0},
+        num_tokens=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
+    )
+    runner = SimpleNamespace(
+        requests={"req-0": req_state},
+        input_batch=input_batch,
+        model_config=SimpleNamespace(max_model_len=8),
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        trace_mode="decode_only",
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller.note_dp_decode_submitted(True)
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(req_state,),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+    )
+
+    controller.apply_completed_decode_step(completed)
+    controller.note_prefill_submitted()
+    plan = controller.plan_decode_reload(_decode_input())
+
+    next_position = int(input_batch.num_tokens[0]) - 1
+    assert input_batch.token_ids_cpu[0, next_position] == 7
+    assert next_position == 3
+    assert req_state.output_token_ids == [7]
+    assert plan.reload_inputs
+    assert plan.reset_sampling_state
+
+
+def test_dp_submission_mirrors_resident_mode_and_prefill_invalidates_it():
+    controller = _controller()
+
+    controller.note_dp_decode_submitted(True)
+
+    assert controller._decode_chain_valid
+    assert controller._previous_device_sampling is True
+
+    controller.note_prefill_submitted()
+
+    assert not controller._decode_chain_valid
+
+
+def test_dp_slot_remap_is_offset_into_global_slot_namespace():
+    rank_local = torch.tensor([[3, 1, 2, 0], [2, 0, 3, 1]], dtype=torch.int32)
+
+    global_remap = TTModelRunner._globalize_dp_slot_remap(rank_local)
+
+    assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
+
+
+def test_submit_decode_keeps_layout_hint_inside_planner():
+    captured = {}
+
+    class FakeModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = SimpleNamespace(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.tensor([1.0]),
+            top_k=torch.tensor([32]),
+            top_p=torch.tensor([1.0]),
+            presence_penalty=torch.tensor([0.0]),
+            frequency_penalty=torch.tensor([0.0]),
+            repetition_penalty=torch.tensor([1.0]),
+            seed=torch.tensor([-1]),
+            num_logprobs=torch.tensor([-2]),
+            enable_log_probs=torch.tensor([False]),
+        ),
+        perform_device_sampling=True,
+        prompt_tokens=None,
+        output_tokens=None,
+        reset_batch=True,
+        slot_remap=torch.tensor([0], dtype=torch.int32),
+    )
+
+    controller.submit_decode(model_input, read_from_device=False, async_read=False)
+
+    assert "reset_batch" not in captured
+    assert captured["reload_inputs"] is True
+    assert captured["reload_sampling_params"] is True
+    assert captured["reset_sampling_state"] is True
+
+
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():
     controller = _controller(("req-0", "req-1"))
 
     same = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1})
     removed = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
-    added = SimpleNamespace(
-        num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1}
-    )
+    added = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1})
 
     assert controller.scheduler_preserves_decode_layout(same)
     assert not controller.scheduler_preserves_decode_layout(removed)
@@ -155,9 +281,7 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
         completion_time_ns=2,
     )
 
-    controller.apply_completed_decode_step(
-        completed, skip_req_ids={"req-0"}
-    )
+    controller.apply_completed_decode_step(completed, skip_req_ids={"req-0"})
 
     assert captured[0]["skip_req_ids"] == {"req-0"}
 
@@ -172,8 +296,8 @@ def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
     )
     controller = _controller()
     controller.runner.requests = {"req-0": new_req_state}
-    controller.runner._apply_sampled_tokens_to_state = (
-        lambda **kwargs: captured.append(kwargs)
+    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
+        kwargs
     )
     completed = CompletedDecodeStep(
         sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -30,10 +30,10 @@ def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
     return TTAsyncDecodeController(runner)
 
 
-def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
+def _decode_input(*, device_sampling=True, decode_layout_changed=False, page=0):
     return SimpleNamespace(
         perform_device_sampling=device_sampling,
-        reset_batch=reset_batch,
+        decode_layout_changed=decode_layout_changed,
         block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
     )
 
@@ -129,7 +129,7 @@ def test_prefill_and_layout_change_break_the_decode_chain():
     controller.note_prefill_submitted()
 
     after_prefill = _submit(controller, _decode_input())
-    layout_change = _submit(controller, _decode_input(reset_batch=True))
+    layout_change = _submit(controller, _decode_input(decode_layout_changed=True))
 
     assert after_prefill.reload_inputs and after_prefill.reset_sampling_state
     assert layout_change.reload_inputs and layout_change.reset_sampling_state
@@ -239,13 +239,13 @@ def test_submit_decode_keeps_layout_hint_inside_planner():
         perform_device_sampling=True,
         prompt_tokens=None,
         output_tokens=None,
-        reset_batch=True,
+        decode_layout_changed=True,
         slot_remap=torch.tensor([0], dtype=torch.int32),
     )
 
     controller.submit_decode(model_input, read_from_device=False, async_read=False)
 
-    assert "reset_batch" not in captured
+    assert "decode_layout_changed" not in captured
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -189,7 +189,6 @@ def test_drained_decode_updates_next_host_token_and_position_before_transition()
         context=SubmittedStepContext(
             req_ids=["req-0"],
             req_id_to_index={"req-0": 0},
-            request_states=(req_state,),
             submit_time_ns=1,
         ),
         completion_time_ns=2,
@@ -236,11 +235,72 @@ def test_empty_batch_discards_remap_from_previous_request_lifetimes():
         req_output_token_ids=[None],
         _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
     )
+    batch.reset_slot_remap = lambda: InputBatch.reset_slot_remap(batch)
 
     InputBatch.condense(batch, [0])
 
     assert batch._req_ids == []
     assert batch.req_output_token_ids == []
+    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+
+
+def test_remove_all_discards_pending_remap_before_same_step_refill(monkeypatch):
+    class FakeBatch:
+        max_num_reqs = 4
+
+        def __init__(self):
+            self.req_id_to_index = {"old": 0}
+            self._slot_remap = torch.tensor([3, 1, 2, 3], dtype=torch.int32)
+            self.remap_seen_at_add = None
+
+        @property
+        def num_reqs(self):
+            return len(self.req_id_to_index)
+
+        def remove_request(self, req_id):
+            return self.req_id_to_index.pop(req_id, None)
+
+        def reset_slot_remap(self):
+            InputBatch.reset_slot_remap(self)
+
+        def add_request(self, req_state, req_index):
+            self.remap_seen_at_add = self._slot_remap.clone()
+            self.req_id_to_index[req_state.req_id] = req_index
+
+        def condense(self, empty_req_indices):
+            raise AssertionError("same-step refill should consume every freed slot")
+
+        def refresh_logitsprocs(self):
+            pass
+
+    batch = FakeBatch()
+    runner = SimpleNamespace(
+        requests={"old": object()},
+        input_batch=batch,
+        encoder_cache={},
+        _decode_layout_changed_since_last_decode=False,
+    )
+    scheduler_output = SimpleNamespace(
+        finished_req_ids={"old"},
+        free_encoder_mm_hashes=[],
+        num_scheduled_tokens={"new": 1},
+        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            num_computed_tokens=[],
+            new_block_ids=[],
+            resumed_req_ids=set(),
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_tt_plugin.model_runner.build_cached_request_state",
+        lambda new_req: SimpleNamespace(req_id=new_req.req_id),
+    )
+
+    TTModelRunner._update_states(runner, scheduler_output)
+
+    assert batch.req_id_to_index == {"new": 0}
+    assert batch.remap_seen_at_add.tolist() == [0, 1, 2, 3]
     assert batch._slot_remap.tolist() == [0, 1, 2, 3]
 
 
@@ -581,7 +641,6 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
         context=SubmittedStepContext(
             req_ids=["req-0"],
             req_id_to_index={"req-0": 0},
-            request_states=(object(),),
             submit_time_ns=1,
         ),
         completion_time_ns=2,
@@ -589,38 +648,6 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
 
     controller.apply_completed_decode_step(completed, skip_req_ids={"req-0"})
 
-    assert captured[0]["skip_req_ids"] == {"req-0"}
-
-
-def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    captured = []
-    runner_output = SimpleNamespace(
-        sampled_token_ids=[[7]],
-        req_id_to_index={"req-0": 0},
-    )
-    controller = _controller()
-    controller.runner.requests = {"req-0": new_req_state}
-    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
-        kwargs
-    )
-    completed = CompletedDecodeStep(
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        logprobs=None,
-        context=SubmittedStepContext(
-            req_ids=["req-0"],
-            req_id_to_index={"req-0": 0},
-            request_states=(old_req_state,),
-            submit_time_ns=1,
-        ),
-        completion_time_ns=2,
-        runner_output=runner_output,
-    )
-
-    controller.apply_completed_decode_step(completed)
-
-    assert runner_output.sampled_token_ids == [[]]
     assert captured[0]["skip_req_ids"] == {"req-0"}
 
 
@@ -636,53 +663,7 @@ def test_unscheduled_live_request_keeps_completed_token_in_cached_state():
         runner,
         sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
         req_ids=["req-0"],
-        request_states=(req_state,),
         skip_req_ids=set(),
     )
 
     assert req_state.output_token_ids == [7]
-
-
-def test_reused_request_id_rejects_captured_dp_request_identity():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    runner = SimpleNamespace(
-        requests={"req-0": new_req_state},
-        input_batch=SimpleNamespace(req_id_to_index={"req-0": 0}),
-        model_config=SimpleNamespace(max_model_len=32),
-    )
-
-    TTModelRunner._apply_sampled_tokens_to_state(
-        runner,
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        req_ids=["req-0"],
-        request_states=(old_req_state,),
-    )
-
-    assert old_req_state.output_token_ids == []
-    assert new_req_state.output_token_ids == []
-
-
-def test_reused_request_id_suppresses_old_dp_scheduler_output():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    runner = SimpleNamespace(
-        requests={"req-0": new_req_state},
-        input_batch=SimpleNamespace(num_reqs=1),
-        _dp_request_state_snapshots={4: (old_req_state,)},
-        apply_and_build_runner_output=lambda *args, **kwargs: SimpleNamespace(
-            sampled_token_ids=[[7]],
-            req_id_to_index={"req-0": 0},
-        ),
-    )
-
-    output = TTModelRunner.apply_dp_execution_result(
-        runner,
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        req_ids=["req-0"],
-        req_id_to_index={"req-0": 0},
-        request_state_snapshot_id=4,
-    )
-
-    assert output.sampled_token_ids == [[]]
-    assert runner._dp_request_state_snapshots == {}

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -15,8 +15,10 @@ from vllm_tt_plugin.async_decode import (
     SubmittedStepContext,
     TTAsyncDecodeController,
 )
+from vllm_tt_plugin.input_batch import InputBatch
 from vllm_tt_plugin.model_input import TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
+from vllm_tt_plugin.worker import TTWorker
 
 
 def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
@@ -35,6 +37,33 @@ def _decode_input(*, device_sampling=True, decode_layout_changed=False, page=0):
         perform_device_sampling=device_sampling,
         decode_layout_changed=decode_layout_changed,
         block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
+    )
+
+
+def _submission_input(*, device_sampling: bool, slot_remap=(3, 1, 2, 3)):
+    return SimpleNamespace(
+        input_tokens=torch.zeros((4, 1), dtype=torch.int32),
+        input_positions=torch.zeros((4,), dtype=torch.int32),
+        block_tables=torch.zeros((4, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((4, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=4,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.ones(4),
+            top_k=torch.full((4,), 32),
+            top_p=torch.ones(4),
+            presence_penalty=torch.zeros(4),
+            frequency_penalty=torch.zeros(4),
+            repetition_penalty=torch.ones(4),
+            seed=torch.full((4,), -1),
+            num_logprobs=torch.full((4,), -2),
+            enable_log_probs=torch.zeros(4, dtype=torch.bool),
+        ),
+        perform_device_sampling=device_sampling,
+        prompt_tokens=None,
+        output_tokens=None,
+        decode_layout_changed=True,
+        slot_remap=torch.tensor(slot_remap, dtype=torch.int32),
     )
 
 
@@ -199,6 +228,45 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
+def test_empty_batch_discards_remap_from_previous_request_lifetimes():
+    batch = SimpleNamespace(
+        num_reqs=0,
+        max_num_reqs=4,
+        _req_ids=[None],
+        req_output_token_ids=[None],
+        _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
+    )
+
+    InputBatch.condense(batch, [0])
+
+    assert batch._req_ids == []
+    assert batch.req_output_token_ids == []
+    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+
+
+def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():
+    commits = []
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            model=SimpleNamespace(decode_input_update_contract=1),
+            input_batch=SimpleNamespace(
+                commit_slot_remap=lambda: commits.append("v1-host")
+            ),
+        )
+    )
+
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
+
+    worker.model_runner.model = SimpleNamespace()
+    worker.model_runner.input_batch.commit_slot_remap = lambda: commits.append(
+        "v0-device"
+    )
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=True)
+
+    assert commits == ["v1-host", "v0-device"]
+
+
 def test_explicit_contract_keeps_layout_hint_inside_planner():
     captured = {}
 
@@ -251,6 +319,152 @@ def test_explicit_contract_keeps_layout_hint_inside_planner():
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True
+
+
+def test_explicit_contract_delivers_and_commits_slot_remap_for_host_sampling():
+    captured = {}
+    commits = []
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(device_sampling=False),
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert captured["slot_remap"].tolist() == [3, 1, 2, 3]
+    assert commits == [True]
+
+
+def test_layout_change_refreshes_request_rope_even_when_request_id_is_reused():
+    captured = {}
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=True,
+        previous_req_ids={"req-0"},
+        requests={"req-0": SimpleNamespace(mrope_position_delta=17)},
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(
+            req_ids=["req-0"],
+            commit_slot_remap=lambda: None,
+        ),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(device_sampling=False),
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert captured["rope_deltas_all_users"] == [17]
+
+
+def test_slot_remap_is_not_committed_when_decode_submission_fails():
+    commits = []
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            raise RuntimeError("submission rejected")
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    try:
+        controller.submit_decode(
+            _submission_input(device_sampling=False),
+            read_from_device=False,
+            async_read=False,
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "submission rejected"
+    else:
+        raise AssertionError("decode submission should have failed")
+
+    assert commits == []
+
+
+def test_legacy_host_sampling_keeps_slot_remap_pending_for_device_sampling(
+    monkeypatch,
+):
+    calls = []
+    commits = []
+    monkeypatch.setattr(
+        "vllm_tt_plugin.async_decode.logger.warning",
+        lambda *args: None,
+    )
+
+    class FakeLegacyModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            calls.append(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeLegacyModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = _submission_input(device_sampling=False)
+
+    controller.submit_decode(
+        model_input,
+        read_from_device=False,
+        async_read=False,
+    )
+    model_input.perform_device_sampling = True
+    controller.submit_decode(
+        model_input,
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert "slot_remap" not in calls[0]
+    assert calls[1]["slot_remap"].tolist() == [3, 1, 2, 3]
+    assert commits == [True]
 
 
 def test_legacy_contract_receives_reset_batch_without_explicit_commands(

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -255,7 +255,6 @@ def test_async_lane_decode_uses_batch_extraction():
     context = SubmittedStepContext(
         req_ids=["req-4"],
         req_id_to_index={"req-4": 0},
-        request_states=(),
         submit_time_ns=123,
     )
     model_input = object()

--- a/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
+++ b/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
@@ -231,12 +231,12 @@ def test_finish_nondp_sync_applies_grammar_before_sampling():
     def apply_grammar(model_input, grammar_output, *, lane_total):
         order.append("grammar")
         assert lane_total is None
-        return replace(model_input, reset_batch=True)  # mark it was applied
+        return replace(model_input, decode_layout_changed=True)  # mark it was applied
 
     def sample_sync(fwd):
         order.append("sample")
         # Grammar must already be on the input the sampler runs against.
-        assert fwd.model_input.reset_batch is True
+        assert fwd.model_input.decode_layout_changed is True
         return [torch.tensor([[42]], dtype=torch.int32)], []
 
     def build_output(sampled, logprobs, **kwargs):


### PR DESCRIPTION
## Summary

- make vLLM the sole owner of reload policy for contract-v1 TT adapters
- translate lifecycle/layout state into four commands: `reload_inputs`, `reload_page_table`, `reload_sampling_params`, and `reset_sampling_state`
- negotiate per adapter through `decode_input_update_contract`
- preserve version-0 adapters' existing `reset_batch` reload and overlap behavior, while warning that it lacks the v1 correctness guarantee
- keep `decode_layout_changed` internal except for translation to `reset_batch` at the legacy boundary
- drain and apply deferred tokens before v1 host-authoritative transitions; keep page-table-only refresh overlap-safe
- globalize DP slot remaps before merged sampling-state updates
- document mode semantics, rollout compatibility, position advancement, and requirements for `supports_async_decode`

## Negotiation and rollout

`decode_input_update_contract` absent or `0` selects the legacy call shape. Device-sampling calls receive `reset_batch`; the four new keywords are omitted. The plugin does not add a v0-specific drain and preserves the adapter's existing reload/overlap behavior, with a once-per-controller warning.

`decode_input_update_contract >= 1` selects the explicit four-command contract. When host-authoritative inputs or sampling state must be reloaded, vLLM drains the outstanding async step and applies its token/position first. A page-table-only refresh does not drain because it does not overwrite resident token/position state.

`model_capabilities["supports_async_decode"]` remains a separate residency capability, not the protocol version.

Supported rollout order:

1. Merge this vLLM PR; it works with existing version-0 tt-metal adapters.
2. Merge tenstorrent/tt-metal#51646; its refactored adapters advertise version 1.

Old vLLM with a strict version-1 adapter is intentionally unsupported because old vLLM omits the required commands.

The tt-metal PR directly fixes decode-only seed initialization, including the `seed=None` case also fixed independently by tenstorrent/tt-metal#51556. Neither change depends on #51556.

## Validation

- `git diff --check`
- Ruff check and format over changed vLLM Python
- Python compileall over changed source and focused tests
- focused coverage for v0/v1 call shapes, one-time warning, unchanged v0 overlap eligibility, transition planning, deferred-token position application, DP residency/remap, and the exact tt-metal call boundary
- independent design and final cross-repository review; final review clean

Runtime pytest was not rerun on this host because the vLLM/PyTorch test environment is not installed. TT device coverage is tracked through the paired branch CI.

### Compatibility nightlies

- [Version 0: this vLLM branch against tt-metal `main`](https://github.com/tenstorrent/tt-metal/actions/runs/30673295371)
- [Version 1: this vLLM branch against the refactored tt-metal branch](https://github.com/tenstorrent/tt-metal/actions/runs/30673297206)

These runs validate both negotiated call paths. The only failure observed at the time of linking was a Galaxy runner-topology issue: GPT-OSS requested a 4×8/32-device mesh but the runner exposed only a 2×2/4-device mesh, before model initialization.

Fixes #449
