### PR TITLE
[TT] Centralize async decode reload planning (continuation of #456)

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -36,6 +36,9 @@ plugins/vllm-tt-plugin/
 +-- tests/tt/                # Server-facing TT plugin tests
 ```
 
+The async input-ownership rules and generator API are documented in
+[docs/decode-reload-contract.md](docs/decode-reload-contract.md).
+
 ## Requirements
 
 If testing a specific model, check the

--- a/plugins/vllm-tt-plugin/docs/SCHEDULING.md
+++ b/plugins/vllm-tt-plugin/docs/SCHEDULING.md
@@ -16,7 +16,9 @@ The current TT path is more specialized than upstream vLLM:
 
 - A TT step is treated as either all-prefill or all-decode.
 - TT does not support mixed prefill+decode batches.
-- TT does not support chunked prefill at the scheduling level.
+- Chunked prefill is per-model, not global: the platform enables it only for the
+  model types in `_CHUNKED_PREFILL_MODEL_TYPES`, and every other model is
+  scheduled without it.
 - CPU-device work overlap is a decode optimization.
 - Gathered-DP is not just "the same thing on more ranks"; it adds a global mode negotiation and a gather/execute/scatter step around every DP execution.
 
@@ -56,7 +58,7 @@ The TT scheduler prefers to admit waiting work first, because TT wants to form a
 The current TT scheduler enforces two important rules:
 
 - no mixed prefill+decode batch
-- no chunked prefill
+- no chunked prefill, unless the model type opts in (see above)
 
 So each TT scheduling step picks one of:
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,11 +42,7 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. The version-0 compatibility path can leave a remap pending after a
-host-sampling decode because legacy adapters receive remaps only during device
-sampling. If every remaining request departs before that later device decode,
-empty-batch handling discards the obsolete mapping so it cannot be replayed
-after unrelated requests reuse the slots.
+not. Version-0 adapters retain their historical remap behavior unchanged.
 
 ## Mode definitions
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -137,12 +137,20 @@ satisfies every requirement below:
 6. **Sampling-state ordering**: slot remaps are applied before parameter/state
    reset; RNG and penalty state are reset only when requested; seed advancement
    happens exactly once per sampled token.
-7. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
+7. **Host input authority**: the `tokens` and `start_pos` arguments are
+   authoritative only when `reload_inputs` is true. When it is false they are
+   deliberately one step behind, and the adapter must derive nothing from them —
+   not forward inputs, and not sampling state. Deriving an RNG counter from
+   `start_pos` on a steady step makes the sampled stream depend on when the
+   asynchronous readback landed, so the same request and seed stop reproducing.
+   An adapter that ties per-token seeds to the absolute decode position must do
+   so only on a reloading step and advance its own resident counter otherwise.
+8. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
    to all persistent state indexed by the vLLM batch slot, even when that step
    samples on the host. This includes model-internal recurrent/convolution
    state and dormant device-sampler state; a full forward-input reload does
    not implicitly repair either one.
-8. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
+9. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -2,8 +2,9 @@
 
 Async device sampling deliberately lets vLLM's host token state trail the TT
 device by one decode step. Consequently, only the vLLM runner can decide
-whether host tensors are authoritative. The paired tt-metal generator receives
-four independent boolean commands on every decode:
+whether host tensors are authoritative. A contract-aware tt-metal generator
+(`decode_input_update_contract >= 1`) receives four independent boolean
+commands on every decode:
 
 | Command | Effect |
 | --- | --- |
@@ -12,11 +13,12 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`decode_layout_changed` is an internal vLLM lifecycle signal: the planner
-translates it into the four commands, but it is not forwarded to tt-metal. `slot_remap`
-remains data: it is composed by vLLM until a device-sampling submission
-consumes it, then tt-metal applies it once before sampling state is reset or
-advanced.
+`decode_layout_changed` is an internal vLLM lifecycle signal: for an explicit
+contract adapter, the planner translates it into the four commands without
+forwarding the signal itself. For a legacy adapter, vLLM translates it to the
+old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
+it is composed by vLLM until a device-sampling submission consumes it, then
+tt-metal applies it once before sampling state is reset or advanced.
 
 ## Mode definitions
 
@@ -84,8 +86,9 @@ work cannot append runner state or emit an extra client token.
 
 ## Requirements for `supports_async_decode`
 
-Set `model_capabilities["supports_async_decode"] = True` only when the model
-adapter satisfies every requirement below:
+For a version-1 adapter, set
+`model_capabilities["supports_async_decode"] = True` only when the adapter
+satisfies every requirement below:
 
 1. **Split submission and readback**: `decode_forward(...,
    read_from_device=False)` submits decode without synchronizing the result, and
@@ -115,21 +118,46 @@ adapter satisfies every requirement below:
 The capability is fail-closed. If any requirement is not met, leave
 `supports_async_decode` absent or `False`. vLLM disables async scheduling for
 that model and requests a full forward-input reload on every decode, while
-still using the same four-command interface.
+still using the negotiated generator interface. A legacy adapter may already
+advertise `supports_async_decode`; vLLM preserves that adapter's existing
+reload and overlap behavior, but warns that correctness is not guaranteed
+until the adapter also implements and advertises contract version 1.
 
-## Deployment coupling
+## Contract negotiation
 
-The vLLM and tt-metal changes are one required contract and should be deployed
-as a pinned pair. vLLM always sends all four commands; there is no per-model
-contract-version negotiation or fallback to an older tt-metal generator.
-The paired tt-metal change includes the unconditional decode-only seed
-initialization also addressed by
+Model adapters opt in by setting `decode_input_update_contract = 1`. vLLM sends
+the four explicit commands only to adapters advertising version 1 or newer.
+Adapters without the attribute, or with version 0, receive the legacy
+`reset_batch` keyword on device-sampling calls and never receive unknown
+command keywords. Their reload and overlap behavior remains unchanged from the
+pre-contract path, including any model-local heuristics. vLLM logs a warning
+because those heuristics may observe stale host state under async decode and
+cannot provide the version-1 correctness guarantees. This compatibility path
+allows the vLLM change to land before individual tt-metal adapters are
+refactored.
+
+| vLLM | tt-metal adapter | Result |
+| --- | --- | --- |
+| Old | Legacy / version 0 | Supported: existing behavior |
+| New | Legacy / version 0 | Compatibility path: legacy behavior with a warning |
+| New | Version 1+ | Supported: explicit commands and eligible resident overlap |
+| Old | Strict version 1 | Unsupported: old vLLM omits the required commands |
+
+The supported rollout order is therefore vLLM first, followed by tt-metal
+adapter migrations. Advertising version 1 before implementing every command
+is an adapter bug and should fail loudly rather than silently falling back.
+Versions greater than 1 must remain backward-compatible supersets of version 1;
+a breaking interface requires a distinct negotiation key or supported range.
+
+`model_capabilities["supports_async_decode"]` remains independent of contract
+versioning. It controls async scheduling and certifies that sampled-token
+feedback can remain device-resident between decode steps. A version-1 model
+without that capability receives a conservative full-input reload command on
+every decode.
+
+The refactored tt-metal implementation includes the unconditional decode-only
+seed initialization also addressed by
 [tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556):
 `reset_sampling_state=True` forces seed initialization for first-decode and
 layout transitions even when both the requested and cached seed are `None`.
-The paired change implements this directly and does not depend on that PR.
-`model_capabilities["supports_async_decode"]` remains the sole per-model gate.
-It both controls async scheduling and certifies that sampled-token feedback can
-remain device-resident between decode steps. Models without it still receive
-the explicit four-command contract, but vLLM conservatively requests a full
-forward-input reload on every step.
+The implementation does not depend on that PR.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,7 +42,10 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. Empty-batch handling resets the composed layout to identity.
+not. A condense performed for a prefill/resume step records a remap without
+delivering it, because only decode consumes remaps. If every remaining request
+then departs before a later decode, empty-batch handling discards that obsolete
+mapping so it cannot be replayed after unrelated requests reuse the slots.
 
 ## Mode definitions
 
@@ -86,9 +89,9 @@ the persistent token slot contains sampled token `t_k`, and the persistent
 position is the position at which `t_k` must be consumed by step `k+1`.
 
 The base case is a full reload. vLLM first finalizes the prior non-steady step,
-filters finished, resumed, and replaced request identities, updates continuing
-host state (including a live request temporarily unscheduled this step), and
-copies authoritative token/position/layout tensors.
+filters finished and resumed requests, updates continuing host state (including
+a live request temporarily unscheduled this step), and copies authoritative
+token/position/layout tensors.
 
 For the induction step, a steady device decode issues no full or sampling-state
 reload. The trace therefore consumes the device-resident `t_k` and position,
@@ -101,12 +104,14 @@ Host sampling always performs a full reload from the accepted host token.
 Layout, resume, prefill, and sampling-mode transitions break the steady
 invariant and therefore drain and re-establish the base case.
 
-A completed async result is applied only to the captured request object when it
-is still live and was not finished/resumed. Reused request IDs fail the
-object-identity check, and their cached runner-output rows are replaced with an
-empty token list before scheduler update. vLLM's scheduler independently
-ignores outputs for requests that no longer exist, so cancelled speculative
-work cannot append runner state or emit an extra client token.
+A completed async result is applied only when its captured internal request ID
+is still live and was not finished/resumed. vLLM assigns a fresh internal ID to
+every accepted request, so aborting and resubmitting the same external ID cannot
+attach an old result to the new request. Cached runner-output rows for explicitly
+finished/resumed requests are replaced with an empty token list before scheduler
+update. vLLM's scheduler independently ignores outputs for requests that no
+longer exist, so cancelled speculative work cannot append runner state or emit
+an extra client token.
 
 ## Requirements for `supports_async_decode`
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -110,14 +110,15 @@ Host sampling always performs a full reload from the accepted host token.
 Layout, resume, prefill, and sampling-mode transitions break the steady
 invariant and therefore drain and re-establish the base case.
 
-A completed async result is applied only when its captured internal request ID
-is still live and was not finished/resumed. vLLM assigns a fresh internal ID to
-every accepted request, so aborting and resubmitting the same external ID cannot
-attach an old result to the new request. Cached runner-output rows for explicitly
-finished/resumed requests are replaced with an empty token list before scheduler
-update. vLLM's scheduler independently ignores outputs for requests that no
-longer exist, so cancelled speculative work cannot append runner state or emit
-an extra client token.
+A completed async result is applied only to requests that are still live and
+were neither finished nor resumed since the step was submitted. Request ids are
+client-supplied and may be reused, so an abort followed by a resubmit under the
+same id appears in one scheduler output as both a finished id and a new request.
+The finished id is what marks the step's result invalid, which is why rejection
+is keyed on the scheduler's lifecycle events rather than on identity of the
+cached request state. Runner-output rows for those ids are replaced with an empty
+token list before the scheduler update, so a cancelled step can neither append
+runner state nor emit an extra client token.
 
 ## Requirements for `supports_async_decode`
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -192,6 +192,13 @@ heuristics may observe stale host state under async decode and cannot provide
 the version-1 correctness guarantees. This compatibility path allows the vLLM
 change to land before individual tt-metal adapters are refactored.
 
+Overlap eligibility under gathered multi-process DP (`data_parallel_size > 1`)
+therefore requires version 1. Submit-before-finalize is authorised from a plan a
+version-0 adapter is never sent, so those adapters keep the finalize-before-submit
+order and forgo the overlap rather than reload from host tensors that are
+deliberately one step behind the device. Single-process lane DP is unaffected: it
+reports `data_parallel_size == 1` and its overlap behavior predates the contract.
+
 | vLLM | tt-metal adapter | Result |
 | --- | --- | --- |
 | Old | Legacy / version 0 | Supported: existing behavior |

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -6,6 +6,8 @@ whether host tensors are authoritative. A contract-aware tt-metal generator
 (`decode_input_update_contract >= 1`) receives four independent boolean
 commands on every decode:
 
+## Commands
+
 | Command | Effect |
 | --- | --- |
 | `reload_inputs` | Copy all forward inputs: token, position, RoPE inputs, and page tables. Subsumes `reload_page_table`. |
@@ -80,6 +82,13 @@ convolution, cached RoPE deltas) has no equivalent command in version 1, so an
 adapter that keeps such state must rebuild the reused slot from the reloaded
 forward inputs. A future version should carry the reused slots explicitly rather
 than leave that inference to the adapter.
+
+`slot_remap` is in **global** slot indices. Under gathered multi-process DP vLLM
+offsets each rank's local `[0, max_num_seqs)` mapping by `rank * max_num_seqs`, so
+a generator holding per-rank state must rebase its own slice before indexing that
+state, and must check that the width it received matches the stride it assumed. A
+mapping that moves a request between ranks is an error, not a move. Non-DP and
+lane deployments send one rank's worth, where local and global coincide.
 
 The remap and the layout signal are retired together, at the boundary where a
 decode submission is accepted. Retiring one without the other would leave a
@@ -332,8 +341,9 @@ Two obligations follow for tt-metal:
   every existing subclass against the requirements above before doing it, not
   only the adapter that motivated the move.
 - A subclass that overrides `decode_forward` no longer inherits the
-  implementation the marker attests to, so it must re-declare the marker itself
-  or keep its own conformance.
+  implementation the marker attests to. Re-declaring the marker is not what makes
+  it conformant: the override must itself execute every command, or the subclass
+  must set `decode_input_update_contract = 0` and take the legacy path.
 
 | vLLM | tt-metal adapter | Result |
 | --- | --- | --- |

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -42,10 +42,11 @@ Two superficially reasonable implementations are incorrect:
 The rule is therefore delivery on every version-1 decode and exactly-once
 application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
-not. A condense performed for a prefill/resume step records a remap without
-delivering it, because only decode consumes remaps. If every remaining request
-then departs before a later decode, empty-batch handling discards that obsolete
-mapping so it cannot be replayed after unrelated requests reuse the slots.
+not. The version-0 compatibility path can leave a remap pending after a
+host-sampling decode because legacy adapters receive remaps only during device
+sampling. If every remaining request departs before that later device decode,
+empty-batch handling discards the obsolete mapping so it cannot be replayed
+after unrelated requests reuse the slots.
 
 ## Mode definitions
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -120,6 +120,12 @@ still using the same four-command interface.
 The vLLM and tt-metal changes are one required contract and should be deployed
 as a pinned pair. vLLM always sends all four commands; there is no per-model
 contract-version negotiation or fallback to an older tt-metal generator.
+The paired tt-metal change includes the unconditional decode-only seed
+initialization also addressed by
+[tt-metal#51556](https://github.com/tenstorrent/tt-metal/pull/51556):
+`reset_sampling_state=True` forces seed initialization for first-decode and
+layout transitions even when both the requested and cached seed are `None`.
+The paired change implements this directly and does not depend on that PR.
 `model_capabilities["supports_async_decode"]` remains the sole per-model gate.
 It both controls async scheduling and certifies that sampled-token feedback can
 remain device-resident between decode steps. Models without it still receive

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -19,9 +19,30 @@ forwarding the signal itself. For a legacy adapter, vLLM translates it to the
 old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
 for a version-1 adapter it is composed by vLLM until the next accepted decode
 submission in either sampling mode. tt-metal applies it once before the decode
-reads any persistent per-slot state. This includes model-owned recurrent or
-convolution state as well as device sampling state. Version-0 adapters retain
-the legacy device-sampling-only delivery and consumption behavior.
+reads any persistent per-slot state. Dormant state that the decode cannot read,
+such as a device sampler during host sampling, may be remapped immediately
+after successful submission; applying its non-idempotent remap before a call
+that can fail would corrupt a retry. Persistent state includes model-owned
+recurrent or convolution state as well as device sampling state. Version-0
+adapters retain the legacy device-sampling-only delivery and consumption
+behavior.
+
+Two superficially reasonable implementations are incorrect:
+
+1. **Deliver the remap only for device sampling.** A host-sampling decode can
+   still change the vLLM slot layout. Withholding `slot_remap` leaves
+   model-owned slot state, such as recurrent/conv buffers or cached RoPE
+   deltas, attached to the prior request.
+2. **Apply a delivered remap only inside the active device-sampling call.** A
+   model may retain slot-indexed sampler state even while that decode samples
+   on the host. Skipping the dormant sampler leaves seed/RNG/penalty state in
+   the old slots, so a later return to device sampling resumes the wrong
+   request's state.
+
+The rule is therefore delivery on every version-1 decode and exactly-once
+application by every slot-owning subsystem. An authoritative rebuild may
+replace a subsystem's remap, but merely not using that subsystem this step may
+not. Empty-batch handling resets the composed layout to identity.
 
 ## Mode definitions
 
@@ -117,7 +138,8 @@ satisfies every requirement below:
 7. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
    to all persistent state indexed by the vLLM batch slot, even when that step
    samples on the host. This includes model-internal recurrent/convolution
-   state; a full forward-input reload does not implicitly repair such state.
+   state and dormant device-sampler state; a full forward-input reload does
+   not implicitly repair either one.
 8. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -1,0 +1,70 @@
+# TT Decode Reload Contract
+
+Async device sampling deliberately lets vLLM's host token state trail the TT
+device by one decode step. Consequently, only the vLLM runner can decide
+whether host tensors are authoritative. A contract-aware tt-metal generator
+(`decode_input_update_contract >= 1`) receives four independent boolean
+commands on every decode:
+
+| Command | Effect |
+| --- | --- |
+| `reload_inputs` | Copy all forward inputs: token, position, RoPE inputs, and page tables. |
+| `reload_page_table` | Copy only page-table inputs. Ignored when `reload_inputs` is true. |
+| `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
+| `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
+
+`reset_batch` and generator-local tensor/mode comparisons are legacy fallback
+only. `slot_remap` remains data: it is composed by vLLM until a device-sampling
+submission consumes it, then tt-metal applies it once before sampling state is
+reset or advanced.
+
+## Transition table
+
+| Transition | Inputs | Page only | Sampling params | Sampling state |
+| --- | ---: | ---: | ---: | ---: |
+| First decode or prefill → decode | reload | no | reload on device | reset on device |
+| Batch add/remove/reuse/condense or resume | reload | no | reload on device | reset on device |
+| Host → device sampling | reload | no | reload | reset |
+| Steady host sampling | reload every step | no | n/a | n/a |
+| Steady device sampling | keep resident | only if changed | keep | keep |
+
+Any transition requiring a full input or sampling-state update drains pending
+decode work first. Page-table-only refresh is overlap-safe because page tables
+are scheduler-authoritative even while host token/position tensors are stale.
+
+## Correctness argument
+
+The device invariant immediately after a device-sampling decode step `k` is:
+the persistent token slot contains sampled token `t_k`, and the persistent
+position is the position at which `t_k` must be consumed by step `k+1`.
+
+The base case is a full reload. vLLM first finalizes the prior non-steady step,
+filters finished, resumed, and replaced request identities, updates continuing
+host state (including a live request temporarily unscheduled this step), and
+copies authoritative token/position/layout tensors.
+
+For the induction step, a steady device decode issues no full or sampling-state
+reload. The trace therefore consumes the device-resident `t_k` and position,
+writes exactly one KV position, advances position exactly once, and sampling
+writes `t_(k+1)` back to the persistent token slot. A page-table-only copy can
+change KV address mapping but cannot overwrite token or position state.
+Readback is observational and may complete later.
+
+Host sampling always performs a full reload from the accepted host token.
+Layout, resume, prefill, and sampling-mode transitions break the steady
+invariant and therefore drain and re-establish the base case.
+
+A completed async result is applied only to the captured request object when it
+is still live and was not finished/resumed. Reused request IDs fail the
+object-identity check, and their cached runner-output rows are replaced with an
+empty token list before scheduler update. vLLM's scheduler independently
+ignores outputs for requests that no longer exist, so cancelled speculative
+work cannot append runner state or emit an extra client token.
+
+## Compatibility
+
+New vLLM checks `decode_input_update_contract` before sending the four kwargs
+or allowing host-stale overlap. Old tt-metal generators continue on the
+drain-before-next-step legacy path. New tt-metal generators keep their previous
+heuristics only when all four kwargs are absent, allowing the tt-metal change to
+land before the vLLM change.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -17,8 +17,11 @@ commands on every decode:
 contract adapter, the planner translates it into the four commands without
 forwarding the signal itself. For a legacy adapter, vLLM translates it to the
 old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
-it is composed by vLLM until a device-sampling submission consumes it, then
-tt-metal applies it once before sampling state is reset or advanced.
+for a version-1 adapter it is composed by vLLM until the next accepted decode
+submission in either sampling mode. tt-metal applies it once before the decode
+reads any persistent per-slot state. This includes model-owned recurrent or
+convolution state as well as device sampling state. Version-0 adapters retain
+the legacy device-sampling-only delivery and consumption behavior.
 
 ## Mode definitions
 
@@ -111,7 +114,11 @@ satisfies every requirement below:
 6. **Sampling-state ordering**: slot remaps are applied before parameter/state
    reset; RNG and penalty state are reset only when requested; seed advancement
    happens exactly once per sampled token.
-7. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
+7. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
+   to all persistent state indexed by the vLLM batch slot, even when that step
+   samples on the host. This includes model-internal recurrent/convolution
+   state; a full forward-input reload does not implicitly repair such state.
+8. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.
 
@@ -129,12 +136,12 @@ Model adapters opt in by setting `decode_input_update_contract = 1`. vLLM sends
 the four explicit commands only to adapters advertising version 1 or newer.
 Adapters without the attribute, or with version 0, receive the legacy
 `reset_batch` keyword on device-sampling calls and never receive unknown
-command keywords. Their reload and overlap behavior remains unchanged from the
-pre-contract path, including any model-local heuristics. vLLM logs a warning
-because those heuristics may observe stale host state under async decode and
-cannot provide the version-1 correctness guarantees. This compatibility path
-allows the vLLM change to land before individual tt-metal adapters are
-refactored.
+command keywords. They also retain device-sampling-only `slot_remap` delivery.
+Their reload and overlap behavior remains unchanged from the pre-contract path,
+including any model-local heuristics. vLLM logs a warning because those
+heuristics may observe stale host state under async decode and cannot provide
+the version-1 correctness guarantees. This compatibility path allows the vLLM
+change to land before individual tt-metal adapters are refactored.
 
 | vLLM | tt-metal adapter | Result |
 | --- | --- | --- |

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -38,24 +38,32 @@ fails with a message instead of being interpreted as a full reload.
 `decode_layout_changed` is an internal vLLM lifecycle signal: for an explicit
 contract adapter, the planner translates it into the four commands without
 forwarding the signal itself. For a legacy adapter, vLLM translates it to the
-old `reset_batch` keyword on device-sampling calls. `slot_remap` remains data:
-for a version-1 adapter it is composed by vLLM until the next accepted decode
-submission in either sampling mode. tt-metal applies it once before the decode
-reads any persistent per-slot state. Dormant state that the decode cannot read,
-such as a device sampler during host sampling, may be remapped immediately
-after successful submission; applying its non-idempotent remap before a call
-that can fail would corrupt a retry. Persistent state includes model-owned
-recurrent or convolution state as well as device sampling state. Version-0
-adapters retain the legacy device-sampling-only delivery and consumption
-behavior.
+old `reset_batch` keyword on device-sampling calls.
+
+`slot_remap` is data, and it is an **absolute gather permutation**, not a delta:
+`remap[i] = j` means row *i* must read the state currently in slot *j*. vLLM tracks
+which slot holds each request's state by request id, not by row, because a request's
+row moves whenever the batch evicts, re-admits or condenses while its device state
+stays put. Each decode step derives the permutation from that ownership record, so
+it is recomputed rather than accumulated, and it is omitted entirely when it would
+be the identity. A version-1 adapter receives it in both sampling modes; version-0
+adapters retain the legacy device-sampling-only delivery.
+
+Applying it is still not idempotent: gathering twice moves state twice. tt-metal
+therefore applies it exactly once, before the decode reads any persistent per-slot
+state. Dormant state the decode cannot read, such as a device sampler during host
+sampling, may instead be remapped immediately after successful submission, which
+keeps a failed call retryable for that subsystem. Persistent state includes
+model-owned recurrent or convolution state as well as device sampling state.
 
 State the forward *does* read has to be remapped before it, so those remaps are
 necessarily applied on a call that can fail. A raised decode therefore leaves the
-model-owned half applied while vLLM's own commit is still pending. vLLM does not
-retry a failed decode submission: under gathered DP the exception surfaces through
-the gather future and is fatal to the engine, and on the single-engine path the
-pending remap is retired only on success so the next step re-establishes host
-authority. An adapter must not treat a raised `decode_forward` as resumable.
+model-owned half applied while vLLM has not yet advanced its ownership record. vLLM
+does not retry a failed decode submission: under gathered DP the exception surfaces
+through the gather future and is fatal to the engine, and on the single-engine path
+the ownership record advances only on success, so the next step re-derives its
+permutation from where the state actually is. An adapter must not treat a raised
+`decode_forward` as resumable.
 
 Two superficially reasonable implementations are incorrect:
 
@@ -74,9 +82,9 @@ application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
 not. Version-0 adapters retain their historical remap behavior unchanged.
 
-A remap cannot express slot reuse. When a new request takes a slot there is no
-predecessor state to gather from, so vLLM keeps that slot's entry the identity
-and signals the event through `decode_layout_changed`. Sampling state is then
+A remap cannot express slot reuse. A slot a new request has just taken holds no
+predecessor state to gather from, so vLLM leaves that row reading its own slot and
+signals the event through `decode_layout_changed`. Sampling state is then
 invalidated by `reset_sampling_state`. Model-owned per-slot state (recurrent,
 convolution, cached RoPE deltas) has no equivalent command in version 1, so an
 adapter that keeps such state must rebuild the reused slot from the reloaded
@@ -90,10 +98,13 @@ state, and must check that the width it received matches the stride it assumed. 
 mapping that moves a request between ranks is an error, not a move. Non-DP and
 lane deployments send one rank's worth, where local and global coincide.
 
-The remap and the layout signal are retired together, at the boundary where a
-decode submission is accepted. Retiring one without the other would leave a
-remap pending while the rebuild that repairs its destructive effect on a vacated
-slot has already been consumed.
+The ownership record and the layout signal advance together, at the boundary where
+a decode submission is accepted, and neither advances when the step withholds the
+remap from the adapter. Both describe what the accepted submission did to device
+state, so advancing one without the other leaves them describing different steps:
+the signal says the layout was rebuilt while the record still points at the
+pre-gather slots, or the record claims a gather that never ran and every later
+permutation is derived from a layout the device never reached.
 
 ## Mode definitions
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -12,8 +12,8 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` is an internal vLLM lifecycle signal: the planner translates it
-into the four commands, but it is not forwarded to tt-metal. `slot_remap`
+`decode_layout_changed` is an internal vLLM lifecycle signal: the planner
+translates it into the four commands, but it is not forwarded to tt-metal. `slot_remap`
 remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -12,7 +12,8 @@ four independent boolean commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` no longer decides reload behavior in the vLLM path. `slot_remap`
+`reset_batch` is an internal vLLM lifecycle signal: the planner translates it
+into the four commands, but it is not forwarded to tt-metal. `slot_remap`
 remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.
@@ -45,6 +46,7 @@ advanced.
 | Host → device sampling | reload | no | reload | reset |
 | Steady host sampling | reload every step | no | n/a | n/a |
 | Steady device sampling | keep resident | only if changed | keep | keep |
+| Decode tracing disabled | reload every step | no | on transition | on transition |
 | Model without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring a full input or sampling-state update drains pending

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -8,10 +8,30 @@ commands on every decode:
 
 | Command | Effect |
 | --- | --- |
-| `reload_inputs` | Copy all forward inputs: token, position, RoPE inputs, and page tables. |
-| `reload_page_table` | Copy only page-table inputs. Ignored when `reload_inputs` is true. |
+| `reload_inputs` | Copy all forward inputs: token, position, RoPE inputs, and page tables. Subsumes `reload_page_table`. |
+| `reload_page_table` | Copy only page-table inputs. vLLM never sets it together with `reload_inputs`. |
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
+
+The first two are not independent: `reload_inputs` already copies page tables,
+so an adapter that treats them as two disjoint switches never copies the page
+table on a transition step, and the device then addresses the previous batch's
+KV blocks with no error. vLLM asserts the pair is never both true, so the only
+legal readings are "everything", "page tables only", and "nothing".
+
+`reset_sampling_state` implies `reload_inputs`, also asserted on the vLLM side.
+That is what makes requirement 7 satisfiable: an adapter may align seed counters
+from `start_pos` on a state reset precisely because the same step restages it.
+
+### Command defaults
+
+vLLM sends all four explicitly on every version-1 decode, so an adapter needs no
+defaults. Where an adapter does default one, the only permitted value is the
+host-authoritative one: `reload_inputs=True` and the other three `False`. Any
+other default silently reuses device state a caller did not ask to keep. An
+adapter that absorbs unrecognised keywords through `**kwargs` should still reject
+the pre-contract `reset_batch` by name, so a vLLM too old to send the commands
+fails with a message instead of being interpreted as a full reload.
 
 `decode_layout_changed` is an internal vLLM lifecycle signal: for an explicit
 contract adapter, the planner translates it into the four commands without
@@ -26,6 +46,14 @@ that can fail would corrupt a retry. Persistent state includes model-owned
 recurrent or convolution state as well as device sampling state. Version-0
 adapters retain the legacy device-sampling-only delivery and consumption
 behavior.
+
+State the forward *does* read has to be remapped before it, so those remaps are
+necessarily applied on a call that can fail. A raised decode therefore leaves the
+model-owned half applied while vLLM's own commit is still pending. vLLM does not
+retry a failed decode submission: under gathered DP the exception surfaces through
+the gather future and is fatal to the engine, and on the single-engine path the
+pending remap is retired only on success so the next step re-establishes host
+authority. An adapter must not treat a raised `decode_forward` as resumable.
 
 Two superficially reasonable implementations are incorrect:
 
@@ -47,11 +75,16 @@ not. Version-0 adapters retain their historical remap behavior unchanged.
 A remap cannot express slot reuse. When a new request takes a slot there is no
 predecessor state to gather from, so vLLM keeps that slot's entry the identity
 and signals the event through `decode_layout_changed`. Sampling state is then
-invalidated by `reset_sampling_state`. Model-owned per-slot state — recurrent,
-convolution, cached RoPE deltas — has no equivalent command in version 1, so an
+invalidated by `reset_sampling_state`. Model-owned per-slot state (recurrent,
+convolution, cached RoPE deltas) has no equivalent command in version 1, so an
 adapter that keeps such state must rebuild the reused slot from the reloaded
 forward inputs. A future version should carry the reused slots explicitly rather
 than leave that inference to the adapter.
+
+The remap and the layout signal are retired together, at the boundary where a
+decode submission is accepted. Retiring one without the other would leave a
+remap pending while the rebuild that repairs its destructive effect on a vacated
+slot has already been consumed.
 
 ## Mode definitions
 
@@ -65,6 +98,12 @@ than leave that inference to the adapter.
   batch-layout or sampling-mode change, or a resume. Host state is
   authoritative again; pending work drains before a full reload and any
   required sampling-state reset.
+- **Chunked-prefill continuation**: a further prompt chunk of a request that is
+  already resident. It is prefill, but it is neither a new nor a resumed
+  request, so batch membership is unchanged and the layout prediction alone
+  accepts it. vLLM classifies it from the scheduler output's context phase, not
+  from a scheduled-token count: the last chunk of a prompt can be a single
+  token, and a decode row may legitimately be scheduled several.
 - **Steady device decode**: the request layout and sampling mode are unchanged
   after a valid device-sampling decode. Token and position remain
   device-resident, so no full reload occurs.
@@ -78,6 +117,7 @@ than leave that inference to the adapter.
 | --- | ---: | ---: | ---: | ---: |
 | First decode or prefill → decode | reload | no | reload on device | reset on device |
 | Batch add/remove/reuse/condense or resume | reload | no | reload on device | reset on device |
+| Chunked-prefill continuation of a resident request | reload | no | reload on device | reset on device |
 | Host → device sampling | reload | no | reload | reset |
 | Steady host sampling | reload every step | no | n/a | n/a |
 | Steady device sampling | keep resident | only if changed | keep | keep |
@@ -110,6 +150,12 @@ Host sampling always performs a full reload from the accepted host token.
 Layout, resume, prefill, and sampling-mode transitions break the steady
 invariant and therefore drain and re-establish the base case.
 
+"Prefill" there includes an intermediate or final chunk of an already-resident
+request. Such a step leaves batch membership intact, so the membership-based
+layout prediction accepts it and the context-phase test is the only thing that
+rejects it. Missing it would submit a prefill over a pending decode readback
+whose token has not yet reached host state.
+
 A completed async result is applied only to requests that are still live and
 were neither finished nor resumed since the step was submitted. Request ids are
 client-supplied and may be reused, so an abort followed by a resubmit under the
@@ -120,11 +166,70 @@ cached request state. Runner-output rows for those ids are replaced with an empt
 token list before the scheduler update, so a cancelled step can neither append
 runner state nor emit an extra client token.
 
-## Requirements for `supports_async_decode`
+## Requirements for `decode_input_update_contract = 1`
 
-For a version-1 adapter, set
-`model_capabilities["supports_async_decode"] = True` only when the adapter
-satisfies every requirement below:
+Requirements keep their original numbers so existing references stay valid; the
+two headings say which decision each number belongs to.
+
+Every version-1 adapter must satisfy requirements 5, 6, 8 and 9, whatever it
+advertises for `supports_async_decode`. vLLM sends the four commands and delivers
+`slot_remap` to every version-1 adapter, in both sampling modes, so these are
+obligations of the version, not of the capability.
+
+<ol start="5">
+<li>
+
+**Exact command handling**: the adapter honors `reload_inputs`,
+`reload_page_table`, `reload_sampling_params`, and `reset_sampling_state`. It
+must not add model-local mode or tensor comparisons that turn a page-table-only
+update into a full reload. An adapter that cannot execute part of the contract
+must reject the combination loudly, naming the offending command (see "Partial
+adapters" below); quietly ignoring a command is what this contract exists to
+forbid.
+
+</li>
+<li>
+
+**Sampling-state ordering**: slot remaps are applied before parameter/state
+reset; RNG and penalty state are reset only when requested; seed advancement
+happens exactly once per sampled token.
+
+</li>
+</ol>
+
+<ol start="8">
+<li>
+
+**Complete slot remapping**: on every version-1 decode, `slot_remap` applies to
+all persistent state indexed by the vLLM batch slot, even when that step samples
+on the host. This includes model-internal recurrent/convolution state and dormant
+device-sampler state; a full forward-input reload does not implicitly repair
+either one.
+
+One exemption: state that is not addressable by vLLM slot cannot be remapped,
+only reset. Unseeded on-device RNG is the known case: its state is a per-core
+hardware PRNG register that no operation can move between cores, and the adapter
+is expected to leave it in place. An adapter must declare any such state rather
+than silently skip a remap, and vLLM's commit of the mapping is valid for it by
+exemption. "Declare" means naming the state and the reason in the adapter's own
+documentation, next to the code that skips it; the exemption covers only state
+with no move primitive, never state the adapter finds inconvenient to move.
+
+</li>
+<li>
+
+**Stable-buffer lifetime**: persistent decode and sampling buffers remain valid
+until the submitted step is read back and until the next command explicitly
+replaces their contents.
+
+</li>
+</ol>
+
+## Additional requirements for `supports_async_decode`
+
+Set `model_capabilities["supports_async_decode"] = True` only when the adapter
+also satisfies requirements 1 to 4 and 7. These are what let vLLM submit a decode
+whose host token and position state is deliberately one step behind.
 
 1. **Split submission and readback**: `decode_forward(...,
    read_from_device=False)` submits decode without synchronizing the result, and
@@ -140,44 +245,51 @@ satisfies every requirement below:
    step `k+1`.
 4. **Independent page-table refresh**: the model can copy changed page-table
    inputs without copying or rebinding token, position, or RoPE inputs.
-5. **Exact command handling**: the adapter honors `reload_inputs`,
-   `reload_page_table`, `reload_sampling_params`, and
-   `reset_sampling_state` independently. It must not add model-local mode or
-   tensor comparisons that turn a page-table-only update into a full reload.
-6. **Sampling-state ordering**: slot remaps are applied before parameter/state
-   reset; RNG and penalty state are reset only when requested; seed advancement
-   happens exactly once per sampled token.
-7. **Host input authority**: the `tokens` and `start_pos` arguments are
-   authoritative only when `reload_inputs` is true. When it is false they are
-   deliberately one step behind, and the adapter must derive nothing from them —
-   not forward inputs, and not sampling state. Deriving an RNG counter from
-   `start_pos` on a steady step makes the sampled stream depend on when the
-   asynchronous readback landed, so the same request and seed stop reproducing.
-   An adapter that ties per-token seeds to the absolute decode position must do
-   so only on a reloading step and advance its own resident counter otherwise.
-8. **Complete slot remapping**: on every version-1 decode, `slot_remap` applies
-   to all persistent state indexed by the vLLM batch slot, even when that step
-   samples on the host. This includes model-internal recurrent/convolution
-   state and dormant device-sampler state; a full forward-input reload does
-   not implicitly repair either one.
 
-   One exemption: state that is not addressable by vLLM slot cannot be
-   remapped, only reset. Unseeded on-device RNG is the known case — its state
-   is a per-core hardware PRNG register that no operation can move between
-   cores, and the adapter is expected to leave it in place. An adapter must
-   declare any such state rather than silently skip a remap, and vLLM's commit
-   of the mapping is valid for it by exemption.
-9. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
-   valid until the submitted step is read back and until the next command
-   explicitly replaces their contents.
+<ol start="7">
+<li>
+
+**Host input authority**: the `tokens` and `start_pos` arguments are
+authoritative only when `reload_inputs` is true. When it is false they are
+deliberately one step behind, and the adapter must derive nothing from them: not
+forward inputs, and not sampling state. Deriving an RNG counter from `start_pos`
+on a steady step makes the sampled stream depend on when the asynchronous
+readback landed, so the same request and seed stop reproducing. An adapter that
+ties per-token seeds to the absolute decode position must do so only on a
+reloading step and advance its own resident counter otherwise. vLLM guarantees
+`reset_sampling_state` implies `reload_inputs`, so a state reset is always a step
+on which those arguments may be trusted.
+
+</li>
+</ol>
 
 The capability is fail-closed. If any requirement is not met, leave
 `supports_async_decode` absent or `False`. vLLM disables async scheduling for
 that model and requests a full forward-input reload on every decode, while
 still using the negotiated generator interface. A legacy adapter may already
 advertise `supports_async_decode`; vLLM preserves that adapter's existing
-reload and overlap behavior, but warns that correctness is not guaranteed
+reload and overlap behavior, but logs that correctness is not guaranteed
 until the adapter also implements and advertises contract version 1.
+
+### Partial adapters
+
+An adapter may advertise version 1 while being structurally unable to execute a
+command combination, provided both hold:
+
+- it leaves `supports_async_decode` absent or `False`, which is what stops vLLM
+  from ever planning the combination it cannot execute, and
+- it rejects that combination with an error naming the command, rather than
+  degrading silently.
+
+Requiring a full input reload is the common case: an adapter that rebuilds all
+host inputs every decode cannot honor `reload_inputs=False`. Such an adapter is
+conformant, not buggy. The unconditional part of the contract, requirements 5, 6,
+8 and 9, still applies to it in full, which is what makes `slot_remap` delivery
+useful to a host-sampling model that owns per-slot recurrent state.
+
+Because the two keys interact this way, an adapter must not flip
+`supports_async_decode` on without first removing its rejections. The rejection
+comment should say so at the site.
 
 ## Contract negotiation
 
@@ -199,6 +311,30 @@ order and forgo the overlap rather than reload from host tensors that are
 deliberately one step behind the device. Single-process lane DP is unaffected: it
 reports `data_parallel_size == 1` and its overlap behavior predates the contract.
 
+### Where the version is declared, and what that arms
+
+**The marker belongs on the generator that implements the commands, not on each
+leaf adapter, and is therefore inherited by every subclass of that generator.**
+That is the decided placement. Its direct consequence: when a shared generator
+declares version 1, gathered-DP decode overlap becomes eligible for every adapter
+built on it that also advertises `supports_async_decode`, without any further
+per-adapter decision. Arming is not staged one adapter at a time.
+
+This is the right trade because the commands are implemented once, in the shared
+generator, and a subclass that inherits that implementation genuinely implements
+the contract. The alternative, a per-leaf marker, is fail-open in the other and
+worse direction: a leaf that forgets the marker silently drops to the legacy call
+shape and its reload decisions revert to model-local heuristics with no error.
+
+Two obligations follow for tt-metal:
+
+- Moving the marker up onto a generator is a change to the arming set. Audit
+  every existing subclass against the requirements above before doing it, not
+  only the adapter that motivated the move.
+- A subclass that overrides `decode_forward` no longer inherits the
+  implementation the marker attests to, so it must re-declare the marker itself
+  or keep its own conformance.
+
 | vLLM | tt-metal adapter | Result |
 | --- | --- | --- |
 | Old | Legacy / version 0 | Supported: existing behavior |
@@ -207,16 +343,29 @@ reports `data_parallel_size == 1` and its overlap behavior predates the contract
 | Old | Strict version 1 | Unsupported: old vLLM omits the required commands |
 
 The supported rollout order is therefore vLLM first, followed by tt-metal
-adapter migrations. Advertising version 1 before implementing every command
-is an adapter bug and should fail loudly rather than silently falling back.
+adapter migrations. Advertising version 1 while quietly ignoring a command is an
+adapter bug; rejecting a combination it cannot execute is not (see "Partial
+adapters").
+
 Versions greater than 1 must remain backward-compatible supersets of version 1;
 a breaking interface requires a distinct negotiation key or supported range.
+There is no handshake in the other direction: an adapter cannot read the
+plugin's version, and a version-1 plugin sends exactly the four commands above
+to anything advertising 1 or newer. So any command a later version adds must be
+keyword-only with a default that reproduces version-1 behavior, or a version-2
+adapter breaks against a version-1 plugin. Making a new command required is a
+breaking interface and needs a new negotiation key.
 
-`model_capabilities["supports_async_decode"]` remains independent of contract
-versioning. It controls async scheduling and certifies that sampled-token
-feedback can remain device-resident between decode steps. A version-1 model
-without that capability receives a conservative full-input reload command on
-every decode.
+`model_capabilities["supports_async_decode"]` is a separate key with a separate
+question: it controls async scheduling and certifies that sampled-token feedback
+can remain device-resident between decode steps. A version-1 model without that
+capability receives a conservative full-input reload command on every decode.
+The keys are not fully orthogonal in practice, because leaving the capability off
+is what makes a partial adapter safe; see "Partial adapters".
+
+Not every tt-metal generator is migrated. Deliberate version-0 holdouts are
+listed in tt-metal's `models/common/sampling/README.md`, which is authoritative
+for which generator stacks still take the legacy path and why.
 
 The refactored tt-metal implementation includes the unconditional decode-only
 seed initialization also addressed by

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -2,9 +2,8 @@
 
 Async device sampling deliberately lets vLLM's host token state trail the TT
 device by one decode step. Consequently, only the vLLM runner can decide
-whether host tensors are authoritative. A contract-aware tt-metal generator
-(`decode_input_update_contract >= 1`) receives four independent boolean
-commands on every decode:
+whether host tensors are authoritative. The paired tt-metal generator receives
+four independent boolean commands on every decode:
 
 | Command | Effect |
 | --- | --- |
@@ -13,10 +12,10 @@ commands on every decode:
 | `reload_sampling_params` | Upload temperature, top-k/top-p, penalties, seeds, and logprob configuration. |
 | `reset_sampling_state` | Rebuild mutable penalty/RNG state for the current layout. |
 
-`reset_batch` and generator-local tensor/mode comparisons are legacy fallback
-only. `slot_remap` remains data: it is composed by vLLM until a device-sampling
-submission consumes it, then tt-metal applies it once before sampling state is
-reset or advanced.
+`reset_batch` no longer decides reload behavior in the vLLM path. `slot_remap`
+remains data: it is composed by vLLM until a device-sampling submission
+consumes it, then tt-metal applies it once before sampling state is reset or
+advanced.
 
 ## Transition table
 
@@ -27,6 +26,7 @@ reset or advanced.
 | Host → device sampling | reload | no | reload | reset |
 | Steady host sampling | reload every step | no | n/a | n/a |
 | Steady device sampling | keep resident | only if changed | keep | keep |
+| Model without `supports_async_decode` | reload every step | no | on transition | on transition |
 
 Any transition requiring a full input or sampling-state update drains pending
 decode work first. Page-table-only refresh is overlap-safe because page tables
@@ -61,10 +61,13 @@ empty token list before scheduler update. vLLM's scheduler independently
 ignores outputs for requests that no longer exist, so cancelled speculative
 work cannot append runner state or emit an extra client token.
 
-## Compatibility
+## Deployment coupling
 
-New vLLM checks `decode_input_update_contract` before sending the four kwargs
-or allowing host-stale overlap. Old tt-metal generators continue on the
-drain-before-next-step legacy path. New tt-metal generators keep their previous
-heuristics only when all four kwargs are absent, allowing the tt-metal change to
-land before the vLLM change.
+The vLLM and tt-metal changes are one required contract and should be deployed
+as a pinned pair. vLLM always sends all four commands; there is no per-model
+contract-version negotiation or fallback to an older tt-metal generator.
+`model_capabilities["supports_async_decode"]` remains the sole per-model gate.
+It both controls async scheduling and certifies that sampled-token feedback can
+remain device-resident between decode steps. Models without it still receive
+the explicit four-command contract, but vLLM conservatively requests a full
+forward-input reload on every step.

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -44,6 +44,15 @@ application by every slot-owning subsystem. An authoritative rebuild may
 replace a subsystem's remap, but merely not using that subsystem this step may
 not. Version-0 adapters retain their historical remap behavior unchanged.
 
+A remap cannot express slot reuse. When a new request takes a slot there is no
+predecessor state to gather from, so vLLM keeps that slot's entry the identity
+and signals the event through `decode_layout_changed`. Sampling state is then
+invalidated by `reset_sampling_state`. Model-owned per-slot state — recurrent,
+convolution, cached RoPE deltas — has no equivalent command in version 1, so an
+adapter that keeps such state must rebuild the reused slot from the reloaded
+forward inputs. A future version should carry the reused slots explicitly rather
+than leave that inference to the adapter.
+
 ## Mode definitions
 
 - **Host sampling**: tt-metal returns logits and vLLM selects the token. Host

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -17,6 +17,25 @@ remains data: it is composed by vLLM until a device-sampling submission
 consumes it, then tt-metal applies it once before sampling state is reset or
 advanced.
 
+## Mode definitions
+
+- **Host sampling**: tt-metal returns logits and vLLM selects the token. Host
+  token and position tensors are authoritative, so every decode performs a
+  full input reload.
+- **Device sampling**: tt-metal selects the token. A supporting model writes
+  that token directly into the persistent input buffer used by the next decode
+  and advances its persistent position in the forward trace.
+- **Transition decode**: the first decode, the first decode after prefill, a
+  batch-layout or sampling-mode change, or a resume. Host state is
+  authoritative again; pending work drains before a full reload and any
+  required sampling-state reset.
+- **Steady device decode**: the request layout and sampling mode are unchanged
+  after a valid device-sampling decode. Token and position remain
+  device-resident, so no full reload occurs.
+- **Page-table-only refresh**: a steady device decode whose KV block mapping
+  changed. Only page-table trace inputs are copied; token, position, and RoPE
+  state must remain untouched.
+
 ## Transition table
 
 | Transition | Inputs | Page only | Sampling params | Sampling state |
@@ -60,6 +79,41 @@ object-identity check, and their cached runner-output rows are replaced with an
 empty token list before scheduler update. vLLM's scheduler independently
 ignores outputs for requests that no longer exist, so cancelled speculative
 work cannot append runner state or emit an extra client token.
+
+## Requirements for `supports_async_decode`
+
+Set `model_capabilities["supports_async_decode"] = True` only when the model
+adapter satisfies every requirement below:
+
+1. **Split submission and readback**: `decode_forward(...,
+   read_from_device=False)` submits decode without synchronizing the result, and
+   `read_decode_output(..., async_read=True)` can read that exact submission
+   later. Readback must be observational: it cannot advance position, sample
+   another token, or otherwise mutate decode state.
+2. **Persistent token feedback**: device sampling writes the selected token into
+   the same persistent token buffer consumed by the next decode. Writing only
+   to a separate output tensor is insufficient.
+3. **Single position advance**: each successful decode forward advances the
+   persistent position exactly once. Sampling and readback must not advance it.
+   After step `k`, the resident token and position must describe the input to
+   step `k+1`.
+4. **Independent page-table refresh**: the model can copy changed page-table
+   inputs without copying or rebinding token, position, or RoPE inputs.
+5. **Exact command handling**: the adapter honors `reload_inputs`,
+   `reload_page_table`, `reload_sampling_params`, and
+   `reset_sampling_state` independently. It must not add model-local mode or
+   tensor comparisons that turn a page-table-only update into a full reload.
+6. **Sampling-state ordering**: slot remaps are applied before parameter/state
+   reset; RNG and penalty state are reset only when requested; seed advancement
+   happens exactly once per sampled token.
+7. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
+   valid until the submitted step is read back and until the next command
+   explicitly replaces their contents.
+
+The capability is fail-closed. If any requirement is not met, leave
+`supports_async_decode` absent or `False`. vLLM disables async scheduling for
+that model and requests a full forward-input reload on every decode, while
+still using the same four-command interface.
 
 ## Deployment coupling
 

--- a/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
+++ b/plugins/vllm-tt-plugin/docs/decode-reload-contract.md
@@ -159,6 +159,13 @@ satisfies every requirement below:
    samples on the host. This includes model-internal recurrent/convolution
    state and dormant device-sampler state; a full forward-input reload does
    not implicitly repair either one.
+
+   One exemption: state that is not addressable by vLLM slot cannot be
+   remapped, only reset. Unseeded on-device RNG is the known case — its state
+   is a per-core hardware PRNG register that no operation can move between
+   cores, and the adapter is expected to leave it in place. An adapter must
+   declare any such state rather than silently skip a remap, and vLLM's commit
+   of the mapping is valid for it by exemption.
 9. **Stable-buffer lifetime**: persistent decode and sampling buffers remain
    valid until the submitted step is read back and until the next command
    explicitly replaces their contents.

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -907,12 +907,16 @@ class TTAsyncDecodeController:
             self._decode_chain_valid = True
             self._previous_device_sampling = perform_device_sampling
         # Past the forward, so the submission was accepted. Gathered DP retires
-        # both signals from ``TTWorker.commit_dp_slot_updates`` instead, because
+        # these signals from ``TTWorker.commit_dp_slot_updates`` instead, because
         # every rank composed its own and only the driver reaches this line.
         if runner.parallel_config.data_parallel_size == 1:
             runner.note_decode_layout_consumed()
             if slot_remap_consumed:
-                runner.input_batch.commit_slot_remap()
+                runner.note_decode_state_slots_settled()
+            else:
+                # The remap was built but withheld from this adapter, so the gather
+                # never ran and the state did not move.
+                runner.discard_pending_state_slot_settle()
         read_events = None
         if async_read:
             if hasattr(runner.model, "read_decode_output"):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -13,6 +13,7 @@ import ttnn
 
 from vllm.v1.outputs import AsyncModelRunnerOutput, LogprobsLists, ModelRunnerOutput
 from vllm_tt_plugin.input_batch import SEED_NONE_SENTINEL
+from vllm_tt_plugin.logger import init_tt_logger
 from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
@@ -20,6 +21,8 @@ if TYPE_CHECKING:
     from vllm_tt_plugin.input_batch import CachedRequestState
     from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
+
+logger = init_tt_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -220,6 +223,7 @@ class TTAsyncDecodeController:
         self._decode_chain_valid = False
         self._previous_device_sampling: bool | None = None
         self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
+        self._legacy_contract_warning_emitted = False
 
     @staticmethod
     def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
@@ -754,17 +758,33 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
-        # vLLM owns reload decisions because it alone knows when host tensors
-        # are authoritative under async scheduling. The paired tt-metal
-        # revision is therefore required and receives all four commands on
-        # every non-empty decode submission.
-        reload_plan = self.plan_decode_reload(model_input)
-        kwargs.update(
-            reload_inputs=reload_plan.reload_inputs,
-            reload_page_table=reload_plan.reload_page_table,
-            reload_sampling_params=reload_plan.reload_sampling_params,
-            reset_sampling_state=reload_plan.reset_sampling_state,
-        )
+        # Versioned compatibility seam. Refactored tt-metal generators opt in
+        # to the explicit contract. Existing generators retain their legacy
+        # reset_batch interface and never receive unknown command kwargs.
+        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
+        reload_plan = None
+        if contract_version >= 1:
+            reload_plan = self.plan_decode_reload(model_input)
+            kwargs.update(
+                reload_inputs=reload_plan.reload_inputs,
+                reload_page_table=reload_plan.reload_page_table,
+                reload_sampling_params=reload_plan.reload_sampling_params,
+                reset_sampling_state=reload_plan.reset_sampling_state,
+            )
+        elif perform_device_sampling:
+            # Keep the lifecycle hint internal under the explicit contract,
+            # but translate it back to the legacy API while old adapters are
+            # still being migrated.
+            kwargs["reset_batch"] = model_input.decode_layout_changed
+        if contract_version < 1 and not self._legacy_contract_warning_emitted:
+            self._legacy_contract_warning_emitted = True
+            logger.warning(
+                "TT model %s does not advertise decode_input_update_contract "
+                ">= 1; preserving its legacy reset_batch reload behavior. "
+                "Async decode correctness is not guaranteed until the model "
+                "adapter implements and advertises the explicit contract.",
+                type(runner.model).__name__,
+            )
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
@@ -789,7 +809,14 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
-        self.commit_decode_submission(model_input, reload_plan)
+        if reload_plan is not None:
+            self.commit_decode_submission(model_input, reload_plan)
+        else:
+            # Preserve legacy overlap eligibility. The old adapter remains the
+            # owner of reload decisions; this only records that submission
+            # succeeded so the plugin does not introduce a new forced drain.
+            self._decode_chain_valid = True
+            self._previous_device_sampling = perform_device_sampling
         if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -313,39 +313,40 @@ class TTAsyncDecodeController:
             self._submitted_page_tables = self._clone_page_tables(model_input)
 
     @staticmethod
-    def scheduler_output_is_prompt(scheduler_output: SchedulerOutput) -> bool:
+    def scheduler_output_has_prefill_work(scheduler_output: SchedulerOutput) -> bool:
         """Whether this step carries prefill work of any kind.
 
         Decided before ``_update_states``, so the persistent batch's
         ``num_computed_tokens`` still describes the previous step and cannot be
-        consulted. The scheduler output alone is authoritative: a pure decode
-        row is scheduled exactly one token, so a cached request with more is
-        still prefilling - a chunked-prefill continuation, which is a prefill
-        that leaves batch membership intact and therefore passes
-        ``scheduler_preserves_decode_layout``.
+        consulted; the scheduler output is the only sound source here.
 
-        Over-reporting is safe (it only forgoes overlap), so any future feature
-        that schedules several tokens for a decode row lands on the
-        conservative side.
+        A cached request still in its context phase is a chunked-prefill
+        continuation: a prefill that leaves batch membership intact and
+        therefore passes ``scheduler_preserves_decode_layout``, so this is the
+        only test that rejects it. ``is_context_phase`` is exact, unlike a
+        scheduled-token count: a continuation whose remaining prompt is one
+        token schedules one token, and a decode row may legitimately be
+        scheduled several (speculative decode counts its proposals).
         """
         cached_reqs = scheduler_output.scheduled_cached_reqs
         if scheduler_output.scheduled_new_reqs or cached_reqs.resumed_req_ids:
             return True
-        num_scheduled = scheduler_output.num_scheduled_tokens
-        return any(num_scheduled.get(req_id, 0) > 1 for req_id in cached_reqs.req_ids)
+        return any(
+            cached_reqs.is_context_phase(req_id) for req_id in cached_reqs.req_ids
+        )
 
     def scheduler_preserves_decode_layout(
         self, scheduler_output: SchedulerOutput
     ) -> bool:
         """Whether scheduling this step leaves every persistent decode row intact.
 
-        This prediction happens before ``_update_states``. It closes the old
+        This prediction happens before the batch is mutated. It closes the old
         gap where a new/finished/preempted request was only noticed after the
         next decode had already been allowed to overlap with stale host input.
+        The batch answers it, because what moves a row is its own eviction and
+        placement policy: front-packed and lane batches differ there.
         """
-        current_req_ids = set(self.runner.input_batch.req_id_to_index)
-        scheduled_req_ids = set(scheduler_output.num_scheduled_tokens)
-        return current_req_ids == scheduled_req_ids
+        return self.runner.input_batch.scheduling_preserves_rows(scheduler_output)
 
     def capture_submitted_step_context(
         self, req_ids: list[str] | None = None
@@ -390,7 +391,7 @@ class TTAsyncDecodeController:
         grammar_output: GrammarOutput | None,
     ) -> bool:
         runner = self.runner
-        if self.scheduler_output_is_prompt(scheduler_output):
+        if self.scheduler_output_has_prefill_work(scheduler_output):
             return False
         if runner._decode_layout_changed_since_last_decode:
             return False
@@ -453,15 +454,31 @@ class TTAsyncDecodeController:
             return None
         return int(getattr(model, "decode_input_update_contract", 0))
 
-    def gathered_dp_overlap_permitted(self) -> bool:
-        """Whether gathered DP may submit a step before applying the previous one.
+    @staticmethod
+    def slot_remap_delivered_on_host_sampling(contract_version: int) -> bool:
+        """Whether a host-sampling decode still delivers ``slot_remap``.
+
+        Under the explicit contract the remap is decode-layout data, so it is
+        delivered in both sampling modes: an adapter may own persistent per-slot
+        state outside its device sampler. Version-0 adapters keep their historical
+        device-sampling-only call shape. Gathered DP decides this from the agreed
+        version rather than a local read, so both sides must ask the same
+        question of the same number.
+        """
+        return contract_version >= 1
+
+    def resident_decode_overlap_permitted(self) -> bool:
+        """Whether a decode step may be submitted before the previous is applied.
 
         Only a version-1 adapter is told which inputs are authoritative, so a
         version-0 adapter keeps the pre-contract finalize-before-submit order:
         its own reload heuristics would otherwise copy host token/position
-        tensors that are deliberately one step behind the device. Ranks holding
-        no model abstain; the device rank's answer reaches the global decision
-        through the caller's MIN reduction.
+        tensors that are deliberately one step behind the device.
+
+        Ranks holding no model abstain; the device rank's answer reaches the
+        global decision through the caller's MIN reduction. Only gathered
+        multi-process DP finalizes out of scheduler order, so single-engine
+        deployments (including lane-DP) are unaffected either way.
         """
         if self.runner.parallel_config.data_parallel_size == 1:
             return True
@@ -475,7 +492,7 @@ class TTAsyncDecodeController:
     ) -> bool:
         if not self.steady_decode_base_enabled(dp_gather=True):
             return False
-        if not self.gathered_dp_overlap_permitted():
+        if not self.resident_decode_overlap_permitted():
             return False
         if scheduler_output is None or scheduler_output.total_num_scheduled_tokens == 0:
             return True
@@ -752,7 +769,10 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
-        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
+        # Reached only on the rank that submits the forward, so a model is loaded
+        # and the accessor cannot abstain here.
+        contract_version = self.decode_input_update_contract_version()
+        assert contract_version is not None
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,
@@ -795,19 +815,19 @@ class TTAsyncDecodeController:
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
 
-        # Under the explicit contract, slot_remap is decode-layout data and is
-        # delivered even when this step samples on the host: adapters may own
-        # persistent per-slot state outside their device sampler. Preserve the
-        # legacy device-sampling-only call shape for version-0 adapters.
         slot_remap_consumed = model_input.slot_remap is not None and (
-            contract_version >= 1 or perform_device_sampling
+            perform_device_sampling
+            or self.slot_remap_delivered_on_host_sampling(contract_version)
         )
         if slot_remap_consumed:
             kwargs["slot_remap"] = model_input.slot_remap
 
         # Versioned compatibility seam. Refactored tt-metal generators opt in
         # to the explicit contract. Existing generators retain their legacy
-        # reset_batch interface and never receive unknown command kwargs.
+        # reset_batch interface and never receive unknown command kwargs. A
+        # deployment whose tt-metal predates the contract takes the legacy branch
+        # for every model, which is why the contract-v1 code below can look
+        # unreachable in a profile.
         reload_plan = None
         if contract_version >= 1:
             reload_plan = self.plan_decode_reload(model_input)
@@ -823,12 +843,16 @@ class TTAsyncDecodeController:
             # still being migrated.
             kwargs["reset_batch"] = model_input.decode_layout_changed
         if contract_version < 1 and not self._legacy_contract_warning_emitted:
+            # Addressed at whoever can act on it, which is the adapter author,
+            # not the operator running the server: nothing about the deployment
+            # changes this.
             self._legacy_contract_warning_emitted = True
-            logger.warning(
+            logger.info(
                 "TT model %s does not advertise decode_input_update_contract "
-                ">= 1; preserving its legacy reset_batch reload behavior. "
-                "Async decode correctness is not guaranteed until the model "
-                "adapter implements and advertises the explicit contract.",
+                ">= 1; preserving its legacy reset_batch reload behavior. Its "
+                "adapter keeps ownership of reload decisions, and gathered-DP "
+                "decode overlap stays off. Set decode_input_update_contract = 1 "
+                "on the generator once it executes the four update commands.",
                 type(runner.model).__name__,
             )
 
@@ -863,8 +887,13 @@ class TTAsyncDecodeController:
             # succeeded so the plugin does not introduce a new forced drain.
             self._decode_chain_valid = True
             self._previous_device_sampling = perform_device_sampling
-        if slot_remap_consumed and runner.parallel_config.data_parallel_size == 1:
-            runner.input_batch.commit_slot_remap()
+        # Past the forward, so the submission was accepted. Gathered DP retires
+        # both signals from ``TTWorker.commit_dp_slot_updates`` instead, because
+        # every rank composed its own and only the driver reaches this line.
+        if runner.parallel_config.data_parallel_size == 1:
+            runner.note_decode_layout_consumed()
+            if slot_remap_consumed:
+                runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:
             if hasattr(runner.model, "read_decode_output"):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -96,20 +96,38 @@ class DeferredDecodeOutput(AsyncModelRunnerOutput):
     _finalize_lock: threading.Lock
     _finalized: bool
     _cached_output: Any
+    _cached_exception: BaseException | None
 
     def _init_deferred(self) -> None:
         self._finalized = False
         self._cached_output = None
+        self._cached_exception = None
         self._finalize_lock = threading.Lock()
 
     def ensure_finalized(self) -> Any:
         if self._finalized:
-            return self._cached_output
+            return self._replay()
         with self._finalize_lock:
             if not self._finalized:
-                self._cached_output = self._get_output_impl()
-                self._finalized = True
-                self._completion_event.set()
+                # A raised readback still consumed the submission, so record the
+                # failure as terminal: leaving it unfinalized would let the other
+                # caller run the same non-idempotent readback a second time, which
+                # is what this class exists to prevent. Completion is signalled
+                # either way so a waiting drain does not block on a step that will
+                # never resolve.
+                try:
+                    self._cached_output = self._get_output_impl()
+                except BaseException as exc:
+                    self._cached_exception = exc
+                    raise
+                finally:
+                    self._finalized = True
+                    self._completion_event.set()
+        return self._replay()
+
+    def _replay(self) -> Any:
+        if self._cached_exception is not None:
+            raise self._cached_exception
         return self._cached_output
 
     def is_resolved(self) -> bool:
@@ -845,9 +863,10 @@ class TTAsyncDecodeController:
         if contract_version < 1 and not self._legacy_contract_warning_emitted:
             # Addressed at whoever can act on it, which is the adapter author,
             # not the operator running the server: nothing about the deployment
-            # changes this.
+            # changes this. Still a warning, because the adapter keeps ownership
+            # of reload decisions and its heuristics may observe stale host state.
             self._legacy_contract_warning_emitted = True
-            logger.info(
+            logger.warning(
                 "TT model %s does not advertise decode_input_update_contract "
                 ">= 1; preserving its legacy reset_batch reload behavior. Its "
                 "adapter keeps ownership of reload decisions, and gathered-DP "

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -18,7 +18,6 @@ from vllm_tt_plugin.structured_output import has_structured_outputs
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
-    from vllm_tt_plugin.input_batch import CachedRequestState
     from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
 
@@ -61,7 +60,6 @@ class SubmittedStepContext:
 
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-    request_states: tuple[CachedRequestState, ...]
     submit_time_ns: int
 
 
@@ -352,7 +350,6 @@ class TTAsyncDecodeController:
         return SubmittedStepContext(
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_states=tuple(runner.requests[req_id] for req_id in req_ids),
             submit_time_ns=time.perf_counter_ns(),
         )
 
@@ -594,17 +591,9 @@ class TTAsyncDecodeController:
         skip_req_ids: set[str] | None = None,
     ) -> None:
         invalid_req_ids = set(skip_req_ids or ())
-        invalid_req_ids.update(
-            req_id
-            for req_id, captured_state in zip(
-                completed.context.req_ids,
-                completed.context.request_states,
-            )
-            if self.runner.requests.get(req_id) is not captured_state
-        )
         # The batch queue schedules/builds the current step before consuming
         # the prior future. Mutating the cached prior output here therefore
-        # prevents an aborted/reused request ID from receiving its old token
+        # prevents a finished or resumed request from receiving its old token
         # in scheduler.update_from_output, not just in runner host state.
         if completed.runner_output is not None:
             for req_id in invalid_req_ids:
@@ -614,7 +603,6 @@ class TTAsyncDecodeController:
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
-            request_states=completed.context.request_states,
             skip_req_ids=invalid_req_ids,
         )
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -714,6 +714,9 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
+        contract_version = int(
+            getattr(runner.model, "decode_input_update_contract", 0)
+        )
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,
@@ -755,13 +758,20 @@ class TTAsyncDecodeController:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
-            if model_input.slot_remap is not None:
-                kwargs["slot_remap"] = model_input.slot_remap
+
+        # Under the explicit contract, slot_remap is decode-layout data and is
+        # delivered even when this step samples on the host: adapters may own
+        # persistent per-slot state outside their device sampler. Preserve the
+        # legacy device-sampling-only call shape for version-0 adapters.
+        slot_remap_consumed = model_input.slot_remap is not None and (
+            contract_version >= 1 or perform_device_sampling
+        )
+        if slot_remap_consumed:
+            kwargs["slot_remap"] = model_input.slot_remap
 
         # Versioned compatibility seam. Refactored tt-metal generators opt in
         # to the explicit contract. Existing generators retain their legacy
         # reset_batch interface and never receive unknown command kwargs.
-        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
         reload_plan = None
         if contract_version >= 1:
             reload_plan = self.plan_decode_reload(model_input)
@@ -788,7 +798,7 @@ class TTAsyncDecodeController:
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
-            if any(
+            if model_input.decode_layout_changed or any(
                 req_id not in runner.previous_req_ids
                 for req_id in runner.input_batch.req_ids
             ):
@@ -817,7 +827,7 @@ class TTAsyncDecodeController:
             # succeeded so the plugin does not introduce a new forced drain.
             self._decode_chain_valid = True
             self._previous_device_sampling = perform_device_sampling
-        if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
+        if slot_remap_consumed and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -281,7 +281,7 @@ class TTAsyncDecodeController:
         )
         transition = (
             not self._decode_chain_valid
-            or model_input.reset_batch
+            or model_input.decode_layout_changed
             or sampling_mode_changed
         )
         reload_inputs = (
@@ -445,7 +445,7 @@ class TTAsyncDecodeController:
             return False
         if not model_input.perform_device_sampling:
             return False
-        if model_input.reset_batch:
+        if model_input.decode_layout_changed:
             return False
         if model_input.grammar_bitmask[0] is not None:
             return False

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -18,7 +18,7 @@ from vllm_tt_plugin.structured_output import has_structured_outputs
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
     from vllm_tt_plugin.input_batch import CachedRequestState
-    from vllm_tt_plugin.model_input import TTModelInput
+    from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTModelInput
     from vllm_tt_plugin.model_runner import TTModelRunner
 
 
@@ -31,6 +31,7 @@ class TTDecodeSubmission:
     batch_size_per_dp: list[int]
     sampling_params: Any
     perform_device_sampling: bool
+    reload_plan: TTDecodeReloadPlan | None = None
 
 
 @dataclass(frozen=True)
@@ -61,7 +62,7 @@ class SubmittedStepContext:
     submit_time_ns: int
 
 
-@dataclass(frozen=True)
+@dataclass
 class CompletedDecodeStep:
     """Decode output that has completed readback but is not yet applied."""
 
@@ -69,6 +70,7 @@ class CompletedDecodeStep:
     logprobs: LogprobsLists | None
     context: SubmittedStepContext
     completion_time_ns: int
+    runner_output: ModelRunnerOutput | None = None
 
 
 class DeferredDecodeOutput(AsyncModelRunnerOutput):
@@ -160,8 +162,12 @@ class AsyncTTModelRunnerOutput(DeferredDecodeOutput):
             context=self._context,
             scheduled_rows=self._scheduled_rows,
         )
+        runner_output = self._controller.build_runner_output_from_completed_step(
+            completed
+        )
+        completed.runner_output = runner_output
         self._controller.enqueue_completed_decode_step(completed)
-        return self._controller.build_runner_output_from_completed_step(completed)
+        return runner_output
 
 
 class AsyncTTDPGatherOutput(DeferredDecodeOutput):
@@ -207,6 +213,103 @@ class TTAsyncDecodeController:
 
     def __init__(self, runner: TTModelRunner):
         self.runner = runner
+        # Decode-residency state is committed at submission, not readback. An
+        # overlapped device decode may deliberately leave host tokens one step
+        # behind, so only this submitted-device history can decide what is safe
+        # to reload on the next step.
+        self._decode_chain_valid = False
+        self._previous_device_sampling: bool | None = None
+        self._submitted_page_tables: tuple[torch.Tensor, ...] | None = None
+
+    @staticmethod
+    def _clone_page_tables(model_input: TTModelInput) -> tuple[torch.Tensor, ...]:
+        return tuple(
+            table.detach().clone() for table in model_input.block_tables_per_group
+        )
+
+    def note_prefill_submitted(self) -> None:
+        """Invalidate decode-resident token/position state after a prefill."""
+        self._decode_chain_valid = False
+
+    def note_dp_decode_submitted(self, device_sampling: bool) -> None:
+        """Mirror the merged device submission on every DP rank controller.
+
+        Only the device rank executes ``decode_forward`` and owns page-table
+        snapshots, but every rank participates in the pre-submit overlap vote.
+        Mirroring chain/mode state keeps that vote from treating a first decode
+        or host→device transition as steady.
+        """
+        self._decode_chain_valid = True
+        self._previous_device_sampling = device_sampling
+
+    def _page_tables_changed(self, model_input: TTModelInput) -> bool:
+        current = model_input.block_tables_per_group
+        previous = self._submitted_page_tables
+        return (
+            previous is None
+            or len(previous) != len(current)
+            or any(not torch.equal(old, new) for old, new in zip(previous, current))
+        )
+
+    def plan_decode_reload(self, model_input: TTModelInput) -> TTDecodeReloadPlan:
+        """Return the explicit update plan for the next device submission.
+
+        Host sampling always reloads host-authoritative forward inputs. Device
+        sampling retains token/position state only across an uninterrupted,
+        layout-stable decode chain. Page tables are tracked independently so a
+        newly allocated KV block can be copied without clobbering the
+        device-produced token and advanced position.
+        """
+        from vllm_tt_plugin.model_input import TTDecodeReloadPlan
+
+        device_sampling = model_input.perform_device_sampling
+        sampling_mode_changed = (
+            self._previous_device_sampling is not None
+            and self._previous_device_sampling != device_sampling
+        )
+        transition = (
+            not self._decode_chain_valid
+            or model_input.reset_batch
+            or sampling_mode_changed
+        )
+        reload_inputs = (not device_sampling) or transition
+        sampling_reset = device_sampling and transition
+        return TTDecodeReloadPlan(
+            reload_inputs=reload_inputs,
+            reload_page_table=(
+                not reload_inputs and self._page_tables_changed(model_input)
+            ),
+            reload_sampling_params=sampling_reset,
+            reset_sampling_state=sampling_reset,
+        )
+
+    def commit_decode_submission(
+        self,
+        model_input: TTModelInput,
+        reload_plan: TTDecodeReloadPlan,
+    ) -> None:
+        """Commit residency state after ``decode_forward`` accepted the step."""
+        self._decode_chain_valid = True
+        self._previous_device_sampling = model_input.perform_device_sampling
+        if (
+            reload_plan.reload_inputs
+            or reload_plan.reload_page_table
+            or self._submitted_page_tables is None
+        ):
+            self._submitted_page_tables = self._clone_page_tables(model_input)
+
+    def scheduler_preserves_decode_layout(
+        self, scheduler_output: SchedulerOutput
+    ) -> bool:
+        """Whether scheduling this step leaves every persistent decode row intact.
+
+        This prediction happens before ``_update_states``. It closes the old
+        gap where a new/finished/preempted request was only noticed after the
+        next decode had already been allowed to overlap with stale host input.
+        """
+        current_req_ids = set(self.runner.input_batch.req_id_to_index)
+        scheduled_req_ids = set(scheduler_output.num_scheduled_tokens)
+        return current_req_ids == scheduled_req_ids
 
     def capture_submitted_step_context(
         self, req_ids: list[str] | None = None
@@ -234,6 +337,25 @@ class TTAsyncDecodeController:
 
     def steady_decode_base_enabled(self, *, dp_gather: bool) -> bool:
         runner = self.runner
+        contract_version = int(
+            getattr(
+                getattr(runner, "model", None),
+                "decode_input_update_contract",
+                0,
+            )
+        )
+        is_non_device_dp_rank = (
+            dp_gather
+            and runner.parallel_config.data_parallel_rank_local != 0
+        )
+        if contract_version < 1 and not is_non_device_dp_rank:
+            # Legacy generators may still run asynchronously, but must drain
+            # each result before building the next host input because their
+            # model-local reload heuristics cannot be proven host-stale-safe.
+            # Gathered non-device ranks deliberately have no model; their vote
+            # covers scheduler/layout state while each device-local rank 0
+            # supplies the capability vote.
+            return False
         if dp_gather:
             if not runner.scheduler_config.async_scheduling:
                 return False
@@ -257,6 +379,13 @@ class TTAsyncDecodeController:
             cached_reqs.resumed_req_ids
         )
         if is_prompt or runner._decode_layout_changed_since_last_decode:
+            return False
+        if (
+            not self._decode_chain_valid
+            or self._previous_device_sampling is not True
+        ):
+            return False
+        if not self.scheduler_preserves_decode_layout(scheduler_output):
             return False
         # Structured outputs are detected from the scheduler state, not from a
         # prepared bitmask: the non-DP/lane paths now defer grammar to sample
@@ -337,7 +466,7 @@ class TTAsyncDecodeController:
         max_num_logprobs = model_input.max_num_logprobs[0]
         if max_num_logprobs is not None:  # noqa: SIM103
             return False
-        return True
+        return self.plan_decode_reload(model_input).overlap_safe
 
     def enqueue_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
         with self.runner._steady_decode_lock:
@@ -369,12 +498,14 @@ class TTAsyncDecodeController:
                 completed.append(self.runner._completed_decode_steps.popleft())
         return completed
 
-    def apply_ready_completed_decode_steps(self) -> None:
+    def apply_ready_completed_decode_steps(
+        self, *, skip_req_ids: set[str] | None = None
+    ) -> None:
         for completed in self.drain_completed_decode_steps():
-            self.apply_completed_decode_step(completed)
+            self.apply_completed_decode_step(completed, skip_req_ids=skip_req_ids)
         self.prune_finished_async_events()
 
-    def wait_for_all_pending_async_steps(self) -> None:
+    def wait_for_all_pending_async_steps(self, *, apply_completed: bool = True) -> None:
         # Drive each pending readback to completion here rather than blocking on
         # its event: the engine has not popped these futures yet (and on 0.22
         # will not until after this returns), so nothing else will set the
@@ -384,7 +515,8 @@ class TTAsyncDecodeController:
             steps = list(self.runner._pending_async_steps)
         for step in steps:
             step.ensure_finalized()
-        self.apply_ready_completed_decode_steps()
+        if apply_completed:
+            self.apply_ready_completed_decode_steps()
 
     def must_drain_pending_async_steps(
         self,
@@ -456,11 +588,35 @@ class TTAsyncDecodeController:
             req_id_to_index=completed.context.req_id_to_index,
         )
 
-    def apply_completed_decode_step(self, completed: CompletedDecodeStep) -> None:
+    def apply_completed_decode_step(
+        self,
+        completed: CompletedDecodeStep,
+        *,
+        skip_req_ids: set[str] | None = None,
+    ) -> None:
+        invalid_req_ids = set(skip_req_ids or ())
+        invalid_req_ids.update(
+            req_id
+            for req_id, captured_state in zip(
+                completed.context.req_ids,
+                completed.context.request_states,
+            )
+            if self.runner.requests.get(req_id) is not captured_state
+        )
+        # The batch queue schedules/builds the current step before consuming
+        # the prior future. Mutating the cached prior output here therefore
+        # prevents an aborted/reused request ID from receiving its old token
+        # in scheduler.update_from_output, not just in runner host state.
+        if completed.runner_output is not None:
+            for req_id in invalid_req_ids:
+                req_idx = completed.runner_output.req_id_to_index.get(req_id)
+                if req_idx is not None:
+                    completed.runner_output.sampled_token_ids[req_idx] = []
         self.runner._apply_sampled_tokens_to_state(
             sampled_token_ids=completed.sampled_token_ids,
             req_ids=completed.context.req_ids,
             request_states=completed.context.request_states,
+            skip_req_ids=invalid_req_ids,
         )
 
     def submit_async_non_dp_decode(
@@ -566,6 +722,7 @@ class TTAsyncDecodeController:
                 batch_size_per_dp=batch_size_per_dp,
                 sampling_params=sampling_params,
                 perform_device_sampling=perform_device_sampling,
+                reload_plan=None,
             )
 
         kwargs: dict[str, Any] = {
@@ -603,6 +760,22 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
+        # Versioned compatibility seam. New tt-metal generators advertise the
+        # explicit contract; old generators keep their existing reset_batch
+        # heuristics and never see unknown kwargs.
+        contract_version = int(
+            getattr(runner.model, "decode_input_update_contract", 0)
+        )
+        reload_plan = None
+        if contract_version >= 1:
+            reload_plan = self.plan_decode_reload(model_input)
+            kwargs.update(
+                reload_inputs=reload_plan.reload_inputs,
+                reload_page_table=reload_plan.reload_page_table,
+                reload_sampling_params=reload_plan.reload_sampling_params,
+                reset_sampling_state=reload_plan.reset_sampling_state,
+            )
+
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
             if any(
@@ -626,6 +799,13 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
+        if reload_plan is not None:
+            self.commit_decode_submission(model_input, reload_plan)
+        if (
+            perform_device_sampling
+            and runner.parallel_config.data_parallel_size == 1
+        ):
+            runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:
             if hasattr(runner.model, "read_decode_output"):
@@ -650,6 +830,7 @@ class TTAsyncDecodeController:
             batch_size_per_dp=batch_size_per_dp,
             sampling_params=sampling_params,
             perform_device_sampling=perform_device_sampling,
+            reload_plan=reload_plan,
         )
 
     def finalize_decode(

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -620,11 +620,17 @@ class TTAsyncDecodeController:
         skip_req_ids: set[str] | None = None,
     ) -> None:
         invalid_req_ids = set(skip_req_ids or ())
-        # The batch queue schedules/builds the current step before consuming
-        # the prior future. Mutating the cached prior output here therefore
-        # prevents a finished or resumed request from receiving its old token
-        # in scheduler.update_from_output, not just in runner host state.
+        # The batch queue schedules and executes the current step before
+        # resolving the prior future, so this engine-thread mutation of an
+        # output the executor's output thread produced still lands before
+        # ``scheduler.update_from_output`` reads it. That ordering is what lets
+        # a finished or resumed request reject the token in the scheduler too,
+        # not only in runner host state; assert it rather than trust it.
         if completed.runner_output is not None:
+            assert self.runner.scheduler_config.async_scheduling, (
+                "mutating a published runner output is only ordered correctly "
+                "under the batch-queue step loop"
+            )
             for req_id in invalid_req_ids:
                 req_idx = completed.runner_output.req_id_to_index.get(req_id)
                 if req_idx is not None:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -426,12 +426,41 @@ class TTAsyncDecodeController:
             scheduler_output, grammar_output
         )
 
+    def decode_input_update_contract_version(self) -> int | None:
+        """Adapter's negotiated contract version.
+
+        ``None`` when this rank holds no model: only
+        ``data_parallel_rank_local == 0`` loads one, so the other ranks cannot
+        inspect it and must not answer on its behalf.
+        """
+        model = getattr(self.runner, "model", None)
+        if model is None:
+            return None
+        return int(getattr(model, "decode_input_update_contract", 0))
+
+    def gathered_dp_overlap_permitted(self) -> bool:
+        """Whether gathered DP may submit a step before applying the previous one.
+
+        Only a version-1 adapter is told which inputs are authoritative, so a
+        version-0 adapter keeps the pre-contract finalize-before-submit order:
+        its own reload heuristics would otherwise copy host token/position
+        tensors that are deliberately one step behind the device. Ranks holding
+        no model abstain; the device rank's answer reaches the global decision
+        through the caller's MIN reduction.
+        """
+        if self.runner.parallel_config.data_parallel_size == 1:
+            return True
+        version = self.decode_input_update_contract_version()
+        return version is None or version >= 1
+
     def can_attempt_steady_dp_decode_from_scheduler(
         self,
         scheduler_output: SchedulerOutput | None,
         grammar_output: GrammarOutput | None,
     ) -> bool:
         if not self.steady_decode_base_enabled(dp_gather=True):
+            return False
+        if not self.gathered_dp_overlap_permitted():
             return False
         if scheduler_output is None or scheduler_output.total_num_scheduled_tokens == 0:
             return True
@@ -702,9 +731,7 @@ class TTAsyncDecodeController:
 
         sampling_params = model_input.tt_sampling_params
         perform_device_sampling = model_input.perform_device_sampling
-        contract_version = int(
-            getattr(runner.model, "decode_input_update_contract", 0)
-        )
+        contract_version = int(getattr(runner.model, "decode_input_update_contract", 0))
         if not any(bs > 0 for bs in batch_size_per_dp):
             return TTDecodeSubmission(
                 tt_out=None,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -263,14 +263,18 @@ class TTAsyncDecodeController:
         from vllm_tt_plugin.model_input import TTDecodeReloadPlan
 
         device_sampling = model_input.perform_device_sampling
-        model_capabilities = getattr(
-            getattr(self.runner, "model", None),
-            "model_capabilities",
-            {},
-        ) or {}
+        model_capabilities = (
+            getattr(
+                getattr(self.runner, "model", None),
+                "model_capabilities",
+                {},
+            )
+            or {}
+        )
         supports_resident_decode = bool(
             model_capabilities.get("supports_async_decode", False)
         )
+        decode_trace_enabled = self.runner.trace_mode in ("all", "decode_only")
         sampling_mode_changed = (
             self._previous_device_sampling is not None
             and self._previous_device_sampling != device_sampling
@@ -284,6 +288,7 @@ class TTAsyncDecodeController:
             not device_sampling
             or transition
             or not supports_resident_decode
+            or not decode_trace_enabled
         )
         sampling_reset = device_sampling and transition
         return TTDecodeReloadPlan(
@@ -373,10 +378,7 @@ class TTAsyncDecodeController:
         )
         if is_prompt or runner._decode_layout_changed_since_last_decode:
             return False
-        if (
-            not self._decode_chain_valid
-            or self._previous_device_sampling is not True
-        ):
+        if not self._decode_chain_valid or self._previous_device_sampling is not True:
             return False
         if not self.scheduler_preserves_decode_layout(scheduler_output):
             return False
@@ -749,7 +751,6 @@ class TTAsyncDecodeController:
                 assert model_input.output_tokens is not None
                 kwargs["prompt_tokens"] = model_input.prompt_tokens
                 kwargs["output_tokens"] = model_input.output_tokens
-            kwargs["reset_batch"] = model_input.reset_batch
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
@@ -789,10 +790,7 @@ class TTAsyncDecodeController:
             read_from_device=read_from_device,
         )
         self.commit_decode_submission(model_input, reload_plan)
-        if (
-            perform_device_sampling
-            and runner.parallel_config.data_parallel_size == 1
-        ):
+        if perform_device_sampling and runner.parallel_config.data_parallel_size == 1:
             runner.input_batch.commit_slot_remap()
         read_events = None
         if async_read:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -263,6 +263,14 @@ class TTAsyncDecodeController:
         from vllm_tt_plugin.model_input import TTDecodeReloadPlan
 
         device_sampling = model_input.perform_device_sampling
+        model_capabilities = getattr(
+            getattr(self.runner, "model", None),
+            "model_capabilities",
+            {},
+        ) or {}
+        supports_resident_decode = bool(
+            model_capabilities.get("supports_async_decode", False)
+        )
         sampling_mode_changed = (
             self._previous_device_sampling is not None
             and self._previous_device_sampling != device_sampling
@@ -272,7 +280,11 @@ class TTAsyncDecodeController:
             or model_input.reset_batch
             or sampling_mode_changed
         )
-        reload_inputs = (not device_sampling) or transition
+        reload_inputs = (
+            not device_sampling
+            or transition
+            or not supports_resident_decode
+        )
         sampling_reset = device_sampling and transition
         return TTDecodeReloadPlan(
             reload_inputs=reload_inputs,
@@ -337,25 +349,6 @@ class TTAsyncDecodeController:
 
     def steady_decode_base_enabled(self, *, dp_gather: bool) -> bool:
         runner = self.runner
-        contract_version = int(
-            getattr(
-                getattr(runner, "model", None),
-                "decode_input_update_contract",
-                0,
-            )
-        )
-        is_non_device_dp_rank = (
-            dp_gather
-            and runner.parallel_config.data_parallel_rank_local != 0
-        )
-        if contract_version < 1 and not is_non_device_dp_rank:
-            # Legacy generators may still run asynchronously, but must drain
-            # each result before building the next host input because their
-            # model-local reload heuristics cannot be proven host-stale-safe.
-            # Gathered non-device ranks deliberately have no model; their vote
-            # covers scheduler/layout state while each device-local rank 0
-            # supplies the capability vote.
-            return False
         if dp_gather:
             if not runner.scheduler_config.async_scheduling:
                 return False
@@ -760,21 +753,17 @@ class TTAsyncDecodeController:
             if model_input.slot_remap is not None:
                 kwargs["slot_remap"] = model_input.slot_remap
 
-        # Versioned compatibility seam. New tt-metal generators advertise the
-        # explicit contract; old generators keep their existing reset_batch
-        # heuristics and never see unknown kwargs.
-        contract_version = int(
-            getattr(runner.model, "decode_input_update_contract", 0)
+        # vLLM owns reload decisions because it alone knows when host tensors
+        # are authoritative under async scheduling. The paired tt-metal
+        # revision is therefore required and receives all four commands on
+        # every non-empty decode submission.
+        reload_plan = self.plan_decode_reload(model_input)
+        kwargs.update(
+            reload_inputs=reload_plan.reload_inputs,
+            reload_page_table=reload_plan.reload_page_table,
+            reload_sampling_params=reload_plan.reload_sampling_params,
+            reset_sampling_state=reload_plan.reset_sampling_state,
         )
-        reload_plan = None
-        if contract_version >= 1:
-            reload_plan = self.plan_decode_reload(model_input)
-            kwargs.update(
-                reload_inputs=reload_plan.reload_inputs,
-                reload_page_table=reload_plan.reload_page_table,
-                reload_sampling_params=reload_plan.reload_sampling_params,
-                reset_sampling_state=reload_plan.reset_sampling_state,
-            )
 
         enc_dec_kwargs: dict[str, Any] = {}
         if runner.request_specific_rope:
@@ -799,8 +788,7 @@ class TTAsyncDecodeController:
             enable_trace=enable_trace,
             read_from_device=read_from_device,
         )
-        if reload_plan is not None:
-            self.commit_decode_submission(model_input, reload_plan)
+        self.commit_decode_submission(model_input, reload_plan)
         if (
             perform_device_sampling
             and runner.parallel_config.data_parallel_size == 1

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -265,14 +265,9 @@ class TTAsyncDecodeController:
         from vllm_tt_plugin.model_input import TTDecodeReloadPlan
 
         device_sampling = model_input.perform_device_sampling
-        model_capabilities = (
-            getattr(
-                getattr(self.runner, "model", None),
-                "model_capabilities",
-                {},
-            )
-            or {}
-        )
+        # Reached only on the rank that submits the forward, so a model is
+        # loaded here.
+        model_capabilities = getattr(self.runner.model, "model_capabilities", {}) or {}
         supports_resident_decode = bool(
             model_capabilities.get("supports_async_decode", False)
         )

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/async_decode.py
@@ -312,6 +312,28 @@ class TTAsyncDecodeController:
         ):
             self._submitted_page_tables = self._clone_page_tables(model_input)
 
+    @staticmethod
+    def scheduler_output_is_prompt(scheduler_output: SchedulerOutput) -> bool:
+        """Whether this step carries prefill work of any kind.
+
+        Decided before ``_update_states``, so the persistent batch's
+        ``num_computed_tokens`` still describes the previous step and cannot be
+        consulted. The scheduler output alone is authoritative: a pure decode
+        row is scheduled exactly one token, so a cached request with more is
+        still prefilling - a chunked-prefill continuation, which is a prefill
+        that leaves batch membership intact and therefore passes
+        ``scheduler_preserves_decode_layout``.
+
+        Over-reporting is safe (it only forgoes overlap), so any future feature
+        that schedules several tokens for a decode row lands on the
+        conservative side.
+        """
+        cached_reqs = scheduler_output.scheduled_cached_reqs
+        if scheduler_output.scheduled_new_reqs or cached_reqs.resumed_req_ids:
+            return True
+        num_scheduled = scheduler_output.num_scheduled_tokens
+        return any(num_scheduled.get(req_id, 0) > 1 for req_id in cached_reqs.req_ids)
+
     def scheduler_preserves_decode_layout(
         self, scheduler_output: SchedulerOutput
     ) -> bool:
@@ -368,11 +390,9 @@ class TTAsyncDecodeController:
         grammar_output: GrammarOutput | None,
     ) -> bool:
         runner = self.runner
-        cached_reqs = scheduler_output.scheduled_cached_reqs
-        is_prompt = (len(scheduler_output.scheduled_new_reqs) > 0) or bool(
-            cached_reqs.resumed_req_ids
-        )
-        if is_prompt or runner._decode_layout_changed_since_last_decode:
+        if self.scheduler_output_is_prompt(scheduler_output):
+            return False
+        if runner._decode_layout_changed_since_last_decode:
             return False
         if not self._decode_chain_valid or self._previous_device_sampling is not True:
             return False

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -6,7 +6,7 @@ import os
 import pickle
 import queue
 from concurrent.futures import Future
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TypeVar, cast
 
 import torch
@@ -78,6 +78,10 @@ class DPGatherHandle:
     intermediate_prefill_mask: torch.Tensor | None
     req_ids: list[str]
     req_id_to_index: dict[str, int]
+    # Requests a scheduler output processed after this submission invalidated,
+    # filled in by the later ``dp_gather_submit`` that observes them. Rows for
+    # these ids are dropped when this handle's result is applied.
+    invalidated_req_ids: set[str] = field(default_factory=set)
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):
@@ -428,8 +432,11 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         # sampling-state changes reports ``current_overlap_ok=False`` and
         # drains first, re-establishing host authority before submission.
         # Version-0 adapters never report True (see
-        # ``gathered_dp_overlap_permitted``) because their model-local reload
-        # heuristics would copy the stale host tensors.
+        # ``resident_decode_overlap_permitted``) because their model-local reload
+        # heuristics would copy the stale host tensors: getting this wrong
+        # presents as doubled end-of-turn tokens (``<|end|>`` then
+        # ``<|start|>assistant``), which break harmony parsing and silently null
+        # out chat responses.
         finalize_before_submit = prev_handle is not None and not current_overlap_ok
 
         engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
@@ -447,10 +454,14 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
         next_handle: DPGatherHandle | None = None
         if global_has_requests:
+            # ``prev_handle`` is None exactly when it was already finalized
+            # above, which is what tells the submit whether an outstanding
+            # result still needs this step's invalidations.
             next_handle = self.dp_gather_submit(
                 scheduler_output,
                 grammar_output,
                 overlap_ok=current_overlap_ok,
+                outstanding=prev_handle,
             )
 
         if not finalize_before_submit and prev_handle is not None:
@@ -486,7 +497,18 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         grammar_output: GrammarOutput | None,
         *,
         overlap_ok: bool = False,
+        outstanding: DPGatherHandle | None = None,
     ) -> DPGatherHandle:
+        """Submit one merged DP step and return its handle.
+
+        ``outstanding`` is the still-unapplied handle this step overlaps, if
+        any. Building the local input processes this step's scheduler output,
+        which is what invalidates requests for that earlier submission, so the
+        ids go to ``outstanding`` and never to the handle returned here. When
+        the caller already applied the previous result they pass ``None`` and
+        the ids are dropped: the results were applied in scheduler order, so
+        there is nothing left to reject.
+        """
         parallel_config = self.vllm_config.parallel_config
         group = self.dp_group
         rank = self.dp_rank
@@ -517,7 +539,10 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
+            invalidated_req_ids,
         ) = all_local_inputs
+        if outstanding is not None:
+            outstanding.invalidated_req_ids |= invalidated_req_ids
         max_blocks_decode = None
         any_structured_inputs = False
         any_needs_logprobs = False
@@ -741,10 +766,11 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             else:
                 self.model_executor.collective_rpc("note_dp_prefill_submitted")
             if is_decode and local_input is not None:
-                # Each participating DP rank built its remap from local
-                # persistent state. Commit it only after the globally merged
-                # submission has accepted it. The worker preserves v0's
-                # historical device-sampling-only consumption rule.
+                # Each participating DP rank built its own remap and layout
+                # signal from local persistent state, and only the driver runs
+                # the merged forward, so every rank retires its pair here. The
+                # worker preserves v0's historical device-sampling-only
+                # consumption rule.
                 self.model_executor.collective_rpc(
                     "commit_dp_slot_updates",
                     args=(all_sample_device, contract_version),
@@ -801,6 +827,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     handle.req_ids,
                     handle.req_id_to_index,
                     handle.intermediate_prefill_mask,
+                    handle.invalidated_req_ids,
                 ),
             )[0]
             return output
@@ -811,8 +838,10 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         scheduler_output: SchedulerOutput | None,
         grammar_output: GrammarOutput | None,
     ) -> ModelRunnerOutput:
+        # Submit and finalize the same step, so no earlier result is
+        # outstanding and this step's own invalidations apply to nothing.
         handle = self.dp_gather_submit(
-            scheduler_output, grammar_output, overlap_ok=False
+            scheduler_output, grammar_output, overlap_ok=False, outstanding=None
         )
         return self.dp_gather_finalize(handle)
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -723,12 +723,14 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 )
             else:
                 self.model_executor.collective_rpc("note_dp_prefill_submitted")
-            if is_decode and all_sample_device:
-                # Each DP rank built its remap from local persistent state.
-                # Consume it only after the globally merged device-sampling
-                # submission has been accepted.
+            if is_decode and local_input is not None:
+                # Each participating DP rank built its remap from local
+                # persistent state. Commit it only after the globally merged
+                # submission has accepted it. The worker preserves v0's
+                # historical device-sampling-only consumption rule.
                 self.model_executor.collective_rpc(
-                    "commit_device_sampling_slot_updates"
+                    "commit_dp_slot_updates",
+                    args=(all_sample_device,),
                 )
         else:
             future = self._completed_dp_gather_future()

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -540,6 +540,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     1 - local_can_sample_device,
                     local_needs_logprobs,
                     self._dp_local_contract_version,
+                    int(local_input is not None),
                 ],
                 dtype=torch.int32,
             )
@@ -551,6 +552,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             all_sample_device = input_info_t[4].item() == 0
             any_needs_logprobs = input_info_t[5].item() > 0
             contract_version = int(input_info_t[6].item())
+            any_local_input = input_info_t[7].item() > 0
 
             decode_inputs: dict[str, Any] = self.model_executor.collective_rpc(
                 "build_dp_decode_gather_input",
@@ -728,10 +730,14 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             )
             future = _unwrap_single_worker_future(collective_future)
             if is_decode:
-                self.model_executor.collective_rpc(
-                    "note_dp_decode_submitted",
-                    args=(all_sample_device,),
-                )
+                # With no rank contributing work the merged submit short-circuits
+                # without a forward, so nothing became device-resident and the
+                # residency flags must not advance.
+                if any_local_input:
+                    self.model_executor.collective_rpc(
+                        "note_dp_decode_submitted",
+                        args=(all_sample_device,),
+                    )
             else:
                 self.model_executor.collective_rpc("note_dp_prefill_submitted")
             if is_decode and local_input is not None:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -78,7 +78,6 @@ class DPGatherHandle:
     intermediate_prefill_mask: torch.Tensor | None
     req_ids: list[str]
     req_id_to_index: dict[str, int]
-    request_state_snapshot_id: int | None
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):
@@ -514,7 +513,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
-            request_state_snapshot_id,
         ) = all_local_inputs
         max_blocks_decode = None
         any_structured_inputs = False
@@ -745,7 +743,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             intermediate_prefill_mask=intermediate_prefill_mask,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
-            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
@@ -785,7 +782,6 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     handle.req_ids,
                     handle.req_id_to_index,
                     handle.intermediate_prefill_mask,
-                    handle.request_state_snapshot_id,
                 ),
             )[0]
             return output

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -569,7 +569,17 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 ],
                 dtype=torch.int32,
             )
+            # MIN alongside MAX for the version alone. Every device rank loads the
+            # same model, so their versions agree and MAX simply skips the
+            # abstaining -1s. If that ever stops holding, MAX would hand a
+            # version-0 rank the v1 consumption rule and it would retire a remap
+            # its adapter was never sent, so disagreement has to be fatal rather
+            # than resolved in the permissive direction.
+            version_floor_t = torch.tensor(
+                [self._dp_local_contract_version], dtype=torch.int32
+            )
             dist.all_reduce(input_info_t, op=dist.ReduceOp.MAX, group=group)
+            dist.all_reduce(version_floor_t, op=dist.ReduceOp.MIN, group=group)
             max_blocks_decode = int(input_info_t[0].item())
             any_structured_inputs = input_info_t[1].item() > 0
             any_penalties_inputs = input_info_t[2].item() > 0
@@ -578,6 +588,13 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             any_needs_logprobs = input_info_t[5].item() > 0
             contract_version = int(input_info_t[6].item())
             any_local_input = input_info_t[7].item() > 0
+            version_floor = int(version_floor_t.item())
+            if version_floor >= 0 and version_floor != contract_version:
+                raise RuntimeError(
+                    "gathered DP ranks disagree on the decode input-update "
+                    f"contract version ({version_floor} vs {contract_version}); "
+                    "every device rank must load the same model"
+                )
 
             decode_inputs: dict[str, Any] = self.model_executor.collective_rpc(
                 "build_dp_decode_gather_input",

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -420,12 +420,15 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 handle.scheduler_output, model_output
             )
 
-        # A contract-aware steady device decode deliberately builds the next
-        # step while host token/position state is one step behind: its explicit
+        # A contract-v1 steady device decode deliberately builds the next step
+        # while host token/position state is one step behind: its explicit
         # update plan preserves device-resident token/position buffers (and may
         # refresh only page tables). Every transition requiring host inputs or
         # sampling-state changes reports ``current_overlap_ok=False`` and
         # drains first, re-establishing host authority before submission.
+        # Version-0 adapters never report True (see
+        # ``gathered_dp_overlap_permitted``) because their model-local reload
+        # heuristics would copy the stale host tensors.
         finalize_before_submit = prev_handle is not None and not current_overlap_ok
 
         engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -99,6 +99,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         self.dlog = dlog_logger
         super().__init__(vllm_config, *args, **kwargs)
         self._dp_in_flight: DPGatherHandle | None = None
+        self._dp_local_contract_version: int | None = None
         if self.batch_queue is not None:
             self.step_fn = self.step_dp_with_batch_queue
 
@@ -523,6 +524,13 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
         gathered_inputs: Any = None
         if is_decode:
+            # Only ``data_parallel_rank_local == 0`` loads a model, so ranks
+            # without one report -1 and the MAX reduction below yields the
+            # device ranks' agreed version. Static for the process lifetime.
+            if self._dp_local_contract_version is None:
+                self._dp_local_contract_version = self.model_executor.collective_rpc(
+                    "decode_input_update_contract_version"
+                )[0]
             input_info_t = torch.tensor(
                 [
                     local_max_blocks,
@@ -531,6 +539,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     local_decode_layout_changed,
                     1 - local_can_sample_device,
                     local_needs_logprobs,
+                    self._dp_local_contract_version,
                 ],
                 dtype=torch.int32,
             )
@@ -541,6 +550,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             any_decode_layout_changed = input_info_t[3].item() > 0
             all_sample_device = input_info_t[4].item() == 0
             any_needs_logprobs = input_info_t[5].item() > 0
+            contract_version = int(input_info_t[6].item())
 
             decode_inputs: dict[str, Any] = self.model_executor.collective_rpc(
                 "build_dp_decode_gather_input",
@@ -731,7 +741,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 # historical device-sampling-only consumption rule.
                 self.model_executor.collective_rpc(
                     "commit_dp_slot_updates",
-                    args=(all_sample_device,),
+                    args=(all_sample_device, contract_version),
                 )
         else:
             future = self._completed_dp_gather_future()

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -78,6 +78,7 @@ class DPGatherHandle:
     intermediate_prefill_mask: torch.Tensor | None
     req_ids: list[str]
     req_id_to_index: dict[str, int]
+    request_state_snapshot_id: int | None
 
 
 class TTDPEngineCoreProc(DPEngineCoreProc):
@@ -412,21 +413,21 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             model_output = self.dp_gather_finalize(handle)
             if handle.scheduler_output is None:
                 return {}
+            # Match the synchronous/upstream engine ordering: aborts that
+            # arrived while the device step was in flight must update
+            # scheduler membership before its old output is applied.
+            self._process_aborts_queue()
             return self.scheduler.update_from_output(
                 handle.scheduler_output, model_output
             )
 
-        # Always finalize the previous step before submitting the next one.
-        #
-        # The submit reads ``input_batch.token_ids_cpu`` to build the decode
-        # input for the next step; that table is only updated once
-        # ``apply_dp_execution_result`` runs inside ``_finalize_previous``. The
-        # original overlap path (submit-next then finalize-prev) therefore
-        # built the next step's input from stale token state, so the device
-        # re-sampled the previous step's near-deterministic position — most
-        # visibly as doubled ``<|end|>`` and ``<|start|>assistant`` tokens,
-        # which break harmony parsing and silently null out chat responses.
-        finalize_before_submit = prev_handle is not None
+        # A contract-aware steady device decode deliberately builds the next
+        # step while host token/position state is one step behind: its explicit
+        # update plan preserves device-resident token/position buffers (and may
+        # refresh only page tables). Every transition requiring host inputs or
+        # sampling-state changes reports ``current_overlap_ok=False`` and
+        # drains first, re-establishing host authority before submission.
+        finalize_before_submit = prev_handle is not None and not current_overlap_ok
 
         engine_core_outputs: dict[int, EngineCoreOutputs] | None = {}
         if finalize_before_submit:
@@ -513,6 +514,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
+            request_state_snapshot_id,
         ) = all_local_inputs
         max_blocks_decode = None
         any_structured_inputs = False
@@ -712,6 +714,20 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                 ),
             )
             future = _unwrap_single_worker_future(collective_future)
+            if is_decode:
+                self.model_executor.collective_rpc(
+                    "note_dp_decode_submitted",
+                    args=(all_sample_device,),
+                )
+            else:
+                self.model_executor.collective_rpc("note_dp_prefill_submitted")
+            if is_decode and all_sample_device:
+                # Each DP rank built its remap from local persistent state.
+                # Consume it only after the globally merged device-sampling
+                # submission has been accepted.
+                self.model_executor.collective_rpc(
+                    "commit_device_sampling_slot_updates"
+                )
         else:
             future = self._completed_dp_gather_future()
 
@@ -725,6 +741,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             intermediate_prefill_mask=intermediate_prefill_mask,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     def dp_gather_finalize(self, handle: DPGatherHandle) -> ModelRunnerOutput:
@@ -764,6 +781,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     handle.req_ids,
                     handle.req_id_to_index,
                     handle.intermediate_prefill_mask,
+                    handle.request_state_snapshot_id,
                 ),
             )[0]
             return output

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -508,7 +508,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             local_max_blocks,
             local_has_structured,
             local_has_penalties,
-            local_reset_batch,
+            local_decode_layout_changed,
             local_can_sample_device,
             local_needs_logprobs,
             intermediate_prefill_mask,
@@ -527,7 +527,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     local_max_blocks,
                     local_has_structured,
                     local_has_penalties,
-                    local_reset_batch,
+                    local_decode_layout_changed,
                     1 - local_can_sample_device,
                     local_needs_logprobs,
                 ],
@@ -537,7 +537,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             max_blocks_decode = int(input_info_t[0].item())
             any_structured_inputs = input_info_t[1].item() > 0
             any_penalties_inputs = input_info_t[2].item() > 0
-            any_reset_batch = input_info_t[3].item() > 0
+            any_decode_layout_changed = input_info_t[3].item() > 0
             all_sample_device = input_info_t[4].item() == 0
             any_needs_logprobs = input_info_t[5].item() > 0
 
@@ -586,7 +586,9 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     dist.recv(stacked_float, src=0, group=group)
 
             gathered_tokens_inputs = None
-            if any_penalties_inputs and (not all_sample_device or any_reset_batch):
+            if any_penalties_inputs and (
+                not all_sample_device or any_decode_layout_changed
+            ):
                 if rank == 0:
                     gathered_tokens_inputs = [None for _ in range(world)]
                 local_tokens_inputs = decode_inputs["sampling_tokens_inputs"]
@@ -662,7 +664,7 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
                     "float_inputs": stacked_float,
                     "sampling_tokens_inputs": gathered_tokens_inputs,
                     "host_only_sample_params": gathered_host_only_sample_params,
-                    "reset_batch": any_reset_batch,
+                    "decode_layout_changed": any_decode_layout_changed,
                     "all_sample_device": all_sample_device,
                 }
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -274,16 +274,6 @@ class InputBatch:
         """
         self._slot_remap[req_index] = req_index
 
-    def pop_slot_remap(self) -> torch.Tensor:
-        """Legacy eager-consume helper.
-
-        New decode submission code uses :meth:`peek_slot_remap` and commits only
-        after device sampling actually accepts the update.
-        """
-        remap = self.peek_slot_remap()
-        self.commit_slot_remap()
-        return remap
-
     @property
     def req_ids(self) -> list[str]:
         # None elements should only be present transiently

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -262,10 +262,6 @@ class InputBatch:
 
     def commit_slot_remap(self) -> None:
         """Mark the pending remap as consumed by an accepted decode submit."""
-        self.reset_slot_remap()
-
-    def reset_slot_remap(self) -> None:
-        """Discard the pending remap because no continuing slot state remains."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -482,10 +478,6 @@ class InputBatch:
             # The batched states are empty.
             self._req_ids.clear()
             self.req_output_token_ids.clear()
-            # No continuing request state remains to remap. A non-identity
-            # mapping composed before the last removal must not be replayed
-            # onto slots initialized later by unrelated requests.
-            self.reset_slot_remap()
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -677,6 +677,22 @@ class InputBatch:
             out.append(bt_cpu)
         return out
 
+    def allocated_blocks_for_rows(self, rows: torch.Tensor | list[int]) -> int:
+        """Widest per-group block count the scheduler has allocated to ``rows``.
+
+        Truncating a block table narrower than this drops a block the device
+        will address. Derived from the allocation rather than from a token count
+        because host token state is intentionally one step behind an overlapped
+        device-sampling decode.
+        """
+        return max(
+            (
+                int(bt.num_blocks_per_row[rows].max())
+                for bt in self.block_table.block_tables
+            ),
+            default=0,
+        )
+
     def advance_generators(self, req_indices: list[int] | None = None) -> None:
         # This relies on the fact, that for a torch all_gather_object,
         # the local object is also copied,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -264,6 +264,16 @@ class InputBatch:
         """Mark the pending remap as consumed by an accepted decode submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
+    def _reset_slot_remap_entry(self, req_index: int) -> None:
+        """Drop a pending remap entry for a slot taken by a new request.
+
+        A newly placed request has no predecessor state to gather from, so a
+        non-identity entry would tell the model to copy another slot's
+        persistent state into it. The pending remap outlives steps that submit
+        no decode, so such an entry can outlive the layout that produced it.
+        """
+        self._slot_remap[req_index] = req_index
+
     def pop_slot_remap(self) -> torch.Tensor:
         """Legacy eager-consume helper.
 
@@ -308,6 +318,7 @@ class InputBatch:
         assert req_index < self.max_num_reqs, (
             f"req_index={req_index} >= max_num_reqs={self.max_num_reqs}"
         )
+        self._reset_slot_remap_entry(req_index)
 
         req_id = request.req_id
         if req_index == len(self._req_ids):

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -262,6 +262,10 @@ class InputBatch:
 
     def commit_slot_remap(self) -> None:
         """Mark the pending remap as consumed by an accepted decode submit."""
+        self.reset_slot_remap()
+
+    def reset_slot_remap(self) -> None:
+        """Discard the pending remap because no continuing slot state remains."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -379,8 +383,8 @@ class InputBatch:
         )
 
         # Update fast-path bookkeeping sets.
-        # NOTE: Use `discard()` because `req_id` can be reused (abort+resubmit)
-        # and slots can be overwritten.
+        # Use `discard()` because slots can be overwritten and the request may
+        # not currently be present in a particular fast-path set.
         if sampling_params.temperature == 0.0:
             self.random_reqs.discard(req_id)
         else:
@@ -481,10 +485,7 @@ class InputBatch:
             # No continuing request state remains to remap. A non-identity
             # mapping composed before the last removal must not be replayed
             # onto slots initialized later by unrelated requests.
-            self._slot_remap = torch.arange(
-                self.max_num_reqs,
-                dtype=torch.int32,
-            )
+            self.reset_slot_remap()
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -1169,7 +1169,7 @@ class TTLaneInputBatch(InputBatch):
         if perform_device_sampling and not lane_batch.no_penalties:
             prompt_tokens = lane_batch.make_prompt_token_ids_tensor(rows_all)
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
-        reset_batch = runner._decode_layout_changed_since_last_decode
+        decode_layout_changed = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
         # Device-sampling state owns this remap. Merely building a host-sampling
         # input must not consume it; submit_decode commits it after a successful
@@ -1193,7 +1193,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host sampling reads the merged batch directly (see
             # ``extract_output``); the per-rank sidecars are unused here.
@@ -1286,7 +1286,7 @@ class TTLaneInputBatch(InputBatch):
             grammar_bitmask=[bitmask],
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=False,
+            decode_layout_changed=False,
             slot_remap=None,
             allowed_token_ids_mask_list=[None],
             bad_words_token_ids_list=[{}],

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -1174,9 +1174,7 @@ class TTLaneInputBatch(InputBatch):
         # Device-sampling state owns this remap. Merely building a host-sampling
         # input must not consume it; submit_decode commits it after a successful
         # contract-aware device-sampling submission.
-        slot_remap = (
-            lane_batch.peek_slot_remap() if perform_device_sampling else None
-        )
+        slot_remap = lane_batch.peek_slot_remap() if perform_device_sampling else None
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -264,6 +264,16 @@ class InputBatch:
         """Mark the pending remap as consumed by an accepted decode submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
+    def scheduling_preserves_rows(self, scheduler_output: "SchedulerOutput") -> bool:
+        """Whether applying this scheduler output leaves every row where it is.
+
+        Answered before the batch is mutated, so it has to be derived from the
+        scheduler output alone. This batch front-packs: an occupied row absent
+        from the step is evicted and ``condense`` moves the rows behind it, so
+        membership equality is exactly the question.
+        """
+        return set(self.req_id_to_index) == set(scheduler_output.num_scheduled_tokens)
+
     def _reset_slot_remap_entry(self, req_index: int) -> None:
         """Drop a pending remap entry for a slot taken by a new request.
 
@@ -863,6 +873,23 @@ class TTLaneInputBatch(InputBatch):
         """
         return
 
+    def scheduling_preserves_rows(self, scheduler_output: "SchedulerOutput") -> bool:
+        """Lane rows are stable, so only a release or a placement moves state.
+
+        Mirrors ``apply_step_plan``'s three ``layout_changed`` causes. Merely
+        being unscheduled keeps a request's slot here, so the front-packed
+        membership-equality test would report a change on every step that leaves
+        a running decode unscheduled and give up overlap for nothing.
+        """
+        if scheduler_output.scheduled_new_reqs:
+            return False
+        if scheduler_output.scheduled_cached_reqs.resumed_req_ids:
+            return False
+        return not any(
+            req_id in self.req_id_to_index
+            for req_id in scheduler_output.finished_req_ids
+        )
+
     # ------------------------------------------------------------------
     # State update (lane step plan -> batch + request map)
     # ------------------------------------------------------------------
@@ -1186,11 +1213,11 @@ class TTLaneInputBatch(InputBatch):
         if perform_device_sampling and not lane_batch.no_penalties:
             prompt_tokens = lane_batch.make_prompt_token_ids_tensor(rows_all)
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
-        decode_layout_changed = runner._decode_layout_changed_since_last_decode
-        runner._decode_layout_changed_since_last_decode = False
         # The remap covers any persistent per-slot model state, not just the
-        # device sampler. Merely building the input does not consume it;
-        # submit_decode commits after a contract-aware decode accepts it.
+        # device sampler. Merely building the input does not consume it, nor the
+        # layout signal beside it; ``submit_decode`` retires both once a
+        # contract-aware decode has accepted them.
+        decode_layout_changed = runner._decode_layout_changed_since_last_decode
         slot_remap = lane_batch.peek_slot_remap()
 
         return TTModelInput(

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -247,22 +247,15 @@ class InputBatch:
         # Sampling-related.
         self.sampling = SamplingInputBatch(max_num_reqs, logitsprocs=logitsprocs)
 
-        # Pending persistent-state remap: remap[i] = j means slot i's data
-        # came from slot j after condense. This covers sampler state and any
-        # model-owned per-slot decode state. Identity when nothing moved.
+        # Slot remap for seed manager: remap[i] = j means slot i's data came
+        # from slot j after condense.  Identity when nothing moved.
         self._slot_remap = torch.arange(max_num_reqs, dtype=torch.int32)
 
-    def peek_slot_remap(self) -> torch.Tensor:
-        """Return the pending slot remap without consuming it.
-
-        Building an input does not prove that the model accepted it. Keep the
-        composed remap pending until the successful decode-submission boundary.
-        """
-        return self._slot_remap.clone()
-
-    def commit_slot_remap(self) -> None:
-        """Mark the pending remap as consumed by an accepted decode submit."""
+    def pop_slot_remap(self) -> torch.Tensor:
+        """Return pending slot remap and reset to identity."""
+        remap = self._slot_remap
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
+        return remap
 
     def scheduling_preserves_rows(self, scheduler_output: "SchedulerOutput") -> bool:
         """Whether applying this scheduler output leaves every row where it is.
@@ -273,16 +266,6 @@ class InputBatch:
         membership equality is exactly the question.
         """
         return set(self.req_id_to_index) == set(scheduler_output.num_scheduled_tokens)
-
-    def _reset_slot_remap_entry(self, req_index: int) -> None:
-        """Drop a pending remap entry for a slot taken by a new request.
-
-        A newly placed request has no predecessor state to gather from, so a
-        non-identity entry would tell the model to copy another slot's
-        persistent state into it. The pending remap outlives steps that submit
-        no decode, so such an entry can outlive the layout that produced it.
-        """
-        self._slot_remap[req_index] = req_index
 
     @property
     def req_ids(self) -> list[str]:
@@ -318,8 +301,6 @@ class InputBatch:
         assert req_index < self.max_num_reqs, (
             f"req_index={req_index} >= max_num_reqs={self.max_num_reqs}"
         )
-        self._reset_slot_remap_entry(req_index)
-
         req_id = request.req_id
         if req_index == len(self._req_ids):
             self._req_ids.append(req_id)
@@ -1213,12 +1194,11 @@ class TTLaneInputBatch(InputBatch):
         if perform_device_sampling and not lane_batch.no_penalties:
             prompt_tokens = lane_batch.make_prompt_token_ids_tensor(rows_all)
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
-        # The remap covers any persistent per-slot model state, not just the
-        # device sampler. Merely building the input does not consume it, nor the
-        # layout signal beside it; ``submit_decode`` retires both once a
-        # contract-aware decode has accepted them.
+        # Lane rows are stable, so this batch never moves per-slot state and its
+        # remap is always the identity. The layout signal is read but not retired:
+        # ``submit_decode`` does that once a contract-aware decode has accepted it.
         decode_layout_changed = runner._decode_layout_changed_since_last_decode
-        slot_remap = lane_batch.peek_slot_remap()
+        slot_remap = lane_batch.pop_slot_remap()  # identity for stable slots
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -251,10 +251,27 @@ class InputBatch:
         # from slot j after condense.  Identity when nothing moved.
         self._slot_remap = torch.arange(max_num_reqs, dtype=torch.int32)
 
-    def pop_slot_remap(self) -> torch.Tensor:
-        """Return pending slot remap and reset to identity."""
-        remap = self._slot_remap
+    def peek_slot_remap(self) -> torch.Tensor:
+        """Return the pending slot remap without consuming it.
+
+        A batch may temporarily fall back to host sampling. In that case the
+        device sampler has not consumed the remap, so clearing it would lose the
+        RNG/state move required when device sampling resumes.
+        """
+        return self._slot_remap.clone()
+
+    def commit_slot_remap(self) -> None:
+        """Mark the pending remap as consumed by a device-sampling submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
+
+    def pop_slot_remap(self) -> torch.Tensor:
+        """Legacy eager-consume helper.
+
+        New decode submission code uses :meth:`peek_slot_remap` and commits only
+        after device sampling actually accepts the update.
+        """
+        remap = self.peek_slot_remap()
+        self.commit_slot_remap()
         return remap
 
     @property
@@ -1154,7 +1171,12 @@ class TTLaneInputBatch(InputBatch):
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
         reset_batch = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
-        slot_remap = lane_batch.pop_slot_remap()  # identity for stable slots
+        # Device-sampling state owns this remap. Merely building a host-sampling
+        # input must not consume it; submit_decode commits it after a successful
+        # contract-aware device-sampling submission.
+        slot_remap = (
+            lane_batch.peek_slot_remap() if perform_device_sampling else None
+        )
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/input_batch.py
@@ -247,21 +247,21 @@ class InputBatch:
         # Sampling-related.
         self.sampling = SamplingInputBatch(max_num_reqs, logitsprocs=logitsprocs)
 
-        # Slot remap for seed manager: remap[i] = j means slot i's data came
-        # from slot j after condense.  Identity when nothing moved.
+        # Pending persistent-state remap: remap[i] = j means slot i's data
+        # came from slot j after condense. This covers sampler state and any
+        # model-owned per-slot decode state. Identity when nothing moved.
         self._slot_remap = torch.arange(max_num_reqs, dtype=torch.int32)
 
     def peek_slot_remap(self) -> torch.Tensor:
         """Return the pending slot remap without consuming it.
 
-        A batch may temporarily fall back to host sampling. In that case the
-        device sampler has not consumed the remap, so clearing it would lose the
-        RNG/state move required when device sampling resumes.
+        Building an input does not prove that the model accepted it. Keep the
+        composed remap pending until the successful decode-submission boundary.
         """
         return self._slot_remap.clone()
 
     def commit_slot_remap(self) -> None:
-        """Mark the pending remap as consumed by a device-sampling submit."""
+        """Mark the pending remap as consumed by an accepted decode submit."""
         self._slot_remap = torch.arange(self.max_num_reqs, dtype=torch.int32)
 
     def pop_slot_remap(self) -> torch.Tensor:
@@ -478,6 +478,13 @@ class InputBatch:
             # The batched states are empty.
             self._req_ids.clear()
             self.req_output_token_ids.clear()
+            # No continuing request state remains to remap. A non-identity
+            # mapping composed before the last removal must not be replayed
+            # onto slots initialized later by unrelated requests.
+            self._slot_remap = torch.arange(
+                self.max_num_reqs,
+                dtype=torch.int32,
+            )
             return
 
         # NOTE(woosuk): This function assumes that the empty_req_indices
@@ -1171,10 +1178,10 @@ class TTLaneInputBatch(InputBatch):
             output_tokens = lane_batch.make_output_token_ids_tensor(rows_all)
         decode_layout_changed = runner._decode_layout_changed_since_last_decode
         runner._decode_layout_changed_since_last_decode = False
-        # Device-sampling state owns this remap. Merely building a host-sampling
-        # input must not consume it; submit_decode commits it after a successful
-        # contract-aware device-sampling submission.
-        slot_remap = lane_batch.peek_slot_remap() if perform_device_sampling else None
+        # The remap covers any persistent per-slot model state, not just the
+        # device sampler. Merely building the input does not consume it;
+        # submit_decode commits after a contract-aware decode accepts it.
+        slot_remap = lane_batch.peek_slot_remap()
 
         return TTModelInput(
             input_tokens=input_tokens,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -21,6 +21,38 @@ from vllm.v1.sample.logits_processor import LogitsProcessors
 
 
 @dataclass(frozen=True)
+class TTDecodeReloadPlan:
+    """Explicit host-to-device updates for one decode submission.
+
+    The TT runner is the sole owner of these decisions because it knows whether
+    the host token/position tensors are authoritative or intentionally one step
+    behind an overlapped device-sampling decode. Contract-aware generators must
+    execute these flags as commands and must not infer additional reloads from
+    tensor equality, sampling mode, or their own previous-call state.
+
+    ``reload_inputs`` is a full forward-input copy (tokens, positions, RoPE
+    inputs and page tables). ``reload_page_table`` is the cheaper page-table-only
+    copy and is only meaningful when ``reload_inputs`` is false. Sampling
+    parameters and mutable sampling state are separate so forward and sampling
+    can be split without coupling either update to the batch-layout hint.
+    """
+
+    reload_inputs: bool
+    reload_page_table: bool
+    reload_sampling_params: bool
+    reset_sampling_state: bool
+
+    @property
+    def overlap_safe(self) -> bool:
+        """Whether a device-resident decode may be submitted host-stale."""
+        return not (
+            self.reload_inputs
+            or self.reload_sampling_params
+            or self.reset_sampling_state
+        )
+
+
+@dataclass(frozen=True)
 class TTSamplingParams:
     """Sampling parameters for TT model execution.
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -150,9 +150,10 @@ class TTModelInput:
     # previous step (used by on-device sampling).
     decode_layout_changed: bool = False
 
-    # Per-rank slot remap from condense - remap[i]=j means slot i's data came
-    # from slot j. Identity when nothing moved. Shape: [total_B] (concat of
-    # per-rank [B] tensors for DP).
+    # Per-rank persistent-state remap from condense - remap[i]=j means slot i's
+    # data came from slot j. Applies to model-owned decode state as well as
+    # sampler state, including during host sampling. Identity when nothing
+    # moved. Shape: [total_B] (concat of per-rank [B] tensors for DP).
     slot_remap: torch.Tensor | None = None
 
     # Single-process DP prefill only: global stable slots supplied by the

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -148,7 +148,7 @@ class TTModelInput:
 
     # Decode-only: indicates the padded decode-batch layout changed since the
     # previous step (used by on-device sampling).
-    reset_batch: bool = False
+    decode_layout_changed: bool = False
 
     # Per-rank slot remap from condense - remap[i]=j means slot i's data came
     # from slot j. Identity when nothing moved. Shape: [total_B] (concat of

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_input.py
@@ -42,6 +42,24 @@ class TTDecodeReloadPlan:
     reload_sampling_params: bool
     reset_sampling_state: bool
 
+    def __post_init__(self) -> None:
+        # Requirement 7, host input authority: an adapter aligns its RNG counters
+        # from the host positions on a state reset, which is only sound when the
+        # same step also restages them. Without this the alignment would silently
+        # bind a seeded stream to positions that lag the device by one step, so
+        # the implication is checked here rather than left to hold by accident of
+        # how the two flags happen to be computed.
+        assert not (self.reset_sampling_state and not self.reload_inputs), (
+            "reset_sampling_state requires reload_inputs: an adapter derives its "
+            "seed counters from host positions on a state reset"
+        )
+        # ``reload_inputs`` subsumes the page-table copy, so asking for both is a
+        # contradiction rather than a stronger request.
+        assert not (self.reload_page_table and self.reload_inputs), (
+            "reload_page_table is the page-table-only copy and is meaningless "
+            "when reload_inputs already copies it"
+        )
+
     @property
     def overlap_safe(self) -> bool:
         """Whether a device-resident decode may be submitted host-stale."""

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -952,11 +952,14 @@ class TTModelRunner:
 
         # DP optimization: don't send padding blocks if possible to reduce
         # overhead from gathering inputs to rank 0 and rely on DP concat
-        # function to pad to global max blocks.
+        # function to pad to global max blocks. The width comes from the
+        # scheduler's allocation, not from a token count: an overlapped
+        # device-sampling decode builds this input while host token state is
+        # one step behind, and a token-derived width would drop the block the
+        # device is about to write at every block boundary.
         if self.tt_data_parallel_size > 1:
-            max_tokens_in_batch = max(input_batch.num_tokens[i] for i in req_indices)
-            max_blocks_in_batch = cdiv(
-                max_tokens_in_batch, self.cache_config.block_size
+            max_blocks_in_batch = min(
+                input_batch.allocated_blocks_for_rows(req_indices), target_width
             )
             block_tables_per_group = [
                 bt[:, :max_blocks_in_batch] for bt in block_tables_per_group

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1291,19 +1291,6 @@ class TTModelRunner:
         if not scheduler_output.total_num_scheduled_tokens:
             return None
 
-        # ``_update_states`` may have just discovered a layout change that the
-        # scheduler-output prediction could not see: it predicts the resets caused by
-        # new or resumed requests, but removals, unscheduled requests and batch
-        # condensation only surface here, after the drain decision was already made.
-        # ``_decode_layout_changed_since_last_decode = True`` implies
-        # ``reset_batch=True``: ``_prepare_model_inputs`` below reloads inputs from host
-        # state, which a pending async decode step has not been applied to yet. This
-        # step is therefore not steady-decode eligible, so drain pending decodes to
-        # ensure updated host inputs. No-op when the flag was already set before the
-        # step (the caller's drain decision covered it) or when nothing is pending.
-        if self._decode_layout_changed_since_last_decode:
-            self.async_decode.wait_for_all_pending_async_steps()
-
         # Prepare model inputs only
         model_input = self._prepare_model_inputs(scheduler_output, grammar_output)
         return model_input
@@ -2148,11 +2135,6 @@ class TTModelRunner:
         self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
-            # ``_decode_layout_changed_since_last_decode = True`` implies
-            # ``reset_batch=True``: the model will reload inputs. This step is not
-            # steady-decode eligible, so drain pending decodes to ensure updated
-            # host inputs.
-            self.async_decode.wait_for_all_pending_async_steps()
 
         if not scheduler_output.total_num_scheduled_tokens:
             return EMPTY_MODEL_RUNNER_OUTPUT

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -221,6 +221,9 @@ class TTModelRunner:
         # RNG, decode trace buffers). Needed because evict/re-add and condense move a
         # request's ROW, not its state.
         self._req_state_slot: dict[str, int] = {}
+        # Where the remap built this step will leave that state, held until the
+        # submission carrying it is accepted.
+        self._pending_state_slot_settle: dict[str, int] | None = None
 
         # Sampler for sampling on host when device sampling is not supported.
         # Only used by device ranks (local dp rank 0).
@@ -737,13 +740,12 @@ class TTModelRunner:
     def note_decode_layout_consumed(self) -> None:
         """Retire the layout signal an accepted decode submission carried.
 
-        Paired with ``InputBatch.commit_slot_remap`` at the same boundary. The
-        two must not be retired separately: a remap tells the model to gather
-        each slot's state from its old slot and zeroes what it vacated, and the
-        authoritative rebuild that ``decode_layout_changed`` requests is what
-        repairs that for a slot an intervening prefill has refilled. Retiring
-        the signal at input-build time would drop it on a raised decode while
-        leaving the remap pending.
+        Paired with ``note_decode_state_slots_settled`` at the same boundary. Both
+        describe what the accepted submission did to device state, so retiring one
+        without the other leaves the pair describing different steps: the signal
+        says the layout was rebuilt while the ownership map still points at the
+        pre-gather slots, or the reverse. Retiring either at input-build time drops
+        it on a raised decode.
         """
         self._decode_layout_changed_since_last_decode = False
 
@@ -900,28 +902,55 @@ class TTModelRunner:
     def _decode_state_slot_remap(self, row_req_ids: list[str]) -> torch.Tensor | None:
         """Gather permutation taking each request's state to its decode row: row
         ``i`` reads slot ``remap[i]``. Always full slot width (no OOB gather); None
-        means identity, so skip it."""
+        means identity, so skip it.
+
+        Records where the gather *will* leave each request's state as pending rather
+        than applying it here. Building an input does not prove the model accepted
+        it: on a raised ``decode_forward`` the gather never runs, and an ownership
+        map already advanced to the post-gather layout would compute every later
+        remap from a layout the device never reached.
+        ``note_decode_state_slots_settled`` promotes it once the submission is
+        accepted.
+        """
         n_slots = self.tt_per_lane_max_num_seqs
         row_req_ids = row_req_ids[:n_slots]
         want = [self._req_state_slot.get(r, row) for row, r in enumerate(row_req_ids)]
         # post-gather: state sits at its row
-        settled = {r: row for row, r in enumerate(row_req_ids)}
+        self._pending_state_slot_settle = {r: row for row, r in enumerate(row_req_ids)}
         if len(set(want)) != len(want) or any(not 0 <= s < n_slots for s in want):
             # Never hand a non-permutation to a gather: one incoherent response beats
-            # an out-of-bounds device read.
+            # an out-of-bounds device read. No gather runs, so the state stays where
+            # it is and the map must not move either.
             logger.warning(
                 "TT decode state slots are not a permutation (%s); skipping the state "
                 "remap for this step -- one response may be incoherent.",
                 want,
             )
-            self._req_state_slot.update(settled)
+            self._pending_state_slot_settle = None
             return None
         taken = set(want)
         remap = want + [s for s in range(n_slots) if s not in taken]
-        self._req_state_slot.update(settled)
         if all(remap[i] == i for i in range(n_slots)):
+            # Identity: nothing to gather, so nothing moves and the map already
+            # describes the layout.
+            self._pending_state_slot_settle = None
             return None
         return torch.tensor(remap, dtype=torch.int32)
+
+    def note_decode_state_slots_settled(self) -> None:
+        """Promote the pending state-slot layout after an accepted decode submit.
+
+        Paired with ``note_decode_layout_consumed`` at the same boundary: the remap
+        and the ownership record it implies have to advance together, or a later step
+        derives its gather from a layout the device never reached.
+        """
+        if self._pending_state_slot_settle is not None:
+            self._req_state_slot.update(self._pending_state_slot_settle)
+            self._pending_state_slot_settle = None
+
+    def discard_pending_state_slot_settle(self) -> None:
+        """Drop the pending layout for a submission that was never made."""
+        self._pending_state_slot_settle = None
 
     @staticmethod
     def _build_host_generators(
@@ -970,9 +999,9 @@ class TTModelRunner:
                 structured-output bitmasks.
             grammar_output: Structured-output bitmasks for this step, or
                 ``None`` when no request uses guided decoding.
-            capture_slot_remap: Whether to attach the input batch's pending
-                slot remap. The remap is committed only after a decode accepts
-                it.
+            capture_slot_remap: Whether to attach the per-request state-slot
+                remap. The ownership map it implies advances only after a decode
+                accepts the submission.
 
         Returns:
             A ``TTModelInput`` with tokens, positions, block tables, sampling

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -649,12 +649,6 @@ class TTModelRunner:
             removed_req_indices.append(req_index)
             persistent_batch_layout_changed = True
 
-        # A pending remap refers only to continuing occupants of the old
-        # layout. If removals empty the batch, discard it before this same
-        # scheduler update can refill every freed slot and bypass condense().
-        if removed_req_indices and self.input_batch.num_reqs == 0:
-            self.input_batch.reset_slot_remap()
-
         req_ids_to_add: list[str] = []
         # Add new requests to the cached states.
         for new_req_data in scheduler_output.scheduled_new_reqs:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -212,9 +212,7 @@ class TTModelRunner:
         # Keep the corresponding request-object identities local so an
         # abort+resubmit that reuses a request ID cannot accept an old result.
         self._next_dp_request_state_snapshot_id = 0
-        self._dp_request_state_snapshots: dict[
-            int, tuple[CachedRequestState, ...]
-        ] = {}
+        self._dp_request_state_snapshots: dict[int, tuple[CachedRequestState, ...]] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -1385,6 +1383,24 @@ class TTModelRunner:
         tail = torch.arange(n, max_batch, dtype=torch.int32, device=flat.device)
         return torch.cat([flat, tail])
 
+    @staticmethod
+    def _globalize_dp_slot_remap(raw_remap: torch.Tensor) -> torch.Tensor:
+        """Convert rank-local seed slots into the merged DP slot namespace."""
+        if raw_remap.dim() != 2:
+            raise ValueError(
+                "DP slot remap must have shape [world_size, per_rank_batch]"
+            )
+        per_rank_batch = raw_remap.shape[1]
+        offsets = (
+            torch.arange(
+                raw_remap.shape[0],
+                dtype=raw_remap.dtype,
+                device=raw_remap.device,
+            ).unsqueeze(1)
+            * per_rank_batch
+        )
+        return (raw_remap + offsets).reshape(-1)
+
     def build_dp_decode_gather_input(
         self,
         model_input: TTModelInput | None,
@@ -1762,8 +1778,7 @@ class TTModelRunner:
             # the row-sharded SeedManager uses global indices [0, total_B).
             # Offset each rank's remap values by rank * B.
             raw_remap = stacked_int[:, off : off + B]  # [world, B]
-            offsets = torch.arange(world, dtype=torch.int32).unsqueeze(1) * B
-            slot_remap = (raw_remap + offsets).reshape(total_B)
+            slot_remap = self._globalize_dp_slot_remap(raw_remap)
             off += B
 
             # Optional structured inputs: keep as list[Optional[tensor]]
@@ -2132,9 +2147,7 @@ class TTModelRunner:
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps(
-                apply_completed=False
-            )
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
@@ -2293,9 +2306,7 @@ class TTModelRunner:
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps(
-                apply_completed=False
-            )
+            self.async_decode.wait_for_all_pending_async_steps(apply_completed=False)
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -2784,12 +2795,10 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
-                request_state_snapshot_id = (
-                    self._next_dp_request_state_snapshot_id
-                )
+                request_state_snapshot_id = self._next_dp_request_state_snapshot_id
                 self._next_dp_request_state_snapshot_id += 1
-                self._dp_request_state_snapshots[request_state_snapshot_id] = (
-                    tuple(self.requests[req_id] for req_id in req_ids)
+                self._dp_request_state_snapshots[request_state_snapshot_id] = tuple(
+                    self.requests[req_id] for req_id in req_ids
                 )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -622,9 +622,12 @@ class TTModelRunner:
             # owns its state even though the lines below drop it from the batch.
             self._req_state_slot.pop(req_id, None)
 
-        # Remove the finished requests from the persistent batch. vLLM gives
-        # each accepted request a fresh internal ID, including when a client
-        # aborts and resubmits the same external ID.
+        # Remove the finished requests from the persistent batch.
+        # ``finished_req_ids`` can overlap the scheduled ids: a request id is the
+        # client-supplied one, so an abort followed by a resubmit under the same
+        # id arrives as two distinct requests in one step. The first is cleared
+        # here and the second is added below; the invalidated set keeps the old
+        # request's in-flight result from reaching the new one.
         removed_req_indices: list[int] = []
         for req_id in scheduler_output.finished_req_ids:
             req_index = self.input_batch.remove_request(req_id)
@@ -3180,10 +3183,10 @@ class TTModelRunner:
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
-        # time. vLLM assigns a fresh internal ID to every accepted request, so
-        # a live lookup by captured ID cannot resolve to a later request that
-        # reused the same external ID. ``req_id_to_index`` is therefore the
-        # single source of truth for the target row.
+        # time, because the batch may have condensed in between. Request ids are
+        # client-supplied and can therefore be reused after an abort; the caller
+        # excludes such ids via ``skip_req_ids`` so a stale result cannot reach
+        # the request that took the id over.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         assert sampled_token_ids.shape[0] == num_reqs, (

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -919,8 +919,9 @@ class TTModelRunner:
                 structured-output bitmasks.
             grammar_output: Structured-output bitmasks for this step, or
                 ``None`` when no request uses guided decoding.
-            capture_slot_remap: Whether to pop and attach the input batch's
-                pending slot remap.
+            capture_slot_remap: Whether to attach the input batch's pending
+                slot remap. The remap is committed only after a decode accepts
+                it.
 
         Returns:
             A ``TTModelInput`` with tokens, positions, block tables, sampling

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -718,6 +718,11 @@ class TTModelRunner:
         A finished request must not receive a speculative token, and a request
         resumed from preemption re-prefills from freed KV, so the token computed
         against that KV is void.
+
+        These ids reject only results submitted *before* this scheduler output
+        was processed. A request resumed here is a member of this step's own
+        batch, so its own result is legitimate; the set must therefore reach the
+        outstanding submission and no later one.
         """
         self._invalidated_req_ids.update(scheduler_output.finished_req_ids)
         self._invalidated_req_ids.update(
@@ -728,6 +733,35 @@ class TTModelRunner:
         invalidated = self._invalidated_req_ids
         self._invalidated_req_ids = set()
         return invalidated
+
+    def note_decode_layout_consumed(self) -> None:
+        """Retire the layout signal an accepted decode submission carried.
+
+        Paired with ``InputBatch.commit_slot_remap`` at the same boundary. The
+        two must not be retired separately: a remap tells the model to gather
+        each slot's state from its old slot and zeroes what it vacated, and the
+        authoritative rebuild that ``decode_layout_changed`` requests is what
+        repairs that for a slot an intervening prefill has refilled. Retiring
+        the signal at input-build time would drop it on a raised decode while
+        leaving the remap pending.
+        """
+        self._decode_layout_changed_since_last_decode = False
+
+    def _dp_block_table_width(
+        self, req_indices: list[int], *, target_width: int
+    ) -> int:
+        """Width the gathered page table is trimmed to for this batch.
+
+        Derived from the scheduler's allocation rather than a token count: an
+        overlapped device-sampling decode builds its input while host token
+        state is one step behind, and a token-derived width would drop the block
+        the device is about to write at every block boundary. The DP concat then
+        zero-pads that column back to block id 0, i.e. into another request's
+        page.
+        """
+        return min(
+            self.input_batch.allocated_blocks_for_rows(req_indices), target_width
+        )
 
     def _validate_mm_feature(self, mm_feature: MultiModalFeatureSpec) -> None:
         """Validate the multimodal feature is an image."""
@@ -977,14 +1011,10 @@ class TTModelRunner:
 
         # DP optimization: don't send padding blocks if possible to reduce
         # overhead from gathering inputs to rank 0 and rely on DP concat
-        # function to pad to global max blocks. The width comes from the
-        # scheduler's allocation, not from a token count: an overlapped
-        # device-sampling decode builds this input while host token state is
-        # one step behind, and a token-derived width would drop the block the
-        # device is about to write at every block boundary.
+        # function to pad to global max blocks.
         if self.tt_data_parallel_size > 1:
-            max_blocks_in_batch = min(
-                input_batch.allocated_blocks_for_rows(req_indices), target_width
+            max_blocks_in_batch = self._dp_block_table_width(
+                req_indices, target_width=target_width
             )
             block_tables_per_group = [
                 bt[:, :max_blocks_in_batch] for bt in block_tables_per_group
@@ -1079,9 +1109,11 @@ class TTModelRunner:
             ].view(-1, 1)
             prompt_lens = None
             # For on-device decode sampling, tell the backend if the padded
-            # decode batch layout changed since the previous step.
+            # decode batch layout changed since the previous step. Read but not
+            # cleared here: building an input does not prove the model accepted
+            # it, and this signal has to survive or die with the pending slot
+            # remap it travels beside (see ``note_decode_layout_consumed``).
             decode_layout_changed = self._decode_layout_changed_since_last_decode
-            self._decode_layout_changed_since_last_decode = False
 
             # TODO: Remove once TT models can support arbitrary batch sizes.
             # Pad decode to the lane/rank wire capacity.
@@ -1314,8 +1346,10 @@ class TTModelRunner:
         # so its captured request state must still receive the accepted token.
         self._update_states(scheduler_output)
         self._note_invalidated_requests(scheduler_output)
-        # Gathered DP applies the outstanding result later, in
-        # ``apply_dp_execution_result``, so it must not consume the set here.
+        # The drain below applies the step submitted before this scheduler
+        # output was processed, so it is the submission these ids reject.
+        # Gathered DP applies its outstanding result from the engine's handle
+        # instead, and ``prepare_dp_model_input`` drains the set into it.
         skipped = (
             self._consume_invalidated_req_ids()
             if self.parallel_config.data_parallel_size == 1
@@ -2774,11 +2808,13 @@ class TTModelRunner:
         torch.Tensor | None,
         list[str],
         dict[str, int],
+        set[str],
     ]:
         """Build the per-rank DP payload consumed by gather orchestration.
 
         Returns the local TT model input plus the per-rank metadata needed by
-        gathered-DP negotiation and input gathering.
+        gathered-DP negotiation and input gathering, ending with the requests
+        this step invalidated for the outstanding submission.
         """
         model_input = None
         has_penalties = 0
@@ -2805,6 +2841,11 @@ class TTModelRunner:
         has_structured_input = (
             int(model_input.grammar_bitmask[0] is not None) if model_input else 0
         )
+        # Drained unconditionally, including when this rank scheduled nothing:
+        # the ids belong to the submission that was outstanding when
+        # ``build_model_input`` noted them, and carrying them into a later step
+        # would reject a token that step legitimately produced.
+        invalidated_req_ids = self._consume_invalidated_req_ids()
         return (
             model_input,
             max_blocks,
@@ -2816,6 +2857,7 @@ class TTModelRunner:
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
+            invalidated_req_ids,
         )
 
     def submit_dp_execution(
@@ -2856,20 +2898,19 @@ class TTModelRunner:
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
         Converts the local gathered-DP result into the same state update and
-        `ModelRunnerOutput` used by non-DP execution. Under overlap the next
-        step's scheduler output has already been processed, so requests it
-        finished or resumed must reject this result.
+        `ModelRunnerOutput` used by non-DP execution. ``skip_req_ids`` comes
+        from the engine handle for this submission and names the requests a
+        later scheduler output invalidated while it was in flight; the caller
+        owns that set precisely so this result cannot be filtered by ids
+        belonging to a different step.
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        # Consumed before the chunked-prefill branch: an intermediate-chunk step
-        # that returned early would otherwise leave the set for a later step,
-        # which would then reject a token that is legitimately its own.
-        skip_req_ids = self._consume_invalidated_req_ids() if req_ids else None
         if intermediate_prefill_mask is not None:
             intermediate_mask = intermediate_prefill_mask[:num_reqs]
             if intermediate_mask.any():

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -207,6 +207,11 @@ class TTModelRunner:
         self._pending_async_steps: deque[DeferredDecodeOutput] = deque()
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
+        # Requests whose state an in-flight decode result may no longer touch:
+        # finished, or resumed from preemption and therefore re-prefilling.
+        # Accumulated as the scheduler reveals them and consumed by whichever
+        # path applies the outstanding result.
+        self._invalidated_req_ids: set[str] = set()
         self.async_decode = TTAsyncDecodeController(self)
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
@@ -703,6 +708,23 @@ class TTModelRunner:
 
         # Refresh logits processors with batch state changes
         self.input_batch.refresh_logitsprocs()
+
+    def _note_invalidated_requests(self, scheduler_output: SchedulerOutput) -> None:
+        """Record requests an outstanding decode result may no longer update.
+
+        A finished request must not receive a speculative token, and a request
+        resumed from preemption re-prefills from freed KV, so the token computed
+        against that KV is void.
+        """
+        self._invalidated_req_ids.update(scheduler_output.finished_req_ids)
+        self._invalidated_req_ids.update(
+            scheduler_output.scheduled_cached_reqs.resumed_req_ids
+        )
+
+    def _consume_invalidated_req_ids(self) -> set[str]:
+        invalidated = self._invalidated_req_ids
+        self._invalidated_req_ids = set()
+        return invalidated
 
     def _validate_mm_feature(self, mm_feature: MultiModalFeatureSpec) -> None:
         """Validate the multimodal feature is an image."""
@@ -1288,8 +1310,14 @@ class TTModelRunner:
         # host tensors are built. A request may remain live while unscheduled,
         # so its captured request state must still receive the accepted token.
         self._update_states(scheduler_output)
-        skipped = set(scheduler_output.finished_req_ids)
-        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        self._note_invalidated_requests(scheduler_output)
+        # Gathered DP applies the outstanding result later, in
+        # ``apply_dp_execution_result``, so it must not consume the set here.
+        skipped = (
+            self._consume_invalidated_req_ids()
+            if self.parallel_config.data_parallel_size == 1
+            else None
+        )
         self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if not scheduler_output.total_num_scheduled_tokens:
             return None
@@ -2133,9 +2161,10 @@ class TTModelRunner:
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
         )
-        skipped = set(scheduler_output.finished_req_ids)
-        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
-        self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
+        self._note_invalidated_requests(scheduler_output)
+        self.async_decode.apply_ready_completed_decode_steps(
+            skip_req_ids=self._consume_invalidated_req_ids()
+        )
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
 
@@ -2828,10 +2857,16 @@ class TTModelRunner:
         """Apply the local DP rank result to runner state and build output.
 
         Converts the local gathered-DP result into the same state update and
-        `ModelRunnerOutput` used by non-DP execution.
+        `ModelRunnerOutput` used by non-DP execution. Under overlap the next
+        step's scheduler output has already been processed, so requests it
+        finished or resumed must reject this result.
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
+        # Consumed before the chunked-prefill branch: an intermediate-chunk step
+        # that returned early would otherwise leave the set for a later step,
+        # which would then reject a token that is legitimately its own.
+        skip_req_ids = self._consume_invalidated_req_ids() if req_ids else None
         if intermediate_prefill_mask is not None:
             intermediate_mask = intermediate_prefill_mask[:num_reqs]
             if intermediate_mask.any():
@@ -2845,12 +2880,14 @@ class TTModelRunner:
                     logprobs=logprobs_lists,
                     intermediate_mask=intermediate_mask.cpu().numpy(),
                     req_id_to_index=req_id_to_index,
+                    skip_req_ids=skip_req_ids,
                 )
         return self.apply_and_build_runner_output(
             sampled_token_ids,
             logprobs_lists,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
+            skip_req_ids=skip_req_ids,
         )
 
     def _get_output_tokens(
@@ -3211,22 +3248,34 @@ class TTModelRunner:
         logprobs: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        skip_req_ids: set[str] | None = None,
     ):
         """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
         Updates persistent runner state from sampled tokens and returns the
-        `ModelRunnerOutput` consumed by the rest of vLLM.
+        `ModelRunnerOutput` consumed by the rest of vLLM. ``skip_req_ids`` names
+        requests whose state this result may no longer touch; their rows are
+        emptied so the scheduler does not append the token either.
         """
+        assert not skip_req_ids or req_ids is not None, (
+            "skip_req_ids resolves rows by request id, so req_ids is required"
+        )
         self._apply_sampled_tokens_to_state(
             sampled_token_ids=sampled_token_ids,
             req_ids=req_ids,
+            skip_req_ids=skip_req_ids,
         )
-        return self._build_runner_output(
+        output = self._build_runner_output(
             sampled_token_ids=sampled_token_ids,
             logprobs=logprobs,
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
         )
+        for req_id in skip_req_ids or ():
+            req_idx = output.req_id_to_index.get(req_id)
+            if req_idx is not None:
+                output.sampled_token_ids[req_idx] = []
+        return output
 
     def warmup_model(self) -> None:
         # Two-phase warmup: compile first, then capture traces.

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -208,11 +208,6 @@ class TTModelRunner:
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
         self.async_decode = TTAsyncDecodeController(self)
-        # Gathered-DP results cross the engine/worker boundary as tensors.
-        # Keep the corresponding request-object identities local so an
-        # abort+resubmit that reuses a request ID cannot accept an old result.
-        self._next_dp_request_state_snapshot_id = 0
-        self._dp_request_state_snapshots: dict[int, tuple[CachedRequestState, ...]] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -622,12 +617,9 @@ class TTModelRunner:
             # owns its state even though the lines below drop it from the batch.
             self._req_state_slot.pop(req_id, None)
 
-        # Remove the finished requests from the persistent batch.
-        # NOTE(woosuk): There could be an edge case where finished_req_ids and
-        # scheduled_req_ids overlap. This happens when a request is aborted and
-        # then resubmitted with the same ID. In this case, we treat them as two
-        # distinct requests - clearing the cached states for the first request
-        # and handling the second as a new request.
+        # Remove the finished requests from the persistent batch. vLLM gives
+        # each accepted request a fresh internal ID, including when a client
+        # aborts and resubmits the same external ID.
         removed_req_indices: list[int] = []
         for req_id in scheduler_output.finished_req_ids:
             req_index = self.input_batch.remove_request(req_id)
@@ -656,6 +648,12 @@ class TTModelRunner:
             assert req_index is not None
             removed_req_indices.append(req_index)
             persistent_batch_layout_changed = True
+
+        # A pending remap refers only to continuing occupants of the old
+        # layout. If removals empty the batch, discard it before this same
+        # scheduler update can refill every freed slot and bypass condense().
+        if removed_req_indices and self.input_batch.num_reqs == 0:
+            self.input_batch.reset_slot_remap()
 
         req_ids_to_add: list[str] = []
         # Add new requests to the cached states.
@@ -1292,8 +1290,6 @@ class TTModelRunner:
         # continuing requests need the accepted token appended before current
         # host tensors are built. A request may remain live while unscheduled,
         # so its captured request state must still receive the accepted token.
-        # Captured request-object identity separately protects abort+resubmit
-        # with the same request ID.
         self._update_states(scheduler_output)
         skipped = set(scheduler_output.finished_req_ids)
         skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
@@ -2767,7 +2763,6 @@ class TTModelRunner:
         torch.Tensor | None,
         list[str],
         dict[str, int],
-        int | None,
     ]:
         """Build the per-rank DP payload consumed by gather orchestration.
 
@@ -2782,7 +2777,6 @@ class TTModelRunner:
         intermediate_prefill_mask = None
         req_ids: list[str] = []
         req_id_to_index: dict[str, int] = {}
-        request_state_snapshot_id: int | None = None
         if scheduler_output is not None:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
@@ -2796,11 +2790,6 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
-                request_state_snapshot_id = self._next_dp_request_state_snapshot_id
-                self._next_dp_request_state_snapshot_id += 1
-                self._dp_request_state_snapshots[request_state_snapshot_id] = tuple(
-                    self.requests[req_id] for req_id in req_ids
-                )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (
             int(model_input.grammar_bitmask[0] is not None) if model_input else 0
@@ -2816,7 +2805,6 @@ class TTModelRunner:
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
-            request_state_snapshot_id,
         )
 
     def submit_dp_execution(
@@ -2857,7 +2845,6 @@ class TTModelRunner:
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
-        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
@@ -2866,56 +2853,26 @@ class TTModelRunner:
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        # The snapshot is popped before any early return: an intermediate-chunk
-        # step must not leave its entry behind for a later step to mistake for
-        # its own.
-        request_states = (
-            self._dp_request_state_snapshots.pop(request_state_snapshot_id)
-            if request_state_snapshot_id is not None
-            else None
+        if intermediate_prefill_mask is not None:
+            intermediate_mask = intermediate_prefill_mask[:num_reqs]
+            if intermediate_mask.any():
+                return self._build_chunked_prefill_output(
+                    req_ids=(
+                        list(req_ids)
+                        if req_ids is not None
+                        else list(self.input_batch.req_ids[:num_reqs])
+                    ),
+                    sampled_token_ids=sampled_token_ids,
+                    logprobs=logprobs_lists,
+                    intermediate_mask=intermediate_mask.cpu().numpy(),
+                    req_id_to_index=req_id_to_index,
+                )
+        return self.apply_and_build_runner_output(
+            sampled_token_ids,
+            logprobs_lists,
+            req_ids=req_ids,
+            req_id_to_index=req_id_to_index,
         )
-        invalid_req_ids = (
-            {
-                req_id
-                for req_id, captured_state in zip(req_ids or (), request_states)
-                if self.requests.get(req_id) is not captured_state
-            }
-            if request_states is not None
-            else set()
-        )
-        intermediate_mask = (
-            intermediate_prefill_mask[:num_reqs]
-            if intermediate_prefill_mask is not None
-            else None
-        )
-        if intermediate_mask is not None and bool(intermediate_mask.any()):
-            output = self._build_chunked_prefill_output(
-                req_ids=(
-                    list(req_ids)
-                    if req_ids is not None
-                    else list(self.input_batch.req_ids[:num_reqs])
-                ),
-                sampled_token_ids=sampled_token_ids,
-                logprobs=logprobs_lists,
-                intermediate_mask=intermediate_mask.cpu().numpy(),
-                req_id_to_index=req_id_to_index,
-                skip_req_ids=invalid_req_ids,
-            )
-        else:
-            output = self.apply_and_build_runner_output(
-                sampled_token_ids,
-                logprobs_lists,
-                req_ids=req_ids,
-                req_id_to_index=req_id_to_index,
-                request_states=request_states,
-            )
-        # Identity-invalid rows belong to an aborted/replaced request. Keep
-        # their wire positions, but expose no generated token so the scheduler
-        # cannot apply an old in-flight result to a new request with the same
-        # string ID.
-        for req_id in invalid_req_ids:
-            output.sampled_token_ids[output.req_id_to_index[req_id]] = []
-        return output
 
     def _get_output_tokens(
         self,
@@ -3203,14 +3160,13 @@ class TTModelRunner:
         self,
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
-        request_states: tuple[CachedRequestState, ...] | None = None,
         skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
-        # time: lane mode pins each request to a stable slot for its lifetime
-        # and the ``request_states`` identity check guards slot reuse, so the
-        # live row equals the captured one. ``req_id_to_index`` is therefore the
+        # time. vLLM assigns a fresh internal ID to every accepted request, so
+        # a live lookup by captured ID cannot resolve to a later request that
+        # reused the same external ID. ``req_id_to_index`` is therefore the
         # single source of truth for the target row.
         use_captured_req_ids = req_ids is not None
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
@@ -3253,8 +3209,6 @@ class TTModelRunner:
             req_state = self.requests.get(req_id)
             if req_state is None:
                 continue
-            if request_states is not None and req_state is not request_states[req_idx]:
-                continue
 
             current_row = self.input_batch.req_id_to_index.get(req_id)
             if current_row is not None:
@@ -3278,7 +3232,6 @@ class TTModelRunner:
         logprobs: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
-        request_states: tuple[CachedRequestState, ...] | None = None,
     ):
         """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
@@ -3288,7 +3241,6 @@ class TTModelRunner:
         self._apply_sampled_tokens_to_state(
             sampled_token_ids=sampled_token_ids,
             req_ids=req_ids,
-            request_states=request_states,
         )
         return self._build_runner_output(
             sampled_token_ids=sampled_token_ids,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -208,6 +208,13 @@ class TTModelRunner:
         self._pending_async_overlap_ok: deque[bool] = deque()
         self._completed_decode_steps: deque[CompletedDecodeStep] = deque()
         self.async_decode = TTAsyncDecodeController(self)
+        # Gathered-DP results cross the engine/worker boundary as tensors.
+        # Keep the corresponding request-object identities local so an
+        # abort+resubmit that reuses a request ID cannot accept an old result.
+        self._next_dp_request_state_snapshot_id = 0
+        self._dp_request_state_snapshots: dict[
+            int, tuple[CachedRequestState, ...]
+        ] = {}
         self.tt_data_parallel_size = get_tt_data_parallel_size(vllm_config)
         self.tt_max_batch_size = get_tt_max_batch_size(vllm_config)
         self.tt_per_lane_max_num_seqs = get_tt_per_lane_max_num_seqs(vllm_config)
@@ -1281,8 +1288,17 @@ class TTModelRunner:
         For data parallel, this function is called by each DP rank to build
         TTModelInput from it's own scheduler output.
         """
-        # Update cached state
+        # Update scheduler-owned membership before applying a drained async
+        # output. Finished/resumed requests must reject the speculative token;
+        # continuing requests need the accepted token appended before current
+        # host tensors are built. A request may remain live while unscheduled,
+        # so its captured request state must still receive the accepted token.
+        # Captured request-object identity separately protects abort+resubmit
+        # with the same request ID.
         self._update_states(scheduler_output)
+        skipped = set(scheduler_output.finished_req_ids)
+        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if not scheduler_output.total_num_scheduled_tokens:
             return None
 
@@ -2110,18 +2126,22 @@ class TTModelRunner:
             )
 
         lane_batch = self.lane_batch
-        self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_dp_decode_from_scheduler(
                 scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(
+                apply_completed=False
+            )
 
         layout_changed = lane_batch.apply_step_plan(
             scheduler_output, plan, self.requests, self.encoder_cache
         )
+        skipped = set(scheduler_output.finished_req_ids)
+        skipped.update(scheduler_output.scheduled_cached_reqs.resumed_req_ids)
+        self.async_decode.apply_ready_completed_decode_steps(skip_req_ids=skipped)
         if layout_changed:
             self._decode_layout_changed_since_last_decode = True
             # ``_decode_layout_changed_since_last_decode = True`` implies
@@ -2267,14 +2287,15 @@ class TTModelRunner:
         # thread. In steady decode mode we intentionally allow one step of
         # lag between host application and device submission, but we never let
         # completed work pile up unbounded.
-        self.async_decode.apply_ready_completed_decode_steps()
         steady_decode_candidate = (
             self.async_decode.can_attempt_steady_decode_from_scheduler(
                 scheduler_output, None
             )
         )
         if self.async_decode.must_drain_pending_async_steps(steady_decode_candidate):
-            self.async_decode.wait_for_all_pending_async_steps()
+            self.async_decode.wait_for_all_pending_async_steps(
+                apply_completed=False
+            )
 
         # Grammar is applied at sample time, so the forward builds without it.
         model_input = self.build_model_input(scheduler_output, None)
@@ -2411,6 +2432,7 @@ class TTModelRunner:
         logprobs: list | None,
         intermediate_mask: np.ndarray,
         req_id_to_index: dict[str, int] | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> ModelRunnerOutput:
         """Builds output with ``[]`` for intermediate, ``[tokens]`` for final chunks."""
         final_idx_np = np.where(~intermediate_mask)[0]
@@ -2418,14 +2440,18 @@ class TTModelRunner:
             final_idx_tensor = torch.from_numpy(final_idx_np.astype(np.int64))
             final_tokens = sampled_token_ids[final_idx_tensor]
             final_req_ids = [req_ids[int(i)] for i in final_idx_np]
-            self._apply_sampled_tokens_to_state(final_tokens, req_ids=final_req_ids)
+            self._apply_sampled_tokens_to_state(
+                final_tokens, req_ids=final_req_ids, skip_req_ids=skip_req_ids
+            )
 
         num_reqs = len(req_ids)
         sampled_token_ids_np = sampled_token_ids.view(num_reqs).numpy()
         if sampled_token_ids_np.dtype != np.int32:
             sampled_token_ids_np = sampled_token_ids_np.astype(np.int32, copy=False)
         sampled_token_id_lists = [
-            [] if intermediate_mask[i] else [int(sampled_token_ids_np[i])]
+            []
+            if intermediate_mask[i] or (skip_req_ids and req_ids[i] in skip_req_ids)
+            else [int(sampled_token_ids_np[i])]
             for i in range(num_reqs)
         ]
 
@@ -2610,8 +2636,11 @@ class TTModelRunner:
             # Store rope_deltas for each prefilled request
             for i, req_id in enumerate(self.input_batch.req_ids):
                 self.requests[req_id].mrope_position_delta = rope_deltas[i].item()
+            self.async_decode.note_prefill_submitted()
             return tt_out
-        return self.model.prefill_forward(**kwargs)
+        tt_out = self.model.prefill_forward(**kwargs)
+        self.async_decode.note_prefill_submitted()
+        return tt_out
 
     def _forward_with_model_input(
         self,
@@ -2726,6 +2755,7 @@ class TTModelRunner:
         torch.Tensor | None,
         list[str],
         dict[str, int],
+        int | None,
     ]:
         """Build the per-rank DP payload consumed by gather orchestration.
 
@@ -2740,6 +2770,7 @@ class TTModelRunner:
         intermediate_prefill_mask = None
         req_ids: list[str] = []
         req_id_to_index: dict[str, int] = {}
+        request_state_snapshot_id: int | None = None
         if scheduler_output is not None:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
@@ -2753,6 +2784,13 @@ class TTModelRunner:
                 num_reqs = self.input_batch.num_reqs
                 req_ids = list(self.input_batch.req_ids[:num_reqs])
                 req_id_to_index = dict(self.input_batch.req_id_to_index)
+                request_state_snapshot_id = (
+                    self._next_dp_request_state_snapshot_id
+                )
+                self._next_dp_request_state_snapshot_id += 1
+                self._dp_request_state_snapshots[request_state_snapshot_id] = (
+                    tuple(self.requests[req_id] for req_id in req_ids)
+                )
         max_blocks = model_input.block_tables.shape[1] if model_input else 0
         has_structured_input = (
             int(model_input.grammar_bitmask[0] is not None) if model_input else 0
@@ -2768,6 +2806,7 @@ class TTModelRunner:
             intermediate_prefill_mask,
             req_ids,
             req_id_to_index,
+            request_state_snapshot_id,
         )
 
     def submit_dp_execution(
@@ -2808,6 +2847,7 @@ class TTModelRunner:
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
+        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result to runner state and build output.
 
@@ -2816,27 +2856,56 @@ class TTModelRunner:
         """
         num_reqs = len(req_ids) if req_ids is not None else self.input_batch.num_reqs
         sampled_token_ids = sampled_token_ids[:num_reqs]
-        if intermediate_prefill_mask is not None:
-            intermediate_mask = intermediate_prefill_mask[:num_reqs]
-            if intermediate_mask.any():
-                output_req_ids = (
+        # The snapshot is popped before any early return: an intermediate-chunk
+        # step must not leave its entry behind for a later step to mistake for
+        # its own.
+        request_states = (
+            self._dp_request_state_snapshots.pop(request_state_snapshot_id)
+            if request_state_snapshot_id is not None
+            else None
+        )
+        invalid_req_ids = (
+            {
+                req_id
+                for req_id, captured_state in zip(req_ids or (), request_states)
+                if self.requests.get(req_id) is not captured_state
+            }
+            if request_states is not None
+            else set()
+        )
+        intermediate_mask = (
+            intermediate_prefill_mask[:num_reqs]
+            if intermediate_prefill_mask is not None
+            else None
+        )
+        if intermediate_mask is not None and bool(intermediate_mask.any()):
+            output = self._build_chunked_prefill_output(
+                req_ids=(
                     list(req_ids)
                     if req_ids is not None
                     else list(self.input_batch.req_ids[:num_reqs])
-                )
-                return self._build_chunked_prefill_output(
-                    req_ids=output_req_ids,
-                    sampled_token_ids=sampled_token_ids,
-                    logprobs=logprobs_lists,
-                    intermediate_mask=intermediate_mask.cpu().numpy(),
-                    req_id_to_index=req_id_to_index,
-                )
-        return self.apply_and_build_runner_output(
-            sampled_token_ids,
-            logprobs_lists,
-            req_ids=req_ids,
-            req_id_to_index=req_id_to_index,
-        )
+                ),
+                sampled_token_ids=sampled_token_ids,
+                logprobs=logprobs_lists,
+                intermediate_mask=intermediate_mask.cpu().numpy(),
+                req_id_to_index=req_id_to_index,
+                skip_req_ids=invalid_req_ids,
+            )
+        else:
+            output = self.apply_and_build_runner_output(
+                sampled_token_ids,
+                logprobs_lists,
+                req_ids=req_ids,
+                req_id_to_index=req_id_to_index,
+                request_states=request_states,
+            )
+        # Identity-invalid rows belong to an aborted/replaced request. Keep
+        # their wire positions, but expose no generated token so the scheduler
+        # cannot apply an old in-flight result to a new request with the same
+        # string ID.
+        for req_id in invalid_req_ids:
+            output.sampled_token_ids[output.req_id_to_index[req_id]] = []
+        return output
 
     def _get_output_tokens(
         self,
@@ -3125,6 +3194,7 @@ class TTModelRunner:
         sampled_token_ids: torch.Tensor,
         req_ids: list[str] | None = None,
         request_states: tuple[CachedRequestState, ...] | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> None:
         # When applying a deferred async step, the write row is resolved live
         # from ``req_id_to_index`` (below), not from the row captured at submit
@@ -3168,6 +3238,8 @@ class TTModelRunner:
         assert req_ids is not None
         captured_req_ids = req_ids
         for req_idx, req_id in enumerate(captured_req_ids):
+            if skip_req_ids is not None and req_id in skip_req_ids:
+                continue
             req_state = self.requests.get(req_id)
             if req_state is None:
                 continue
@@ -3196,6 +3268,7 @@ class TTModelRunner:
         logprobs: LogprobsLists | None = None,
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
+        request_states: tuple[CachedRequestState, ...] | None = None,
     ):
         """Apply sampled tokens to runner state and build `ModelRunnerOutput`.
 
@@ -3205,6 +3278,7 @@ class TTModelRunner:
         self._apply_sampled_tokens_to_state(
             sampled_token_ids=sampled_token_ids,
             req_ids=req_ids,
+            request_states=request_states,
         )
         return self._build_runner_output(
             sampled_token_ids=sampled_token_ids,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -1049,7 +1049,7 @@ class TTModelRunner:
             input_tokens = input_batch.token_ids_cpu_tensor[
                 req_indices, :max_prefill_tokens
             ]
-            reset_batch = False
+            decode_layout_changed = False
         else:
             positions_np = input_batch.num_tokens[req_indices] - 1
             input_positions = torch.from_numpy(positions_np)
@@ -1059,7 +1059,7 @@ class TTModelRunner:
             prompt_lens = None
             # For on-device decode sampling, tell the backend if the padded
             # decode batch layout changed since the previous step.
-            reset_batch = self._decode_layout_changed_since_last_decode
+            decode_layout_changed = self._decode_layout_changed_since_last_decode
             self._decode_layout_changed_since_last_decode = False
 
             # TODO: Remove once TT models can support arbitrary batch sizes.
@@ -1258,7 +1258,7 @@ class TTModelRunner:
             grammar_bitmask=[bitmask],  # wrap to match DP case
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host-only sampling params - wrapped in lists for DP compatibility
             allowed_token_ids_mask_list=[allowed_token_ids_mask],
@@ -1660,7 +1660,7 @@ class TTModelRunner:
             Only provided when there are requests with penalties.
             One dict per DP rank, each with keys "prompt_tokens" and
             "output_tokens" (tensors padded with -1).
-          - "reset_batch": bool for if the batch layout changed
+          - "decode_layout_changed": bool for if the batch layout changed
             since the previous step.
           - "all_sample_device": bool for if all ranks can sample on device.
         """
@@ -1703,7 +1703,7 @@ class TTModelRunner:
             )
             B = self.tt_per_lane_max_num_seqs
             W = max_blocks_decode_batch
-            reset_batch = inputs["reset_batch"]
+            decode_layout_changed = inputs["decode_layout_changed"]
             perform_device_sampling = inputs["all_sample_device"]
             stacked_int: torch.Tensor = inputs["int_inputs"]
             stacked_float: torch.Tensor = inputs["float_inputs"]
@@ -1866,7 +1866,7 @@ class TTModelRunner:
             num_logprobs_list: list[torch.Tensor] = []
             enable_log_probs_list: list[torch.Tensor] = []
             intermediate_prefill_masks: list[torch.Tensor] = []
-            reset_batch = False
+            decode_layout_changed = False
 
             active_inputs: list[TTModelInput] = [mi for mi in inputs if mi]
             if not active_inputs:
@@ -2092,7 +2092,7 @@ class TTModelRunner:
             grammar_bitmask=grammar_bitmask_list,
             prompt_tokens=prompt_tokens,
             output_tokens=output_tokens,
-            reset_batch=reset_batch,
+            decode_layout_changed=decode_layout_changed,
             slot_remap=slot_remap,
             # Host-only sampling params (per-rank lists)
             allowed_token_ids_mask_list=allowed_token_ids_mask_list,
@@ -2775,7 +2775,7 @@ class TTModelRunner:
         """
         model_input = None
         has_penalties = 0
-        reset_batch = 0
+        decode_layout_changed = 0
         can_sample_device = 1
         needs_logprobs = 0
         intermediate_prefill_mask = None
@@ -2786,7 +2786,7 @@ class TTModelRunner:
             model_input = self.build_model_input(scheduler_output, grammar_output)
             if model_input is not None:
                 has_penalties = int(not self.input_batch.no_penalties)
-                reset_batch = int(model_input.reset_batch)
+                decode_layout_changed = int(model_input.decode_layout_changed)
                 can_sample_device = int(model_input.perform_device_sampling)
                 max_num_logprobs = model_input.max_num_logprobs[0]
                 # max_num_logprobs=0 still requests the sampled token's logprob.
@@ -2809,7 +2809,7 @@ class TTModelRunner:
             max_blocks,
             has_structured_input,
             has_penalties,
-            reset_batch,
+            decode_layout_changed,
             can_sample_device,
             needs_logprobs,
             intermediate_prefill_mask,

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -708,10 +708,10 @@ class TTPlatform(Platform):
                 "Unset sample_on_device_mode or use a model that supports it."
             )
 
-        # Model-gated async scheduling. Async overlap requires generators that
-        # support split decode submission via `decode_forward(...,
-        # read_from_device=False)` followed by `read_decode_output(...,
-        # async_read=True)`.
+        # Model-gated async scheduling. The capability certifies both split
+        # decode submission/readback and device-resident sampled-token feedback
+        # between decode steps. Models without it use conservative full input
+        # reloads and cannot enable scheduler overlap.
         supports_async_decode = (
             model_capabilities.get("supports_async_decode", False)
             if model_capabilities

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -377,16 +377,15 @@ class TTWorker(WorkerBase):
         torch.Tensor | None,
         list[str],
         dict[str, int],
-        int | None,
     ]:
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, decode_layout_changed, can_sample_device, needs_logprobs,
-        intermediate_prefill_mask, req_ids, req_id_to_index,
-        request_state_snapshot_id)`, where `local_input` is this rank's TT model
-        input (or `None`) and the remaining fields are the per-rank metadata
-        consumed by gathered-DP orchestration.
+        intermediate_prefill_mask, req_ids, req_id_to_index)`, where
+        `local_input` is this rank's TT model input (or `None`) and the
+        remaining fields are the per-rank metadata consumed by gathered-DP
+        orchestration.
         """
         return self.model_runner.prepare_dp_model_input(
             scheduler_output, grammar_output
@@ -505,7 +504,6 @@ class TTWorker(WorkerBase):
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
-        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
@@ -518,7 +516,6 @@ class TTWorker(WorkerBase):
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
             intermediate_prefill_mask=intermediate_prefill_mask,
-            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -377,15 +377,16 @@ class TTWorker(WorkerBase):
         torch.Tensor | None,
         list[str],
         dict[str, int],
+        int | None,
     ]:
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, reset_batch, can_sample_device, needs_logprobs,
-        intermediate_prefill_mask, req_ids, req_id_to_index)`, where
-        `local_input` is this rank's
-        TT model input (or `None`) and the remaining fields are the
-        per-rank metadata consumed by gathered-DP orchestration.
+        intermediate_prefill_mask, req_ids, req_id_to_index,
+        request_state_snapshot_id)`, where `local_input` is this rank's TT model
+        input (or `None`) and the remaining fields are the per-rank metadata
+        consumed by gathered-DP orchestration.
         """
         return self.model_runner.prepare_dp_model_input(
             scheduler_output, grammar_output
@@ -414,6 +415,18 @@ class TTWorker(WorkerBase):
         return self.model_runner.can_attempt_steady_decode_from_scheduler(
             scheduler_output, grammar_output
         )
+
+    def commit_device_sampling_slot_updates(self) -> None:
+        """Commit the local remap after a gathered device-sampling submit."""
+        self.model_runner.input_batch.commit_slot_remap()
+
+    def note_dp_decode_submitted(self, device_sampling: bool) -> None:
+        """Mirror merged decode residency on this rank's overlap controller."""
+        self.model_runner.async_decode.note_dp_decode_submitted(device_sampling)
+
+    def note_dp_prefill_submitted(self) -> None:
+        """Invalidate this rank's decode residency after merged prefill."""
+        self.model_runner.async_decode.note_prefill_submitted()
 
     def build_dp_decode_gather_input(
         self,
@@ -479,6 +492,7 @@ class TTWorker(WorkerBase):
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
+        request_state_snapshot_id: int | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
@@ -491,6 +505,7 @@ class TTWorker(WorkerBase):
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
             intermediate_prefill_mask=intermediate_prefill_mask,
+            request_state_snapshot_id=request_state_snapshot_id,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -382,7 +382,7 @@ class TTWorker(WorkerBase):
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
-        has_penalties, reset_batch, can_sample_device, needs_logprobs,
+        has_penalties, decode_layout_changed, can_sample_device, needs_logprobs,
         intermediate_prefill_mask, req_ids, req_id_to_index,
         request_state_snapshot_id)`, where `local_input` is this rank's TT model
         input (or `None`) and the remaining fields are the per-rank metadata

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -415,20 +415,26 @@ class TTWorker(WorkerBase):
             scheduler_output, grammar_output
         )
 
-    def commit_dp_slot_updates(self, device_sampling: bool) -> None:
+    def decode_input_update_contract_version(self) -> int:
+        """This rank's view of the adapter contract version, or -1 if unknown.
+
+        Only the device rank loads a model; the engine reduces these into one
+        globally agreed version.
+        """
+        version = self.model_runner.async_decode.decode_input_update_contract_version()
+        return -1 if version is None else version
+
+    def commit_dp_slot_updates(
+        self, device_sampling: bool, contract_version: int
+    ) -> None:
         """Commit a local remap consumed by the gathered decode submit.
 
-        Contract-v1 adapters consume layout remaps in both sampling modes.
-        Version-0 adapters retain their historical device-sampling-only call
-        shape, so a host-sampling step must leave their remap pending.
+        ``contract_version`` is the globally agreed value because a rank that
+        holds no model cannot read it. Contract-v1 adapters consume layout
+        remaps in both sampling modes; version-0 adapters retain their
+        historical device-sampling-only call shape, so a host-sampling step must
+        leave their remap pending.
         """
-        contract_version = int(
-            getattr(
-                self.model_runner.model,
-                "decode_input_update_contract",
-                0,
-            )
-        )
         if contract_version >= 1 or device_sampling:
             self.model_runner.input_batch.commit_slot_remap()
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -434,7 +434,7 @@ class TTWorker(WorkerBase):
         holds no model cannot read it. Contract-v1 adapters consume layout
         remaps in both sampling modes; version-0 adapters retain their
         historical device-sampling-only call shape, so a host-sampling step must
-        leave their remap pending.
+        leave their state-slot layout where it is.
 
         Retired at submission rather than completion: only the driver rank runs
         the merged forward, and a raised forward surfaces through the gather
@@ -445,7 +445,9 @@ class TTWorker(WorkerBase):
         if device_sampling or controller.slot_remap_delivered_on_host_sampling(
             contract_version
         ):
-            self.model_runner.input_batch.commit_slot_remap()
+            self.model_runner.note_decode_state_slots_settled()
+        else:
+            self.model_runner.discard_pending_state_slot_settle()
 
     def note_dp_decode_submitted(self, device_sampling: bool) -> None:
         """Mirror merged decode residency on this rank's overlap controller."""

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -377,15 +377,16 @@ class TTWorker(WorkerBase):
         torch.Tensor | None,
         list[str],
         dict[str, int],
+        set[str],
     ]:
         """Build the local DP payload consumed by gathered-DP orchestration.
 
         Returns `(local_input, max_blocks, has_structured_input,
         has_penalties, decode_layout_changed, can_sample_device, needs_logprobs,
-        intermediate_prefill_mask, req_ids, req_id_to_index)`, where
-        `local_input` is this rank's TT model input (or `None`) and the
-        remaining fields are the per-rank metadata consumed by gathered-DP
-        orchestration.
+        intermediate_prefill_mask, req_ids, req_id_to_index,
+        invalidated_req_ids)`, where `local_input` is this rank's TT model input
+        (or `None`) and the remaining fields are the per-rank metadata consumed
+        by gathered-DP orchestration.
         """
         return self.model_runner.prepare_dp_model_input(
             scheduler_output, grammar_output
@@ -427,15 +428,23 @@ class TTWorker(WorkerBase):
     def commit_dp_slot_updates(
         self, device_sampling: bool, contract_version: int
     ) -> None:
-        """Commit a local remap consumed by the gathered decode submit.
+        """Retire the layout signals the gathered decode submit carried.
 
         ``contract_version`` is the globally agreed value because a rank that
         holds no model cannot read it. Contract-v1 adapters consume layout
         remaps in both sampling modes; version-0 adapters retain their
         historical device-sampling-only call shape, so a host-sampling step must
         leave their remap pending.
+
+        Retired at submission rather than completion: only the driver rank runs
+        the merged forward, and a raised forward surfaces through the gather
+        future, which is fatal to the engine rather than retried.
         """
-        if contract_version >= 1 or device_sampling:
+        controller = self.model_runner.async_decode
+        self.model_runner.note_decode_layout_consumed()
+        if device_sampling or controller.slot_remap_delivered_on_host_sampling(
+            contract_version
+        ):
             self.model_runner.input_batch.commit_slot_remap()
 
     def note_dp_decode_submitted(self, device_sampling: bool) -> None:
@@ -510,11 +519,13 @@ class TTWorker(WorkerBase):
         req_ids: list[str] | None = None,
         req_id_to_index: dict[str, int] | None = None,
         intermediate_prefill_mask: torch.Tensor | None = None,
+        skip_req_ids: set[str] | None = None,
     ) -> ModelRunnerOutput:
         """Apply the local DP rank result through the worker facade.
 
         Applies the local DP rank result and returns the corresponding
-        `ModelRunnerOutput`.
+        `ModelRunnerOutput`. ``skip_req_ids`` travels with the submission whose
+        result this is, so it cannot filter a different step's rows.
         """
         return self.model_runner.apply_dp_execution_result(
             sampled_token_ids,
@@ -522,6 +533,7 @@ class TTWorker(WorkerBase):
             req_ids=req_ids,
             req_id_to_index=req_id_to_index,
             intermediate_prefill_mask=intermediate_prefill_mask,
+            skip_req_ids=skip_req_ids,
         )
 
     # ---- Destructor (used to close devices) ----

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -416,9 +416,22 @@ class TTWorker(WorkerBase):
             scheduler_output, grammar_output
         )
 
-    def commit_device_sampling_slot_updates(self) -> None:
-        """Commit the local remap after a gathered device-sampling submit."""
-        self.model_runner.input_batch.commit_slot_remap()
+    def commit_dp_slot_updates(self, device_sampling: bool) -> None:
+        """Commit a local remap consumed by the gathered decode submit.
+
+        Contract-v1 adapters consume layout remaps in both sampling modes.
+        Version-0 adapters retain their historical device-sampling-only call
+        shape, so a host-sampling step must leave their remap pending.
+        """
+        contract_version = int(
+            getattr(
+                self.model_runner.model,
+                "decode_input_update_contract",
+                0,
+            )
+        )
+        if contract_version >= 1 or device_sampling:
+            self.model_runner.input_batch.commit_slot_remap()
 
     def note_dp_decode_submitted(self, device_sampling: bool) -> None:
         """Mirror merged decode residency on this rank's overlap controller."""

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -719,3 +719,24 @@ def test_layout_change_causes_are_all_rejected_before_update_states():
     )
     assert controller.scheduler_preserves_decode_layout(resumed)
     assert not controller.steady_decode_scheduler_invariants_met(resumed, None)
+
+
+def test_dp_block_table_width_follows_allocation_not_host_tokens():
+    """A one-step-stale token count must not narrow the gathered page table.
+
+    At a block boundary the scheduler has already allocated the block the
+    device is about to write, while host ``num_tokens`` still lags by one.
+    Trimming to the token-derived width would drop that block, and the DP
+    concat zero-pads it back to block id 0.
+    """
+    block_size = 32
+    allocated_blocks = 2
+    stale_num_tokens = 32  # the applied token count lags the device by one
+
+    group = SimpleNamespace(
+        num_blocks_per_row=np.array([allocated_blocks, 0], dtype=np.int32)
+    )
+    batch = SimpleNamespace(block_table=SimpleNamespace(block_tables=[group]))
+
+    assert InputBatch.allocated_blocks_for_rows(batch, [0]) == allocated_blocks
+    assert stale_num_tokens // block_size < allocated_blocks

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -9,6 +9,7 @@ the plugin still requires the normal ttnn-enabled test environment.
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 import torch
 from vllm_tt_plugin.async_decode import (
     CompletedDecodeStep,
@@ -16,16 +17,77 @@ from vllm_tt_plugin.async_decode import (
     TTAsyncDecodeController,
 )
 from vllm_tt_plugin.input_batch import InputBatch
-from vllm_tt_plugin.model_input import TTSamplingParams
+from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
 from vllm_tt_plugin.worker import TTWorker
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.output import CachedRequestData
+from vllm.v1.sample.logits_processor import build_logitsprocs
+from vllm.v1.worker.gpu_input_batch import CachedRequestState
+
+_VOCAB = 64
+_BLOCK = 16
+_MAX_MODEL_LEN = 256
+
+
+def _new_request(req_id: str) -> CachedRequestState:
+    return CachedRequestState(
+        req_id=req_id,
+        prompt_token_ids=[1],
+        mm_features=None,
+        sampling_params=SamplingParams(temperature=0.0),
+        generator=None,
+        block_ids=([0],),
+        num_computed_tokens=1,
+        output_token_ids=[],
+    )
+
+
+def _input_batch_with_slot_remap(remap: list[int]) -> InputBatch:
+    """A real occupied ``InputBatch`` carrying a pending non-identity remap."""
+    max_num_reqs = len(remap)
+    logitsprocs = build_logitsprocs(
+        SimpleNamespace(
+            speculative_config=None,
+            scheduler_config=SimpleNamespace(max_num_seqs=max_num_reqs),
+        ),
+        torch.device("cpu"),
+        is_pin_memory=False,
+        is_pooling_model=False,
+        custom_logitsprocs=[],
+    )
+    batch = InputBatch(
+        max_num_reqs=max_num_reqs,
+        max_model_len=_MAX_MODEL_LEN,
+        max_num_batched_tokens=_MAX_MODEL_LEN * max_num_reqs,
+        vocab_size=_VOCAB,
+        block_sizes=[_BLOCK],
+        kernel_block_sizes=[_BLOCK],
+        logitsprocs=logitsprocs,
+    )
+    for row in range(max_num_reqs):
+        batch.add_request(_new_request(f"seed-{row}"), req_index=row)
+    # Set after placement: ``add_request`` resets each entry it fills.
+    batch._slot_remap = torch.tensor(remap, dtype=torch.int32)
+    return batch
+
+
+def _front_packed_batch_stub(current_req_ids, **extra):
+    """Batch stub that answers row questions with the real front-packed rule."""
+    batch = SimpleNamespace(
+        req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)},
+        **extra,
+    )
+    batch.scheduling_preserves_rows = lambda so: InputBatch.scheduling_preserves_rows(
+        batch, so
+    )
+    return batch
 
 
 def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
     runner = SimpleNamespace(
-        input_batch=SimpleNamespace(
-            req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
-        ),
+        input_batch=_front_packed_batch_stub(current_req_ids),
         model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
         trace_mode=trace_mode,
     )
@@ -162,6 +224,32 @@ def test_prefill_and_layout_change_break_the_decode_chain():
 
     assert after_prefill.reload_inputs and after_prefill.reset_sampling_state
     assert layout_change.reload_inputs and layout_change.reset_sampling_state
+
+
+def test_a_plan_cannot_express_a_state_reset_without_a_host_input_reload():
+    """Requirement 7 holds because the plan refuses to say otherwise.
+
+    An adapter aligns its seed counters from the host positions on a state
+    reset, so a reset without a restage would bind a seeded stream to positions
+    that lag the device. The pairing must not depend on how the planner's two
+    boolean expressions happen to line up.
+    """
+    with pytest.raises(AssertionError, match="reset_sampling_state requires"):
+        TTDecodeReloadPlan(
+            reload_inputs=False,
+            reload_page_table=False,
+            reload_sampling_params=True,
+            reset_sampling_state=True,
+        )
+
+    # The page-table-only copy is meaningless alongside a full reload.
+    with pytest.raises(AssertionError, match="reload_page_table"):
+        TTDecodeReloadPlan(
+            reload_inputs=True,
+            reload_page_table=True,
+            reload_sampling_params=False,
+            reset_sampling_state=False,
+        )
 
 
 def test_drained_decode_updates_next_host_token_and_position_before_transition():
@@ -580,19 +668,19 @@ def test_gathered_dp_overlap_requires_the_explicit_contract():
     v0 = SimpleNamespace(decode_input_update_contract=0)
     v1 = SimpleNamespace(decode_input_update_contract=1)
 
-    assert not _controller_for(4, legacy).gathered_dp_overlap_permitted()
-    assert not _controller_for(4, v0).gathered_dp_overlap_permitted()
-    assert _controller_for(4, v1).gathered_dp_overlap_permitted()
+    assert not _controller_for(4, legacy).resident_decode_overlap_permitted()
+    assert not _controller_for(4, v0).resident_decode_overlap_permitted()
+    assert _controller_for(4, v1).resident_decode_overlap_permitted()
 
     # Lane mode is single-process; its overlap path is unchanged by the gate.
-    assert _controller_for(1, legacy).gathered_dp_overlap_permitted()
+    assert _controller_for(1, legacy).resident_decode_overlap_permitted()
 
     # A rank that holds no model abstains instead of vetoing the global vote.
     abstaining = TTAsyncDecodeController(
         SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))
     )
     assert abstaining.decode_input_update_contract_version() is None
-    assert abstaining.gathered_dp_overlap_permitted()
+    assert abstaining.resident_decode_overlap_permitted()
 
 
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():
@@ -654,8 +742,8 @@ def _steady_eligible_runner(current_req_ids=("req-0",)):
         has_active_logitsprocs=lambda: False,
     )
     return SimpleNamespace(
-        input_batch=SimpleNamespace(
-            req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)},
+        input_batch=_front_packed_batch_stub(
+            current_req_ids,
             no_penalties=True,
             no_allowed_token_ids=True,
             max_num_logprobs=None,
@@ -672,13 +760,29 @@ def _steady_eligible_runner(current_req_ids=("req-0",)):
     )
 
 
+def _cached_reqs(req_ids, *, resumed=(), context_phase=()):
+    """A real ``CachedRequestData``, so ``is_context_phase`` cannot be faked.
+
+    ``context_phase`` names requests that have produced no output token yet,
+    i.e. chunked-prefill continuations.
+    """
+    req_ids = list(req_ids)
+    return CachedRequestData(
+        req_ids=req_ids,
+        resumed_req_ids=set(resumed),
+        new_token_ids=[[] for _ in req_ids],
+        all_token_ids={},
+        new_block_ids=[None for _ in req_ids],
+        num_computed_tokens=[1 for _ in req_ids],
+        num_output_tokens=[0 if r in set(context_phase) else 1 for r in req_ids],
+    )
+
+
 def _steady_scheduler_output(current_req_ids=("req-0",), **overrides):
     fields = {
         "num_scheduled_tokens": {req_id: 1 for req_id in current_req_ids},
         "scheduled_new_reqs": [],
-        "scheduled_cached_reqs": SimpleNamespace(
-            req_ids=list(current_req_ids), resumed_req_ids=set()
-        ),
+        "scheduled_cached_reqs": _cached_reqs(current_req_ids),
         "pending_structured_output_tokens": False,
     }
     fields.update(overrides)
@@ -702,9 +806,6 @@ def test_layout_change_causes_are_all_rejected_before_update_states():
 
     # Finished or unscheduled: present in the batch, absent from this step.
     removed = _steady_scheduler_output(("req-0",))
-    removed.scheduled_cached_reqs = SimpleNamespace(
-        req_ids=["req-0"], resumed_req_ids=set()
-    )
     assert not controller.steady_decode_scheduler_invariants_met(removed, None)
 
     # Added: scheduled this step, absent from the batch.
@@ -714,19 +815,36 @@ def test_layout_change_causes_are_all_rejected_before_update_states():
     # Resumed from preemption: membership is unchanged, so only the prefill
     # check rejects it. This leg is why the membership diff alone is not enough.
     resumed = _steady_scheduler_output(("req-0", "req-1"))
-    resumed.scheduled_cached_reqs = SimpleNamespace(
-        req_ids=["req-0", "req-1"], resumed_req_ids={"req-1"}
-    )
+    resumed.scheduled_cached_reqs = _cached_reqs(("req-0", "req-1"), resumed=("req-1",))
     assert controller.scheduler_preserves_decode_layout(resumed)
     assert not controller.steady_decode_scheduler_invariants_met(resumed, None)
 
     # Chunked-prefill continuation: a cached request, neither new nor resumed,
-    # so membership is unchanged and the new/resumed test alone accepts it. The
-    # multi-token schedule is what marks it as still prefilling.
+    # so membership is unchanged and the new/resumed test alone accepts it.
+    # Being in the context phase is what marks it as still prefilling.
     continuation = _steady_scheduler_output(("req-0", "req-1"))
     continuation.num_scheduled_tokens = {"req-0": 1, "req-1": 256}
+    continuation.scheduled_cached_reqs = _cached_reqs(
+        ("req-0", "req-1"), context_phase=("req-1",)
+    )
     assert controller.scheduler_preserves_decode_layout(continuation)
     assert not controller.steady_decode_scheduler_invariants_met(continuation, None)
+
+    # Same continuation with one prompt token left: indistinguishable from a
+    # decode row by scheduled-token count, so only the phase test rejects it.
+    final_chunk = _steady_scheduler_output(("req-0", "req-1"))
+    final_chunk.scheduled_cached_reqs = _cached_reqs(
+        ("req-0", "req-1"), context_phase=("req-1",)
+    )
+    assert final_chunk.num_scheduled_tokens == {"req-0": 1, "req-1": 1}
+    assert controller.scheduler_preserves_decode_layout(final_chunk)
+    assert not controller.steady_decode_scheduler_invariants_met(final_chunk, None)
+
+    # A decode row scheduled several tokens is not prefill work: speculative
+    # decode counts its proposals, and forgoing overlap there is a real cost.
+    speculated = _steady_scheduler_output(("req-0", "req-1"))
+    speculated.num_scheduled_tokens = {"req-0": 1, "req-1": 4}
+    assert controller.steady_decode_scheduler_invariants_met(speculated, None)
 
 
 def test_dp_block_table_width_follows_allocation_not_host_tokens():
@@ -735,19 +853,33 @@ def test_dp_block_table_width_follows_allocation_not_host_tokens():
     At a block boundary the scheduler has already allocated the block the
     device is about to write, while host ``num_tokens`` still lags by one.
     Trimming to the token-derived width would drop that block, and the DP
-    concat zero-pads it back to block id 0.
+    concat zero-pads it back to block id 0, i.e. into another request's page.
     """
     block_size = 32
     allocated_blocks = 2
     stale_num_tokens = 32  # the applied token count lags the device by one
+    target_width = 8
 
     group = SimpleNamespace(
         num_blocks_per_row=np.array([allocated_blocks, 0], dtype=np.int32)
     )
     batch = SimpleNamespace(block_table=SimpleNamespace(block_tables=[group]))
+    batch.allocated_blocks_for_rows = lambda rows: InputBatch.allocated_blocks_for_rows(
+        batch, rows
+    )
+    runner = SimpleNamespace(input_batch=batch)
 
-    assert InputBatch.allocated_blocks_for_rows(batch, [0]) == allocated_blocks
     assert stale_num_tokens // block_size < allocated_blocks
+
+    width = TTModelRunner._dp_block_table_width(runner, [0], target_width=target_width)
+    assert width == allocated_blocks
+
+    # The wire capacity still bounds an over-wide allocation.
+    group.num_blocks_per_row = np.array([target_width + 4, 0], dtype=np.int32)
+    assert (
+        TTModelRunner._dp_block_table_width(runner, [0], target_width=target_width)
+        == target_width
+    )
 
 
 def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
@@ -762,10 +894,6 @@ def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
         requests={"live": live, "resumed": resumed},
         input_batch=SimpleNamespace(req_id_to_index={}, num_reqs=2),
         model_config=SimpleNamespace(max_model_len=32),
-        _invalidated_req_ids={"resumed"},
-    )
-    runner._consume_invalidated_req_ids = lambda: (
-        TTModelRunner._consume_invalidated_req_ids(runner)
     )
     runner._apply_sampled_tokens_to_state = lambda **kwargs: (
         TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
@@ -784,20 +912,79 @@ def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
         None,
         req_ids=["live", "resumed"],
         req_id_to_index={"live": 0, "resumed": 1},
+        skip_req_ids={"resumed"},
     )
 
     assert live.output_token_ids == [5]
     assert resumed.output_token_ids == []
     assert output.sampled_token_ids == [[5], []]
+
+
+def test_dp_result_application_does_not_read_runner_invalidations():
+    """The set arrives with the submission, never from live runner state.
+
+    Reading it here would let a rejection noted for one submission filter a
+    different step's rows.
+    """
+    live = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"live": live},
+        input_batch=SimpleNamespace(req_id_to_index={}, num_reqs=1),
+        model_config=SimpleNamespace(max_model_len=32),
+        _invalidated_req_ids={"live"},
+    )
+    runner._consume_invalidated_req_ids = lambda: pytest.fail(
+        "apply_dp_execution_result must not consume runner-owned invalidations"
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    runner._build_runner_output = lambda **kwargs: SimpleNamespace(
+        req_id_to_index=dict(kwargs["req_id_to_index"]),
+        sampled_token_ids=[[5]],
+    )
+    runner.apply_and_build_runner_output = lambda *args, **kwargs: (
+        TTModelRunner.apply_and_build_runner_output(runner, *args, **kwargs)
+    )
+
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        torch.tensor([[5]], dtype=torch.int32),
+        None,
+        req_ids=["live"],
+        req_id_to_index={"live": 0},
+    )
+
+    assert live.output_token_ids == [5]
+    assert output.sampled_token_ids == [[5]]
+
+
+def test_dp_payload_drains_invalidations_even_on_an_idle_rank():
+    """A rank that scheduled nothing still hands its noted ids to the engine.
+
+    Left on the runner they would filter rows of a step that has no relation to
+    the scheduler output that produced them.
+    """
+    runner = SimpleNamespace(
+        _invalidated_req_ids={"finished"},
+        input_batch=SimpleNamespace(num_reqs=0, req_ids=[], req_id_to_index={}),
+    )
+    runner._consume_invalidated_req_ids = lambda: (
+        TTModelRunner._consume_invalidated_req_ids(runner)
+    )
+
+    payload = TTModelRunner.prepare_dp_model_input(runner, None, None)
+
+    assert payload[0] is None  # no local model input
+    assert payload[-1] == {"finished"}
     assert runner._invalidated_req_ids == set()
 
 
-def test_intermediate_chunk_step_still_consumes_and_honours_rejections():
+def test_intermediate_chunk_step_still_honours_rejections():
     """A chunked-prefill step returns early, but rejection still applies.
 
-    The invalidated set has to be consumed here too: carried into a later step
-    it would reject a token that step legitimately produced. The final-chunk row
-    of an invalidated request must also stay empty.
+    The final-chunk row of an invalidated request must stay empty on this path
+    too, not only on the plain decode path.
     """
     live = SimpleNamespace(output_token_ids=[])
     resumed = SimpleNamespace(output_token_ids=[])
@@ -805,10 +992,6 @@ def test_intermediate_chunk_step_still_consumes_and_honours_rejections():
         requests={"live": live, "resumed": resumed},
         input_batch=SimpleNamespace(req_id_to_index={}, num_reqs=3),
         model_config=SimpleNamespace(max_model_len=32),
-        _invalidated_req_ids={"resumed"},
-    )
-    runner._consume_invalidated_req_ids = lambda: (
-        TTModelRunner._consume_invalidated_req_ids(runner)
     )
     runner._apply_sampled_tokens_to_state = lambda *args, **kwargs: (
         TTModelRunner._apply_sampled_tokens_to_state(runner, *args, **kwargs)
@@ -826,24 +1009,24 @@ def test_intermediate_chunk_step_still_consumes_and_honours_rejections():
         req_ids=["live", "resumed", "chunking"],
         req_id_to_index={"live": 0, "resumed": 1, "chunking": 2},
         intermediate_prefill_mask=torch.tensor([False, False, True]),
+        skip_req_ids={"resumed"},
     )
 
     assert live.output_token_ids == [5]
     assert resumed.output_token_ids == []
     assert output.sampled_token_ids == [[5], [], []]
-    assert runner._invalidated_req_ids == set()
 
 
 def test_slot_reuse_clears_a_stale_pending_remap_entry():
     """Prefill steps neither deliver nor commit a remap, so entries persist.
 
     Two condense-then-reuse rounds without an intervening decode would
-    otherwise hand a brand-new request another slot's source index.
+    otherwise hand a brand-new request another slot's source index. Placing a
+    request has to clear its own entry, and only its own.
     """
-    batch = InputBatch.__new__(InputBatch)
-    batch.max_num_reqs = 4
-    batch._slot_remap = torch.tensor([0, 2, 2, 3], dtype=torch.int32)
+    batch = _input_batch_with_slot_remap([3, 2, 2, 0])
 
-    InputBatch._reset_slot_remap_entry(batch, 1)
+    batch.add_request(_new_request("fresh"), req_index=1)
 
-    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+    # Only the reused slot is reset; the rest of the pending remap survives.
+    assert batch._slot_remap.tolist() == [3, 1, 2, 0]

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -21,7 +21,10 @@ def _controller(current_req_ids=("req-0",)):
     runner = SimpleNamespace(
         input_batch=SimpleNamespace(
             req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
-        )
+        ),
+        model=SimpleNamespace(
+            model_capabilities={"supports_async_decode": True}
+        ),
     )
     return TTAsyncDecodeController(runner)
 
@@ -65,6 +68,20 @@ def test_steady_device_decode_reuses_resident_inputs():
     assert not plan.reset_sampling_state
     assert plan.overlap_safe
     assert controller._submitted_page_tables is submitted_page_tables
+
+
+def test_model_without_async_decode_support_reloads_inputs_every_step():
+    controller = _controller()
+    controller.runner.model.model_capabilities["supports_async_decode"] = False
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert not plan.overlap_safe
 
 
 def test_page_table_only_refresh_is_overlap_safe():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -227,81 +227,19 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
-def test_empty_batch_discards_remap_from_previous_request_lifetimes():
+def test_empty_batch_does_not_consume_pending_slot_remap():
     batch = SimpleNamespace(
         num_reqs=0,
-        max_num_reqs=4,
         _req_ids=[None],
         req_output_token_ids=[None],
         _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
     )
-    batch.reset_slot_remap = lambda: InputBatch.reset_slot_remap(batch)
 
     InputBatch.condense(batch, [0])
 
     assert batch._req_ids == []
     assert batch.req_output_token_ids == []
-    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
-
-
-def test_remove_all_discards_pending_remap_before_same_step_refill(monkeypatch):
-    class FakeBatch:
-        max_num_reqs = 4
-
-        def __init__(self):
-            self.req_id_to_index = {"old": 0}
-            self._slot_remap = torch.tensor([3, 1, 2, 3], dtype=torch.int32)
-            self.remap_seen_at_add = None
-
-        @property
-        def num_reqs(self):
-            return len(self.req_id_to_index)
-
-        def remove_request(self, req_id):
-            return self.req_id_to_index.pop(req_id, None)
-
-        def reset_slot_remap(self):
-            InputBatch.reset_slot_remap(self)
-
-        def add_request(self, req_state, req_index):
-            self.remap_seen_at_add = self._slot_remap.clone()
-            self.req_id_to_index[req_state.req_id] = req_index
-
-        def condense(self, empty_req_indices):
-            raise AssertionError("same-step refill should consume every freed slot")
-
-        def refresh_logitsprocs(self):
-            pass
-
-    batch = FakeBatch()
-    runner = SimpleNamespace(
-        requests={"old": object()},
-        input_batch=batch,
-        encoder_cache={},
-        _decode_layout_changed_since_last_decode=False,
-    )
-    scheduler_output = SimpleNamespace(
-        finished_req_ids={"old"},
-        free_encoder_mm_hashes=[],
-        num_scheduled_tokens={"new": 1},
-        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
-        scheduled_cached_reqs=SimpleNamespace(
-            req_ids=[],
-            num_computed_tokens=[],
-            new_block_ids=[],
-            resumed_req_ids=set(),
-        ),
-    )
-    monkeypatch.setattr(
-        "vllm_tt_plugin.model_runner.build_cached_request_state",
-        lambda new_req: SimpleNamespace(req_id=new_req.req_id),
-    )
-
-    TTModelRunner._update_states(runner, scheduler_output)
-
-    assert batch.req_id_to_index == {"new": 0}
-    assert batch.remap_seen_at_add.tolist() == [0, 1, 2, 3]
-    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+    assert batch._slot_remap.tolist() == [3, 1, 2, 3]
 
 
 def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -21,56 +21,7 @@ from vllm_tt_plugin.model_input import TTDecodeReloadPlan, TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
 from vllm_tt_plugin.worker import TTWorker
 
-from vllm.sampling_params import SamplingParams
 from vllm.v1.core.sched.output import CachedRequestData
-from vllm.v1.sample.logits_processor import build_logitsprocs
-from vllm.v1.worker.gpu_input_batch import CachedRequestState
-
-_VOCAB = 64
-_BLOCK = 16
-_MAX_MODEL_LEN = 256
-
-
-def _new_request(req_id: str) -> CachedRequestState:
-    return CachedRequestState(
-        req_id=req_id,
-        prompt_token_ids=[1],
-        mm_features=None,
-        sampling_params=SamplingParams(temperature=0.0),
-        generator=None,
-        block_ids=([0],),
-        num_computed_tokens=1,
-        output_token_ids=[],
-    )
-
-
-def _input_batch_with_slot_remap(remap: list[int]) -> InputBatch:
-    """A real occupied ``InputBatch`` carrying a pending non-identity remap."""
-    max_num_reqs = len(remap)
-    logitsprocs = build_logitsprocs(
-        SimpleNamespace(
-            speculative_config=None,
-            scheduler_config=SimpleNamespace(max_num_seqs=max_num_reqs),
-        ),
-        torch.device("cpu"),
-        is_pin_memory=False,
-        is_pooling_model=False,
-        custom_logitsprocs=[],
-    )
-    batch = InputBatch(
-        max_num_reqs=max_num_reqs,
-        max_model_len=_MAX_MODEL_LEN,
-        max_num_batched_tokens=_MAX_MODEL_LEN * max_num_reqs,
-        vocab_size=_VOCAB,
-        block_sizes=[_BLOCK],
-        kernel_block_sizes=[_BLOCK],
-        logitsprocs=logitsprocs,
-    )
-    for row in range(max_num_reqs):
-        batch.add_request(_new_request(f"seed-{row}"), req_index=row)
-    # Set after placement: ``add_request`` resets each entry it fills.
-    batch._slot_remap = torch.tensor(remap, dtype=torch.int32)
-    return batch
 
 
 def _front_packed_batch_stub(current_req_ids, **extra):
@@ -330,25 +281,43 @@ def test_empty_batch_does_not_consume_pending_slot_remap():
     assert batch._slot_remap.tolist() == [3, 1, 2, 3]
 
 
-def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():
-    commits = []
-    worker = SimpleNamespace(
-        model_runner=SimpleNamespace(
-            input_batch=SimpleNamespace(
-                commit_slot_remap=lambda: commits.append("v1-host")
-            ),
-        )
+def _dp_commit_worker(events):
+    controller = TTAsyncDecodeController(
+        SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))
+    )
+    runner = SimpleNamespace(
+        async_decode=controller,
+        note_decode_layout_consumed=lambda: events.append("layout"),
+        note_decode_state_slots_settled=lambda: events.append("settled"),
+        discard_pending_state_slot_settle=lambda: events.append("discarded"),
+    )
+    return SimpleNamespace(model_runner=runner)
+
+
+@pytest.mark.parametrize(
+    "device_sampling, contract_version, expected",
+    [
+        # v1 delivers the remap in both sampling modes, so the gather ran.
+        (False, 1, "settled"),
+        (True, 1, "settled"),
+        # v0 keeps its device-sampling-only call shape: on a host-sampling step the
+        # adapter never received the remap, so its state did not move.
+        (True, 0, "settled"),
+        (False, 0, "discarded"),
+    ],
+)
+def test_dp_state_slot_commit_respects_contract_and_sampling_mode(
+    device_sampling, contract_version, expected
+):
+    events = []
+
+    TTWorker.commit_dp_slot_updates(
+        _dp_commit_worker(events),
+        device_sampling=device_sampling,
+        contract_version=contract_version,
     )
 
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=False, contract_version=1)
-
-    worker.model_runner.input_batch.commit_slot_remap = lambda: commits.append(
-        "v0-device"
-    )
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=False, contract_version=0)
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=True, contract_version=0)
-
-    assert commits == ["v1-host", "v0-device"]
+    assert events == ["layout", expected]
 
 
 def test_contract_version_probe_tolerates_a_rank_without_a_model():
@@ -382,7 +351,9 @@ def test_explicit_contract_keeps_layout_hint_inside_planner():
         kv_caches=object(),
         request_specific_rope=False,
         parallel_config=SimpleNamespace(data_parallel_size=1),
-        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: None,
+        discard_pending_state_slot_settle=lambda: None,
     )
     controller = TTAsyncDecodeController(runner)
     model_input = SimpleNamespace(
@@ -437,7 +408,9 @@ def test_explicit_contract_delivers_and_commits_slot_remap_for_host_sampling():
         kv_caches=object(),
         request_specific_rope=False,
         parallel_config=SimpleNamespace(data_parallel_size=1),
-        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: commits.append(True),
+        discard_pending_state_slot_settle=lambda: None,
     )
     controller = TTAsyncDecodeController(runner)
 
@@ -470,9 +443,11 @@ def test_layout_change_refreshes_request_rope_even_when_request_id_is_reused():
         previous_req_ids={"req-0"},
         requests={"req-0": SimpleNamespace(mrope_position_delta=17)},
         parallel_config=SimpleNamespace(data_parallel_size=1),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: None,
+        discard_pending_state_slot_settle=lambda: None,
         input_batch=SimpleNamespace(
             req_ids=["req-0"],
-            commit_slot_remap=lambda: None,
         ),
     )
     controller = TTAsyncDecodeController(runner)
@@ -502,7 +477,9 @@ def test_slot_remap_is_not_committed_when_decode_submission_fails():
         kv_caches=object(),
         request_specific_rope=False,
         parallel_config=SimpleNamespace(data_parallel_size=1),
-        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: commits.append(True),
+        discard_pending_state_slot_settle=lambda: None,
     )
     controller = TTAsyncDecodeController(runner)
 
@@ -543,7 +520,9 @@ def test_legacy_host_sampling_keeps_slot_remap_pending_for_device_sampling(
         kv_caches=object(),
         request_specific_rope=False,
         parallel_config=SimpleNamespace(data_parallel_size=1),
-        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: commits.append(True),
+        discard_pending_state_slot_settle=lambda: None,
     )
     controller = TTAsyncDecodeController(runner)
     model_input = _submission_input(device_sampling=False)
@@ -588,7 +567,9 @@ def test_legacy_contract_receives_reset_batch_without_explicit_commands(
         kv_caches=object(),
         request_specific_rope=False,
         parallel_config=SimpleNamespace(data_parallel_size=1),
-        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+        note_decode_layout_consumed=lambda: None,
+        note_decode_state_slots_settled=lambda: None,
+        discard_pending_state_slot_settle=lambda: None,
     )
     controller = TTAsyncDecodeController(runner)
     model_input = SimpleNamespace(
@@ -1017,16 +998,61 @@ def test_intermediate_chunk_step_still_honours_rejections():
     assert output.sampled_token_ids == [[5], [], []]
 
 
-def test_slot_reuse_clears_a_stale_pending_remap_entry():
-    """Prefill steps neither deliver nor commit a remap, so entries persist.
+def _state_slot_runner(req_state_slot, slots=4):
+    runner = SimpleNamespace(
+        tt_per_lane_max_num_seqs=slots,
+        _req_state_slot=dict(req_state_slot),
+        _pending_state_slot_settle=None,
+    )
+    for name in (
+        "_decode_state_slot_remap",
+        "note_decode_state_slots_settled",
+        "discard_pending_state_slot_settle",
+    ):
+        setattr(
+            runner,
+            name,
+            lambda *a, _n=name, **k: getattr(TTModelRunner, _n)(runner, *a, **k),
+        )
+    return runner
 
-    Two condense-then-reuse rounds without an intervening decode would
-    otherwise hand a brand-new request another slot's source index. Placing a
-    request has to clear its own entry, and only its own.
+
+def test_state_slot_ownership_advances_only_on_an_accepted_submission():
+    """A raised decode never gathers, so the ownership map must not move.
+
+    The map says which slot holds each request's state. Advancing it to the
+    post-gather layout at input-build time would have every later step derive its
+    permutation from a layout the device never reached.
     """
-    batch = _input_batch_with_slot_remap([3, 2, 2, 0])
+    # "a" decodes at row 0 but its state still sits in slot 1.
+    runner = _state_slot_runner({"a": 1, "b": 0})
 
-    batch.add_request(_new_request("fresh"), req_index=1)
+    remap = runner._decode_state_slot_remap(["a", "b"])
 
-    # Only the reused slot is reset; the rest of the pending remap survives.
-    assert batch._slot_remap.tolist() == [3, 1, 2, 0]
+    assert remap is not None and remap.tolist()[:2] == [1, 0]
+    # Still pre-gather until something accepts the submission.
+    assert runner._req_state_slot == {"a": 1, "b": 0}
+
+    runner.discard_pending_state_slot_settle()
+    assert runner._req_state_slot == {"a": 1, "b": 0}
+
+    # Rebuild and accept: now the state is where the rows are.
+    runner._decode_state_slot_remap(["a", "b"])
+    runner.note_decode_state_slots_settled()
+    assert runner._req_state_slot == {"a": 0, "b": 1}
+
+
+def test_a_step_that_moves_nothing_leaves_the_ownership_map_alone():
+    """Identity and non-permutation both skip the gather, so neither may settle."""
+    runner = _state_slot_runner({"a": 0, "b": 1})
+
+    assert runner._decode_state_slot_remap(["a", "b"]) is None
+    assert runner._pending_state_slot_settle is None
+
+    # Two requests claiming one slot is not a permutation: the remap is withheld,
+    # so the map must not record a move either.
+    collided = _state_slot_runner({"a": 1, "b": 1})
+    assert collided._decode_state_slot_remap(["a", "b"]) is None
+    assert collided._pending_state_slot_settle is None
+    collided.note_decode_state_slots_settled()
+    assert collided._req_state_slot == {"a": 1, "b": 1}

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -246,23 +246,35 @@ def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():
     commits = []
     worker = SimpleNamespace(
         model_runner=SimpleNamespace(
-            model=SimpleNamespace(decode_input_update_contract=1),
             input_batch=SimpleNamespace(
                 commit_slot_remap=lambda: commits.append("v1-host")
             ),
         )
     )
 
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False, contract_version=1)
 
-    worker.model_runner.model = SimpleNamespace()
     worker.model_runner.input_batch.commit_slot_remap = lambda: commits.append(
         "v0-device"
     )
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
-    TTWorker.commit_dp_slot_updates(worker, device_sampling=True)
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False, contract_version=0)
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=True, contract_version=0)
 
     assert commits == ["v1-host", "v0-device"]
+
+
+def test_contract_version_probe_tolerates_a_rank_without_a_model():
+    """Non-device DP ranks never load a model, so they cannot read the version."""
+    controller = TTAsyncDecodeController(
+        SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))
+    )
+    worker = SimpleNamespace(model_runner=SimpleNamespace(async_decode=controller))
+
+    assert TTWorker.decode_input_update_contract_version(worker) == -1
+
+    controller.runner.model = SimpleNamespace(decode_input_update_contract=1)
+
+    assert TTWorker.decode_input_update_contract_version(worker) == 1
 
 
 def test_explicit_contract_keeps_layout_hint_inside_planner():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Host-only tests for the explicit TT decode reload contract.
+
+These tests exercise only controller state and plain torch tensors. Importing
+the plugin still requires the normal ttnn-enabled test environment.
+"""
+
+from types import SimpleNamespace
+
+import torch
+from vllm_tt_plugin.async_decode import (
+    CompletedDecodeStep,
+    SubmittedStepContext,
+    TTAsyncDecodeController,
+)
+from vllm_tt_plugin.model_runner import TTModelRunner
+
+
+def _controller(current_req_ids=("req-0",)):
+    runner = SimpleNamespace(
+        input_batch=SimpleNamespace(
+            req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
+        )
+    )
+    return TTAsyncDecodeController(runner)
+
+
+def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
+    return SimpleNamespace(
+        perform_device_sampling=device_sampling,
+        reset_batch=reset_batch,
+        block_tables_per_group=[
+            torch.tensor([[page, 0]], dtype=torch.int32)
+        ],
+    )
+
+
+def _submit(controller, model_input):
+    plan = controller.plan_decode_reload(model_input)
+    controller.commit_decode_submission(model_input, plan)
+    return plan
+
+
+def test_first_device_decode_fully_initializes_forward_and_sampling_state():
+    plan = _submit(_controller(), _decode_input())
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert plan.reload_sampling_params
+    assert plan.reset_sampling_state
+    assert not plan.overlap_safe
+
+
+def test_steady_device_decode_reuses_resident_inputs():
+    controller = _controller()
+    _submit(controller, _decode_input(page=1))
+    submitted_page_tables = controller._submitted_page_tables
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert not plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert plan.overlap_safe
+    assert controller._submitted_page_tables is submitted_page_tables
+
+
+def test_page_table_only_refresh_is_overlap_safe():
+    controller = _controller()
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=2))
+
+    assert not plan.reload_inputs
+    assert plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert plan.overlap_safe
+
+
+def test_host_sampling_reloads_every_step_and_device_switch_reinitializes():
+    controller = _controller()
+    first_host = _submit(controller, _decode_input(device_sampling=False))
+    second_host = _submit(controller, _decode_input(device_sampling=False))
+    device = _submit(controller, _decode_input(device_sampling=True))
+
+    assert first_host.reload_inputs
+    assert second_host.reload_inputs
+    assert not second_host.reload_sampling_params
+    assert device.reload_inputs
+    assert device.reload_sampling_params
+    assert device.reset_sampling_state
+
+
+def test_prefill_and_layout_change_break_the_decode_chain():
+    controller = _controller()
+    _submit(controller, _decode_input())
+    controller.note_prefill_submitted()
+
+    after_prefill = _submit(controller, _decode_input())
+    layout_change = _submit(controller, _decode_input(reset_batch=True))
+
+    assert after_prefill.reload_inputs and after_prefill.reset_sampling_state
+    assert layout_change.reload_inputs and layout_change.reset_sampling_state
+
+
+def test_scheduler_layout_prediction_detects_add_remove_and_preemption():
+    controller = _controller(("req-0", "req-1"))
+
+    same = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1})
+    removed = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
+    added = SimpleNamespace(
+        num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1}
+    )
+
+    assert controller.scheduler_preserves_decode_layout(same)
+    assert not controller.scheduler_preserves_decode_layout(removed)
+    assert not controller.scheduler_preserves_decode_layout(added)
+
+
+def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
+    captured = []
+    controller = _controller()
+    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
+        kwargs
+    )
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(object(),),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+    )
+
+    controller.apply_completed_decode_step(
+        completed, skip_req_ids={"req-0"}
+    )
+
+    assert captured[0]["skip_req_ids"] == {"req-0"}
+
+
+def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    captured = []
+    runner_output = SimpleNamespace(
+        sampled_token_ids=[[7]],
+        req_id_to_index={"req-0": 0},
+    )
+    controller = _controller()
+    controller.runner.requests = {"req-0": new_req_state}
+    controller.runner._apply_sampled_tokens_to_state = (
+        lambda **kwargs: captured.append(kwargs)
+    )
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(old_req_state,),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+        runner_output=runner_output,
+    )
+
+    controller.apply_completed_decode_step(completed)
+
+    assert runner_output.sampled_token_ids == [[]]
+    assert captured[0]["skip_req_ids"] == {"req-0"}
+
+
+def test_unscheduled_live_request_keeps_completed_token_in_cached_state():
+    req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": req_state},
+        input_batch=SimpleNamespace(req_id_to_index={}),
+        model_config=SimpleNamespace(max_model_len=32),
+    )
+
+    TTModelRunner._apply_sampled_tokens_to_state(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        request_states=(req_state,),
+        skip_req_ids=set(),
+    )
+
+    assert req_state.output_token_ids == [7]
+
+
+def test_reused_request_id_rejects_captured_dp_request_identity():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": new_req_state},
+        input_batch=SimpleNamespace(req_id_to_index={"req-0": 0}),
+        model_config=SimpleNamespace(max_model_len=32),
+    )
+
+    TTModelRunner._apply_sampled_tokens_to_state(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        request_states=(old_req_state,),
+    )
+
+    assert old_req_state.output_token_ids == []
+    assert new_req_state.output_token_ids == []
+
+
+def test_reused_request_id_suppresses_old_dp_scheduler_output():
+    old_req_state = SimpleNamespace(output_token_ids=[])
+    new_req_state = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"req-0": new_req_state},
+        input_batch=SimpleNamespace(num_reqs=1),
+        _dp_request_state_snapshots={4: (old_req_state,)},
+        apply_and_build_runner_output=lambda *args, **kwargs: SimpleNamespace(
+            sampled_token_ids=[[7]],
+            req_id_to_index={"req-0": 0},
+        ),
+    )
+
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        req_ids=["req-0"],
+        req_id_to_index={"req-0": 0},
+        request_state_snapshot_id=4,
+    )
+
+    assert output.sampled_token_ids == [[]]
+    assert runner._dp_request_state_snapshots == {}

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -199,10 +199,11 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
-def test_submit_decode_keeps_layout_hint_inside_planner():
+def test_explicit_contract_keeps_layout_hint_inside_planner():
     captured = {}
 
     class FakeModel:
+        decode_input_update_contract = 1
         model_capabilities = {"supports_async_decode": True}
 
         def decode_forward(self, **kwargs):
@@ -245,10 +246,101 @@ def test_submit_decode_keeps_layout_hint_inside_planner():
 
     controller.submit_decode(model_input, read_from_device=False, async_read=False)
 
+    assert "reset_batch" not in captured
     assert "decode_layout_changed" not in captured
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True
+
+
+def test_legacy_contract_receives_reset_batch_without_explicit_commands(
+    monkeypatch,
+):
+    captured = {}
+    warnings = []
+    monkeypatch.setattr(
+        "vllm_tt_plugin.async_decode.logger.warning",
+        lambda *args: warnings.append(args),
+    )
+
+    class FakeLegacyModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeLegacyModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = SimpleNamespace(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.tensor([1.0]),
+            top_k=torch.tensor([32]),
+            top_p=torch.tensor([1.0]),
+            presence_penalty=torch.tensor([0.0]),
+            frequency_penalty=torch.tensor([0.0]),
+            repetition_penalty=torch.tensor([1.0]),
+            seed=torch.tensor([-1]),
+            num_logprobs=torch.tensor([-2]),
+            enable_log_probs=torch.tensor([False]),
+        ),
+        perform_device_sampling=True,
+        prompt_tokens=None,
+        output_tokens=None,
+        decode_layout_changed=True,
+        slot_remap=torch.tensor([0], dtype=torch.int32),
+    )
+
+    first_submission = controller.submit_decode(
+        model_input, read_from_device=False, async_read=False
+    )
+    second_submission = controller.submit_decode(
+        model_input, read_from_device=False, async_read=False
+    )
+
+    assert captured["reset_batch"] is True
+    assert "decode_layout_changed" not in captured
+    assert "reload_inputs" not in captured
+    assert "reload_page_table" not in captured
+    assert "reload_sampling_params" not in captured
+    assert "reset_sampling_state" not in captured
+    assert first_submission.reload_plan is None
+    assert second_submission.reload_plan is None
+    assert controller._decode_chain_valid
+    assert controller._previous_device_sampling is True
+    assert len(warnings) == 1
+
+
+def test_contract_version_does_not_change_steady_decode_eligibility():
+    runner = SimpleNamespace(
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        non_dp_async_scheduling=True,
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_rank_local=0,
+        ),
+        trace_mode="decode_only",
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    assert controller.steady_decode_base_enabled(dp_gather=False)
+
+    runner.model.decode_input_update_contract = 1
+
+    assert controller.steady_decode_base_enabled(dp_gather=False)
 
 
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -8,23 +8,24 @@ the plugin still requires the normal ttnn-enabled test environment.
 
 from types import SimpleNamespace
 
+import numpy as np
 import torch
 from vllm_tt_plugin.async_decode import (
     CompletedDecodeStep,
     SubmittedStepContext,
     TTAsyncDecodeController,
 )
+from vllm_tt_plugin.model_input import TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
 
 
-def _controller(current_req_ids=("req-0",)):
+def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
     runner = SimpleNamespace(
         input_batch=SimpleNamespace(
             req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)}
         ),
-        model=SimpleNamespace(
-            model_capabilities={"supports_async_decode": True}
-        ),
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        trace_mode=trace_mode,
     )
     return TTAsyncDecodeController(runner)
 
@@ -33,9 +34,7 @@ def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
     return SimpleNamespace(
         perform_device_sampling=device_sampling,
         reset_batch=reset_batch,
-        block_tables_per_group=[
-            torch.tensor([[page, 0]], dtype=torch.int32)
-        ],
+        block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
     )
 
 
@@ -73,6 +72,19 @@ def test_steady_device_decode_reuses_resident_inputs():
 def test_model_without_async_decode_support_reloads_inputs_every_step():
     controller = _controller()
     controller.runner.model.model_capabilities["supports_async_decode"] = False
+    _submit(controller, _decode_input(page=1))
+
+    plan = _submit(controller, _decode_input(page=1))
+
+    assert plan.reload_inputs
+    assert not plan.reload_page_table
+    assert not plan.reload_sampling_params
+    assert not plan.reset_sampling_state
+    assert not plan.overlap_safe
+
+
+def test_decode_without_trace_reloads_inputs_every_step():
+    controller = _controller(trace_mode="none")
     _submit(controller, _decode_input(page=1))
 
     plan = _submit(controller, _decode_input(page=1))
@@ -123,14 +135,128 @@ def test_prefill_and_layout_change_break_the_decode_chain():
     assert layout_change.reload_inputs and layout_change.reset_sampling_state
 
 
+def test_drained_decode_updates_next_host_token_and_position_before_transition():
+    req_state = SimpleNamespace(output_token_ids=[])
+    input_batch = SimpleNamespace(
+        req_id_to_index={"req-0": 0},
+        num_tokens=np.array([3], dtype=np.int32),
+        token_ids_cpu=np.zeros((1, 8), dtype=np.int32),
+    )
+    runner = SimpleNamespace(
+        requests={"req-0": req_state},
+        input_batch=input_batch,
+        model_config=SimpleNamespace(max_model_len=8),
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        trace_mode="decode_only",
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    controller = TTAsyncDecodeController(runner)
+    controller.note_dp_decode_submitted(True)
+    completed = CompletedDecodeStep(
+        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
+        logprobs=None,
+        context=SubmittedStepContext(
+            req_ids=["req-0"],
+            req_id_to_index={"req-0": 0},
+            request_states=(req_state,),
+            submit_time_ns=1,
+        ),
+        completion_time_ns=2,
+    )
+
+    controller.apply_completed_decode_step(completed)
+    controller.note_prefill_submitted()
+    plan = controller.plan_decode_reload(_decode_input())
+
+    next_position = int(input_batch.num_tokens[0]) - 1
+    assert input_batch.token_ids_cpu[0, next_position] == 7
+    assert next_position == 3
+    assert req_state.output_token_ids == [7]
+    assert plan.reload_inputs
+    assert plan.reset_sampling_state
+
+
+def test_dp_submission_mirrors_resident_mode_and_prefill_invalidates_it():
+    controller = _controller()
+
+    controller.note_dp_decode_submitted(True)
+
+    assert controller._decode_chain_valid
+    assert controller._previous_device_sampling is True
+
+    controller.note_prefill_submitted()
+
+    assert not controller._decode_chain_valid
+
+
+def test_dp_slot_remap_is_offset_into_global_slot_namespace():
+    rank_local = torch.tensor([[3, 1, 2, 0], [2, 0, 3, 1]], dtype=torch.int32)
+
+    global_remap = TTModelRunner._globalize_dp_slot_remap(rank_local)
+
+    assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
+
+
+def test_submit_decode_keeps_layout_hint_inside_planner():
+    captured = {}
+
+    class FakeModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: None),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = SimpleNamespace(
+        input_tokens=torch.zeros((1, 1), dtype=torch.int32),
+        input_positions=torch.zeros((1,), dtype=torch.int32),
+        block_tables=torch.zeros((1, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((1, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=1,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.tensor([1.0]),
+            top_k=torch.tensor([32]),
+            top_p=torch.tensor([1.0]),
+            presence_penalty=torch.tensor([0.0]),
+            frequency_penalty=torch.tensor([0.0]),
+            repetition_penalty=torch.tensor([1.0]),
+            seed=torch.tensor([-1]),
+            num_logprobs=torch.tensor([-2]),
+            enable_log_probs=torch.tensor([False]),
+        ),
+        perform_device_sampling=True,
+        prompt_tokens=None,
+        output_tokens=None,
+        reset_batch=True,
+        slot_remap=torch.tensor([0], dtype=torch.int32),
+    )
+
+    controller.submit_decode(model_input, read_from_device=False, async_read=False)
+
+    assert "reset_batch" not in captured
+    assert captured["reload_inputs"] is True
+    assert captured["reload_sampling_params"] is True
+    assert captured["reset_sampling_state"] is True
+
+
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():
     controller = _controller(("req-0", "req-1"))
 
     same = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1})
     removed = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
-    added = SimpleNamespace(
-        num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1}
-    )
+    added = SimpleNamespace(num_scheduled_tokens={"req-0": 1, "req-1": 1, "req-2": 1})
 
     assert controller.scheduler_preserves_decode_layout(same)
     assert not controller.scheduler_preserves_decode_layout(removed)
@@ -155,9 +281,7 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
         completion_time_ns=2,
     )
 
-    controller.apply_completed_decode_step(
-        completed, skip_req_ids={"req-0"}
-    )
+    controller.apply_completed_decode_step(completed, skip_req_ids={"req-0"})
 
     assert captured[0]["skip_req_ids"] == {"req-0"}
 
@@ -172,8 +296,8 @@ def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
     )
     controller = _controller()
     controller.runner.requests = {"req-0": new_req_state}
-    controller.runner._apply_sampled_tokens_to_state = (
-        lambda **kwargs: captured.append(kwargs)
+    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
+        kwargs
     )
     completed = CompletedDecodeStep(
         sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -605,3 +605,77 @@ def test_unscheduled_live_request_keeps_completed_token_in_cached_state():
     )
 
     assert req_state.output_token_ids == [7]
+
+
+def _steady_eligible_runner(current_req_ids=("req-0",)):
+    """Runner mock whose every steady-decode invariant is satisfied."""
+    sampling = SimpleNamespace(
+        bad_words_token_ids={},
+        has_active_logitsprocs=lambda: False,
+    )
+    return SimpleNamespace(
+        input_batch=SimpleNamespace(
+            req_id_to_index={req_id: i for i, req_id in enumerate(current_req_ids)},
+            no_penalties=True,
+            no_allowed_token_ids=True,
+            max_num_logprobs=None,
+            sampling=sampling,
+        ),
+        requests={
+            req_id: SimpleNamespace(sampling_params=None) for req_id in current_req_ids
+        },
+        model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
+        model_config=SimpleNamespace(logits_processors=None),
+        trace_mode="decode_only",
+        _decode_layout_changed_since_last_decode=False,
+        check_perform_device_sampling=lambda **_kwargs: True,
+    )
+
+
+def _steady_scheduler_output(current_req_ids=("req-0",), **overrides):
+    fields = {
+        "num_scheduled_tokens": {req_id: 1 for req_id in current_req_ids},
+        "scheduled_new_reqs": [],
+        "scheduled_cached_reqs": SimpleNamespace(
+            req_ids=list(current_req_ids), resumed_req_ids=set()
+        ),
+        "pending_structured_output_tokens": False,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def test_layout_change_causes_are_all_rejected_before_update_states():
+    """Every ``_update_states`` layout-change cause must fail the pre-drain check.
+
+    The drain decision is taken from the scheduler output before the persistent
+    batch is mutated, so it has to reject each event that would later set
+    ``_decode_layout_changed_since_last_decode`` and force a host reload.
+    """
+    controller = _controller(("req-0", "req-1"))
+    controller.note_dp_decode_submitted(True)
+    controller.runner = _steady_eligible_runner(("req-0", "req-1"))
+    controller.runner.input_batch.req_id_to_index = {"req-0": 0, "req-1": 1}
+
+    baseline = _steady_scheduler_output(("req-0", "req-1"))
+    assert controller.steady_decode_scheduler_invariants_met(baseline, None)
+
+    # Finished or unscheduled: present in the batch, absent from this step.
+    removed = _steady_scheduler_output(("req-0",))
+    removed.scheduled_cached_reqs = SimpleNamespace(
+        req_ids=["req-0"], resumed_req_ids=set()
+    )
+    assert not controller.steady_decode_scheduler_invariants_met(removed, None)
+
+    # Added: scheduled this step, absent from the batch.
+    added = _steady_scheduler_output(("req-0", "req-1", "req-2"))
+    assert not controller.steady_decode_scheduler_invariants_met(added, None)
+
+    # Resumed from preemption: membership is unchanged, so only the prefill
+    # check rejects it. This leg is why the membership diff alone is not enough.
+    resumed = _steady_scheduler_output(("req-0", "req-1"))
+    resumed.scheduled_cached_reqs = SimpleNamespace(
+        req_ids=["req-0", "req-1"], resumed_req_ids={"req-1"}
+    )
+    assert controller.scheduler_preserves_decode_layout(resumed)
+    assert not controller.steady_decode_scheduler_invariants_met(resumed, None)

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -536,7 +536,7 @@ def test_legacy_contract_receives_reset_batch_without_explicit_commands(
     assert len(warnings) == 1
 
 
-def test_contract_version_does_not_change_steady_decode_eligibility():
+def test_contract_version_does_not_change_non_dp_steady_decode_eligibility():
     runner = SimpleNamespace(
         model=SimpleNamespace(model_capabilities={"supports_async_decode": True}),
         non_dp_async_scheduling=True,
@@ -553,6 +553,34 @@ def test_contract_version_does_not_change_steady_decode_eligibility():
     runner.model.decode_input_update_contract = 1
 
     assert controller.steady_decode_base_enabled(dp_gather=False)
+
+
+def test_gathered_dp_overlap_requires_the_explicit_contract():
+    def _controller_for(dp_size, model):
+        return TTAsyncDecodeController(
+            SimpleNamespace(
+                model=model,
+                parallel_config=SimpleNamespace(data_parallel_size=dp_size),
+            )
+        )
+
+    legacy = SimpleNamespace()
+    v0 = SimpleNamespace(decode_input_update_contract=0)
+    v1 = SimpleNamespace(decode_input_update_contract=1)
+
+    assert not _controller_for(4, legacy).gathered_dp_overlap_permitted()
+    assert not _controller_for(4, v0).gathered_dp_overlap_permitted()
+    assert _controller_for(4, v1).gathered_dp_overlap_permitted()
+
+    # Lane mode is single-process; its overlap path is unchanged by the gate.
+    assert _controller_for(1, legacy).gathered_dp_overlap_permitted()
+
+    # A rank that holds no model abstains instead of vetoing the global vote.
+    abstaining = TTAsyncDecodeController(
+        SimpleNamespace(parallel_config=SimpleNamespace(data_parallel_size=4))
+    )
+    assert abstaining.decode_input_update_contract_version() is None
+    assert abstaining.gathered_dp_overlap_permitted()
 
 
 def test_scheduler_layout_prediction_detects_add_remove_and_preemption():

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -720,6 +720,14 @@ def test_layout_change_causes_are_all_rejected_before_update_states():
     assert controller.scheduler_preserves_decode_layout(resumed)
     assert not controller.steady_decode_scheduler_invariants_met(resumed, None)
 
+    # Chunked-prefill continuation: a cached request, neither new nor resumed,
+    # so membership is unchanged and the new/resumed test alone accepts it. The
+    # multi-token schedule is what marks it as still prefilling.
+    continuation = _steady_scheduler_output(("req-0", "req-1"))
+    continuation.num_scheduled_tokens = {"req-0": 1, "req-1": 256}
+    assert controller.scheduler_preserves_decode_layout(continuation)
+    assert not controller.steady_decode_scheduler_invariants_met(continuation, None)
+
 
 def test_dp_block_table_width_follows_allocation_not_host_tokens():
     """A one-step-stale token count must not narrow the gathered page table.

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -782,3 +782,18 @@ def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
     assert resumed.output_token_ids == []
     assert output.sampled_token_ids == [[5], []]
     assert runner._invalidated_req_ids == set()
+
+
+def test_slot_reuse_clears_a_stale_pending_remap_entry():
+    """Prefill steps neither deliver nor commit a remap, so entries persist.
+
+    Two condense-then-reuse rounds without an intervening decode would
+    otherwise hand a brand-new request another slot's source index.
+    """
+    batch = InputBatch.__new__(InputBatch)
+    batch.max_num_reqs = 4
+    batch._slot_remap = torch.tensor([0, 2, 2, 3], dtype=torch.int32)
+
+    InputBatch._reset_slot_remap_entry(batch, 1)
+
+    assert batch._slot_remap.tolist() == [0, 1, 2, 3]

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -740,3 +740,45 @@ def test_dp_block_table_width_follows_allocation_not_host_tokens():
 
     assert InputBatch.allocated_blocks_for_rows(batch, [0]) == allocated_blocks
     assert stale_num_tokens // block_size < allocated_blocks
+
+
+def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
+    """Under overlap the next step is processed before the previous is applied.
+
+    A request that step finished or resumed must get neither a runner-state
+    update nor a scheduler-visible token.
+    """
+    live = SimpleNamespace(output_token_ids=[])
+    resumed = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"live": live, "resumed": resumed},
+        input_batch=SimpleNamespace(req_id_to_index={}, num_reqs=2),
+        model_config=SimpleNamespace(max_model_len=32),
+        _invalidated_req_ids={"resumed"},
+    )
+    runner._consume_invalidated_req_ids = lambda: (
+        TTModelRunner._consume_invalidated_req_ids(runner)
+    )
+    runner._apply_sampled_tokens_to_state = lambda **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, **kwargs)
+    )
+    runner._build_runner_output = lambda **kwargs: SimpleNamespace(
+        req_id_to_index=dict(kwargs["req_id_to_index"]),
+        sampled_token_ids=[[5], [6]],
+    )
+    runner.apply_and_build_runner_output = lambda *args, **kwargs: (
+        TTModelRunner.apply_and_build_runner_output(runner, *args, **kwargs)
+    )
+
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        torch.tensor([[5], [6]], dtype=torch.int32),
+        None,
+        req_ids=["live", "resumed"],
+        req_id_to_index={"live": 0, "resumed": 1},
+    )
+
+    assert live.output_token_ids == [5]
+    assert resumed.output_token_ids == []
+    assert output.sampled_token_ids == [[5], []]
+    assert runner._invalidated_req_ids == set()

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -30,10 +30,10 @@ def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
     return TTAsyncDecodeController(runner)
 
 
-def _decode_input(*, device_sampling=True, reset_batch=False, page=0):
+def _decode_input(*, device_sampling=True, decode_layout_changed=False, page=0):
     return SimpleNamespace(
         perform_device_sampling=device_sampling,
-        reset_batch=reset_batch,
+        decode_layout_changed=decode_layout_changed,
         block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
     )
 
@@ -129,7 +129,7 @@ def test_prefill_and_layout_change_break_the_decode_chain():
     controller.note_prefill_submitted()
 
     after_prefill = _submit(controller, _decode_input())
-    layout_change = _submit(controller, _decode_input(reset_batch=True))
+    layout_change = _submit(controller, _decode_input(decode_layout_changed=True))
 
     assert after_prefill.reload_inputs and after_prefill.reset_sampling_state
     assert layout_change.reload_inputs and layout_change.reset_sampling_state
@@ -239,13 +239,13 @@ def test_submit_decode_keeps_layout_hint_inside_planner():
         perform_device_sampling=True,
         prompt_tokens=None,
         output_tokens=None,
-        reset_batch=True,
+        decode_layout_changed=True,
         slot_remap=torch.tensor([0], dtype=torch.int32),
     )
 
     controller.submit_decode(model_input, read_from_device=False, async_read=False)
 
-    assert "reset_batch" not in captured
+    assert "decode_layout_changed" not in captured
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -792,6 +792,48 @@ def test_gathered_dp_result_rejects_requests_invalidated_since_submit():
     assert runner._invalidated_req_ids == set()
 
 
+def test_intermediate_chunk_step_still_consumes_and_honours_rejections():
+    """A chunked-prefill step returns early, but rejection still applies.
+
+    The invalidated set has to be consumed here too: carried into a later step
+    it would reject a token that step legitimately produced. The final-chunk row
+    of an invalidated request must also stay empty.
+    """
+    live = SimpleNamespace(output_token_ids=[])
+    resumed = SimpleNamespace(output_token_ids=[])
+    runner = SimpleNamespace(
+        requests={"live": live, "resumed": resumed},
+        input_batch=SimpleNamespace(req_id_to_index={}, num_reqs=3),
+        model_config=SimpleNamespace(max_model_len=32),
+        _invalidated_req_ids={"resumed"},
+    )
+    runner._consume_invalidated_req_ids = lambda: (
+        TTModelRunner._consume_invalidated_req_ids(runner)
+    )
+    runner._apply_sampled_tokens_to_state = lambda *args, **kwargs: (
+        TTModelRunner._apply_sampled_tokens_to_state(runner, *args, **kwargs)
+    )
+    runner._build_chunked_prefill_output = lambda **kwargs: (
+        TTModelRunner._build_chunked_prefill_output(runner, **kwargs)
+    )
+
+    # Rows: a final chunk that may keep its token, a final chunk that must be
+    # rejected, and an intermediate chunk that never produces one.
+    output = TTModelRunner.apply_dp_execution_result(
+        runner,
+        torch.tensor([[5], [6], [7]], dtype=torch.int32),
+        None,
+        req_ids=["live", "resumed", "chunking"],
+        req_id_to_index={"live": 0, "resumed": 1, "chunking": 2},
+        intermediate_prefill_mask=torch.tensor([False, False, True]),
+    )
+
+    assert live.output_token_ids == [5]
+    assert resumed.output_token_ids == []
+    assert output.sampled_token_ids == [[5], [], []]
+    assert runner._invalidated_req_ids == set()
+
+
 def test_slot_reuse_clears_a_stale_pending_remap_entry():
     """Prefill steps neither deliver nor commit a remap, so entries persist.
 

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -189,7 +189,6 @@ def test_drained_decode_updates_next_host_token_and_position_before_transition()
         context=SubmittedStepContext(
             req_ids=["req-0"],
             req_id_to_index={"req-0": 0},
-            request_states=(req_state,),
             submit_time_ns=1,
         ),
         completion_time_ns=2,
@@ -236,11 +235,72 @@ def test_empty_batch_discards_remap_from_previous_request_lifetimes():
         req_output_token_ids=[None],
         _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
     )
+    batch.reset_slot_remap = lambda: InputBatch.reset_slot_remap(batch)
 
     InputBatch.condense(batch, [0])
 
     assert batch._req_ids == []
     assert batch.req_output_token_ids == []
+    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+
+
+def test_remove_all_discards_pending_remap_before_same_step_refill(monkeypatch):
+    class FakeBatch:
+        max_num_reqs = 4
+
+        def __init__(self):
+            self.req_id_to_index = {"old": 0}
+            self._slot_remap = torch.tensor([3, 1, 2, 3], dtype=torch.int32)
+            self.remap_seen_at_add = None
+
+        @property
+        def num_reqs(self):
+            return len(self.req_id_to_index)
+
+        def remove_request(self, req_id):
+            return self.req_id_to_index.pop(req_id, None)
+
+        def reset_slot_remap(self):
+            InputBatch.reset_slot_remap(self)
+
+        def add_request(self, req_state, req_index):
+            self.remap_seen_at_add = self._slot_remap.clone()
+            self.req_id_to_index[req_state.req_id] = req_index
+
+        def condense(self, empty_req_indices):
+            raise AssertionError("same-step refill should consume every freed slot")
+
+        def refresh_logitsprocs(self):
+            pass
+
+    batch = FakeBatch()
+    runner = SimpleNamespace(
+        requests={"old": object()},
+        input_batch=batch,
+        encoder_cache={},
+        _decode_layout_changed_since_last_decode=False,
+    )
+    scheduler_output = SimpleNamespace(
+        finished_req_ids={"old"},
+        free_encoder_mm_hashes=[],
+        num_scheduled_tokens={"new": 1},
+        scheduled_new_reqs=[SimpleNamespace(req_id="new")],
+        scheduled_cached_reqs=SimpleNamespace(
+            req_ids=[],
+            num_computed_tokens=[],
+            new_block_ids=[],
+            resumed_req_ids=set(),
+        ),
+    )
+    monkeypatch.setattr(
+        "vllm_tt_plugin.model_runner.build_cached_request_state",
+        lambda new_req: SimpleNamespace(req_id=new_req.req_id),
+    )
+
+    TTModelRunner._update_states(runner, scheduler_output)
+
+    assert batch.req_id_to_index == {"new": 0}
+    assert batch.remap_seen_at_add.tolist() == [0, 1, 2, 3]
     assert batch._slot_remap.tolist() == [0, 1, 2, 3]
 
 
@@ -581,7 +641,6 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
         context=SubmittedStepContext(
             req_ids=["req-0"],
             req_id_to_index={"req-0": 0},
-            request_states=(object(),),
             submit_time_ns=1,
         ),
         completion_time_ns=2,
@@ -589,38 +648,6 @@ def test_cancelled_or_resumed_request_is_not_applied_to_runner_state():
 
     controller.apply_completed_decode_step(completed, skip_req_ids={"req-0"})
 
-    assert captured[0]["skip_req_ids"] == {"req-0"}
-
-
-def test_reused_request_id_suppresses_cached_non_dp_scheduler_output():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    captured = []
-    runner_output = SimpleNamespace(
-        sampled_token_ids=[[7]],
-        req_id_to_index={"req-0": 0},
-    )
-    controller = _controller()
-    controller.runner.requests = {"req-0": new_req_state}
-    controller.runner._apply_sampled_tokens_to_state = lambda **kwargs: captured.append(
-        kwargs
-    )
-    completed = CompletedDecodeStep(
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        logprobs=None,
-        context=SubmittedStepContext(
-            req_ids=["req-0"],
-            req_id_to_index={"req-0": 0},
-            request_states=(old_req_state,),
-            submit_time_ns=1,
-        ),
-        completion_time_ns=2,
-        runner_output=runner_output,
-    )
-
-    controller.apply_completed_decode_step(completed)
-
-    assert runner_output.sampled_token_ids == [[]]
     assert captured[0]["skip_req_ids"] == {"req-0"}
 
 
@@ -636,53 +663,7 @@ def test_unscheduled_live_request_keeps_completed_token_in_cached_state():
         runner,
         sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
         req_ids=["req-0"],
-        request_states=(req_state,),
         skip_req_ids=set(),
     )
 
     assert req_state.output_token_ids == [7]
-
-
-def test_reused_request_id_rejects_captured_dp_request_identity():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    runner = SimpleNamespace(
-        requests={"req-0": new_req_state},
-        input_batch=SimpleNamespace(req_id_to_index={"req-0": 0}),
-        model_config=SimpleNamespace(max_model_len=32),
-    )
-
-    TTModelRunner._apply_sampled_tokens_to_state(
-        runner,
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        req_ids=["req-0"],
-        request_states=(old_req_state,),
-    )
-
-    assert old_req_state.output_token_ids == []
-    assert new_req_state.output_token_ids == []
-
-
-def test_reused_request_id_suppresses_old_dp_scheduler_output():
-    old_req_state = SimpleNamespace(output_token_ids=[])
-    new_req_state = SimpleNamespace(output_token_ids=[])
-    runner = SimpleNamespace(
-        requests={"req-0": new_req_state},
-        input_batch=SimpleNamespace(num_reqs=1),
-        _dp_request_state_snapshots={4: (old_req_state,)},
-        apply_and_build_runner_output=lambda *args, **kwargs: SimpleNamespace(
-            sampled_token_ids=[[7]],
-            req_id_to_index={"req-0": 0},
-        ),
-    )
-
-    output = TTModelRunner.apply_dp_execution_result(
-        runner,
-        sampled_token_ids=torch.tensor([[7]], dtype=torch.int32),
-        req_ids=["req-0"],
-        req_id_to_index={"req-0": 0},
-        request_state_snapshot_id=4,
-    )
-
-    assert output.sampled_token_ids == [[]]
-    assert runner._dp_request_state_snapshots == {}

--- a/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
+++ b/plugins/vllm-tt-plugin/tests/test_decode_reload_contract.py
@@ -15,8 +15,10 @@ from vllm_tt_plugin.async_decode import (
     SubmittedStepContext,
     TTAsyncDecodeController,
 )
+from vllm_tt_plugin.input_batch import InputBatch
 from vllm_tt_plugin.model_input import TTSamplingParams
 from vllm_tt_plugin.model_runner import TTModelRunner
+from vllm_tt_plugin.worker import TTWorker
 
 
 def _controller(current_req_ids=("req-0",), *, trace_mode="decode_only"):
@@ -35,6 +37,33 @@ def _decode_input(*, device_sampling=True, decode_layout_changed=False, page=0):
         perform_device_sampling=device_sampling,
         decode_layout_changed=decode_layout_changed,
         block_tables_per_group=[torch.tensor([[page, 0]], dtype=torch.int32)],
+    )
+
+
+def _submission_input(*, device_sampling: bool, slot_remap=(3, 1, 2, 3)):
+    return SimpleNamespace(
+        input_tokens=torch.zeros((4, 1), dtype=torch.int32),
+        input_positions=torch.zeros((4,), dtype=torch.int32),
+        block_tables=torch.zeros((4, 1), dtype=torch.int32),
+        block_tables_per_group=[torch.zeros((4, 1), dtype=torch.int32)],
+        block_tables_per_layer=None,
+        unpadded_batch_size=4,
+        tt_sampling_params=TTSamplingParams(
+            temperature=torch.ones(4),
+            top_k=torch.full((4,), 32),
+            top_p=torch.ones(4),
+            presence_penalty=torch.zeros(4),
+            frequency_penalty=torch.zeros(4),
+            repetition_penalty=torch.ones(4),
+            seed=torch.full((4,), -1),
+            num_logprobs=torch.full((4,), -2),
+            enable_log_probs=torch.zeros(4, dtype=torch.bool),
+        ),
+        perform_device_sampling=device_sampling,
+        prompt_tokens=None,
+        output_tokens=None,
+        decode_layout_changed=True,
+        slot_remap=torch.tensor(slot_remap, dtype=torch.int32),
     )
 
 
@@ -199,6 +228,45 @@ def test_dp_slot_remap_is_offset_into_global_slot_namespace():
     assert global_remap.tolist() == [3, 1, 2, 0, 6, 4, 7, 5]
 
 
+def test_empty_batch_discards_remap_from_previous_request_lifetimes():
+    batch = SimpleNamespace(
+        num_reqs=0,
+        max_num_reqs=4,
+        _req_ids=[None],
+        req_output_token_ids=[None],
+        _slot_remap=torch.tensor([3, 1, 2, 3], dtype=torch.int32),
+    )
+
+    InputBatch.condense(batch, [0])
+
+    assert batch._req_ids == []
+    assert batch.req_output_token_ids == []
+    assert batch._slot_remap.tolist() == [0, 1, 2, 3]
+
+
+def test_dp_slot_remap_commit_respects_contract_and_sampling_mode():
+    commits = []
+    worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            model=SimpleNamespace(decode_input_update_contract=1),
+            input_batch=SimpleNamespace(
+                commit_slot_remap=lambda: commits.append("v1-host")
+            ),
+        )
+    )
+
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
+
+    worker.model_runner.model = SimpleNamespace()
+    worker.model_runner.input_batch.commit_slot_remap = lambda: commits.append(
+        "v0-device"
+    )
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=False)
+    TTWorker.commit_dp_slot_updates(worker, device_sampling=True)
+
+    assert commits == ["v1-host", "v0-device"]
+
+
 def test_explicit_contract_keeps_layout_hint_inside_planner():
     captured = {}
 
@@ -251,6 +319,152 @@ def test_explicit_contract_keeps_layout_hint_inside_planner():
     assert captured["reload_inputs"] is True
     assert captured["reload_sampling_params"] is True
     assert captured["reset_sampling_state"] is True
+
+
+def test_explicit_contract_delivers_and_commits_slot_remap_for_host_sampling():
+    captured = {}
+    commits = []
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(device_sampling=False),
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert captured["slot_remap"].tolist() == [3, 1, 2, 3]
+    assert commits == [True]
+
+
+def test_layout_change_refreshes_request_rope_even_when_request_id_is_reused():
+    captured = {}
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            captured.update(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=True,
+        previous_req_ids={"req-0"},
+        requests={"req-0": SimpleNamespace(mrope_position_delta=17)},
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(
+            req_ids=["req-0"],
+            commit_slot_remap=lambda: None,
+        ),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    controller.submit_decode(
+        _submission_input(device_sampling=False),
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert captured["rope_deltas_all_users"] == [17]
+
+
+def test_slot_remap_is_not_committed_when_decode_submission_fails():
+    commits = []
+
+    class FakeModel:
+        decode_input_update_contract = 1
+        model_capabilities = {"supports_async_decode": False}
+
+        def decode_forward(self, **kwargs):
+            raise RuntimeError("submission rejected")
+
+    runner = SimpleNamespace(
+        model=FakeModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+
+    try:
+        controller.submit_decode(
+            _submission_input(device_sampling=False),
+            read_from_device=False,
+            async_read=False,
+        )
+    except RuntimeError as exc:
+        assert str(exc) == "submission rejected"
+    else:
+        raise AssertionError("decode submission should have failed")
+
+    assert commits == []
+
+
+def test_legacy_host_sampling_keeps_slot_remap_pending_for_device_sampling(
+    monkeypatch,
+):
+    calls = []
+    commits = []
+    monkeypatch.setattr(
+        "vllm_tt_plugin.async_decode.logger.warning",
+        lambda *args: None,
+    )
+
+    class FakeLegacyModel:
+        model_capabilities = {"supports_async_decode": True}
+
+        def decode_forward(self, **kwargs):
+            calls.append(kwargs)
+            return object()
+
+    runner = SimpleNamespace(
+        model=FakeLegacyModel(),
+        trace_mode="decode_only",
+        kv_caches=object(),
+        request_specific_rope=False,
+        parallel_config=SimpleNamespace(data_parallel_size=1),
+        input_batch=SimpleNamespace(commit_slot_remap=lambda: commits.append(True)),
+    )
+    controller = TTAsyncDecodeController(runner)
+    model_input = _submission_input(device_sampling=False)
+
+    controller.submit_decode(
+        model_input,
+        read_from_device=False,
+        async_read=False,
+    )
+    model_input.perform_device_sampling = True
+    controller.submit_decode(
+        model_input,
+        read_from_device=False,
+        async_read=False,
+    )
+
+    assert "slot_remap" not in calls[0]
+    assert calls[1]["slot_remap"].tolist() == [3, 1, 2, 3]
+    assert commits == [True]
 
 
 def test_legacy_contract_receives_reset_batch_without_explicit_commands(

--- a/plugins/vllm-tt-plugin/tests/test_dp_engine.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_engine.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Host-only tests for gathered-DP mode negotiation."""
+"""Host-only tests for gathered-DP mode negotiation and step orchestration."""
 
+from concurrent.futures import Future
 from types import SimpleNamespace
 
+import torch
 import vllm_tt_plugin.engine as engine_module
-from vllm_tt_plugin.engine import TTDPEngineCoreProc
+from vllm_tt_plugin.engine import DPGatherHandle, TTDPEngineCoreProc
 from vllm_tt_plugin.scheduler import TTSchedulingMode
 
 
@@ -15,6 +17,169 @@ def _core_with_scheduler(scheduler):
     core.dp_group = object()
     core.dlog = lambda *args, **kwargs: None
     return core
+
+
+def _handle(**overrides):
+    fields = dict(
+        future=Future(),
+        scheduler_output=SimpleNamespace(total_num_scheduled_tokens=1),
+        local_has_requests=True,
+        is_decode=True,
+        overlap_ok=False,
+        any_needs_logprobs=False,
+        intermediate_prefill_mask=None,
+        req_ids=[],
+        req_id_to_index={},
+    )
+    fields.update(overrides)
+    return DPGatherHandle(**fields)
+
+
+def _step_core(monkeypatch, *, overlap_ok, in_flight):
+    """A core whose ``step_dp_with_batch_queue`` collaborators are recorded."""
+    scheduler_output = SimpleNamespace(
+        total_num_scheduled_tokens=4, pending_structured_output_tokens=False
+    )
+    scheduler = SimpleNamespace(
+        has_requests=lambda: True,
+        schedule=lambda: scheduler_output,
+        get_grammar_bitmask=lambda _so: None,
+        update_from_output=lambda _so, _out: {},
+    )
+    core = _core_with_scheduler(scheduler)
+    core.batch_queue = object()
+    core.is_ec_producer = False
+    core._dp_in_flight = in_flight
+    core._process_aborts_queue = lambda: events.append("aborts")
+
+    events: list = []
+    submits: list = []
+
+    monkeypatch.setattr(
+        core, "_dp_any_rank_has_scheduler_requests", lambda: True, raising=False
+    )
+    monkeypatch.setattr(
+        core,
+        "_dp_negotiate_forced_mode",
+        lambda: TTSchedulingMode.DECODE_ONLY,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        core,
+        "_dp_can_attempt_steady_decode_from_scheduler",
+        lambda _so, _go: overlap_ok,
+        raising=False,
+    )
+
+    def fake_submit(_so, _go, *, overlap_ok, outstanding):
+        events.append("submit")
+        submits.append(outstanding)
+        return _handle()
+
+    def fake_finalize(handle):
+        events.append("finalize")
+        return SimpleNamespace(handle=handle)
+
+    monkeypatch.setattr(core, "dp_gather_submit", fake_submit, raising=False)
+    monkeypatch.setattr(core, "dp_gather_finalize", fake_finalize, raising=False)
+    return core, events, submits
+
+
+def test_step_hands_invalidations_to_the_still_outstanding_submission(monkeypatch):
+    """Overlap applies the previous result after this step's states are updated.
+
+    So the requests this step finished or resumed belong to the outstanding
+    handle. Giving them to the submission created here would reject a token that
+    submission legitimately produces for its own resumed rows.
+    """
+    in_flight = _handle()
+    core, events, submits = _step_core(
+        monkeypatch, overlap_ok=True, in_flight=in_flight
+    )
+
+    core.step_dp_with_batch_queue()
+
+    assert events == ["submit", "aborts", "finalize"]
+    assert submits == [in_flight]
+
+
+def test_step_drops_invalidations_once_the_previous_result_is_applied(monkeypatch):
+    """Without overlap the previous result is applied in scheduler order.
+
+    Nothing is outstanding by the time this step's states are updated, so the
+    invalidations must be discarded rather than held for a later step.
+    """
+    in_flight = _handle()
+    core, events, submits = _step_core(
+        monkeypatch, overlap_ok=False, in_flight=in_flight
+    )
+
+    core.step_dp_with_batch_queue()
+
+    assert events == ["aborts", "finalize", "submit"]
+    assert submits == [None]
+
+
+def test_gather_submit_moves_invalidations_off_the_new_handle(monkeypatch):
+    """The runner drains the set on every DP step, including an idle one.
+
+    A rank that scheduled nothing still notes finished requests, and leaving
+    them on the runner would filter an unrelated later step's rows.
+    """
+    core = _core_with_scheduler(SimpleNamespace())
+    core.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_rank_local=0, data_parallel_size=1
+        )
+    )
+    core.dp_rank = 0
+    core.dp_device_ranks = [0]
+    core._dp_gather_forced_mode = TTSchedulingMode.PREFILL_ONLY
+    core.model_executor = SimpleNamespace(
+        collective_rpc=lambda *args, **kwargs: [
+            (None, 0, 0, 0, 0, 1, 0, None, [], {}, {"finished"})
+        ]
+    )
+
+    monkeypatch.setattr(
+        engine_module.dist, "all_reduce", lambda *a, **k: None, raising=False
+    )
+    monkeypatch.setattr(
+        engine_module.dist, "gather_object", lambda *a, **k: None, raising=False
+    )
+    monkeypatch.setattr(
+        engine_module, "get_tt_per_lane_max_num_seqs", lambda _cfg: 2, raising=False
+    )
+
+    outstanding = _handle()
+    new_handle = core.dp_gather_submit(None, None, outstanding=outstanding)
+
+    assert outstanding.invalidated_req_ids == {"finished"}
+    assert new_handle.invalidated_req_ids == set()
+
+
+def test_finalize_filters_rows_with_the_handles_own_invalidations(monkeypatch):
+    """The set reaches the runner through the handle, not through runner state."""
+    core = _core_with_scheduler(SimpleNamespace())
+    core.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(data_parallel_size=1)
+    )
+    core.dp_rank = 0
+    applied: list = []
+    core.model_executor = SimpleNamespace(
+        collective_rpc=lambda _name, args=None: (applied.append(args), [None])[1]
+    )
+    monkeypatch.setattr(
+        engine_module.dist, "scatter", lambda *a, **k: None, raising=False
+    )
+
+    future: Future = Future()
+    future.set_result((torch.zeros((1, 2, 1), dtype=torch.int32), [None]))
+    handle = _handle(future=future, invalidated_req_ids={"resumed"})
+
+    core.dp_gather_finalize(handle)
+
+    assert applied[0][-1] == {"resumed"}
 
 
 def test_dp_negotiation_prefers_running_prefill_continuation(monkeypatch):
@@ -34,3 +199,61 @@ def test_dp_negotiation_prefers_running_prefill_continuation(monkeypatch):
 
     assert core._dp_negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
     assert core._dp_gather_forced_mode == TTSchedulingMode.PREFILL_ONLY
+
+
+def test_contract_version_is_read_once_and_reduced_permissively(monkeypatch):
+    """Ranks holding no model report -1, so the reduction has to be MAX.
+
+    Reading it once per process is what keeps every rank on one value: only
+    ``data_parallel_rank_local == 0`` loads a model, so a per-rank read of the
+    adapter attribute raises everywhere else.
+    """
+    core = _core_with_scheduler(SimpleNamespace())
+    core.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_rank_local=1, data_parallel_size=2
+        )
+    )
+    core.dp_rank = 1
+    core.dp_device_ranks = [0]
+    core._dp_gather_forced_mode = TTSchedulingMode.DECODE_ONLY
+    core._dp_local_contract_version = None
+
+    rpc_names: list[str] = []
+
+    def collective_rpc(name, args=None, kwargs=None, non_block=False):
+        rpc_names.append(name)
+        if name == "build_dp_model_input":
+            return [(None, 0, 0, 0, 0, 1, 0, None, [], {}, set())]
+        if name == "decode_input_update_contract_version":
+            return [-1]
+        if name == "build_dp_decode_gather_input":
+            return [
+                {
+                    "int_inputs": torch.zeros(2, dtype=torch.int32),
+                    "float_inputs": torch.zeros(2),
+                }
+            ]
+        return [None]
+
+    core.model_executor = SimpleNamespace(collective_rpc=collective_rpc)
+
+    reduced: list[torch.Tensor] = []
+
+    def all_reduce(tensor, *, op, group):
+        assert op == engine_module.dist.ReduceOp.MAX
+        reduced.append(tensor.clone())
+        tensor[6] = 1  # a device rank agreed on version 1
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+    monkeypatch.setattr(engine_module.dist, "gather", lambda *a, **k: None)
+    monkeypatch.setattr(engine_module.dist, "recv", lambda *a, **k: None)
+    monkeypatch.setattr(
+        engine_module, "get_tt_per_lane_max_num_seqs", lambda _cfg: 2, raising=False
+    )
+
+    core.dp_gather_submit(None, None)
+    core.dp_gather_submit(None, None)
+
+    assert reduced[0][6].item() == -1
+    assert rpc_names.count("decode_input_update_contract_version") == 1

--- a/plugins/vllm-tt-plugin/tests/test_lane_input_batch.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_input_batch.py
@@ -621,3 +621,50 @@ def test_runner_is_lane_mode_property():
     assert not _runner_with(data_parallel_size=1, tt_data_parallel_size=1)._is_lane_mode
     # Gathered multi-process DP: each rank is its own engine -> plain InputBatch.
     assert not _runner_with(data_parallel_size=4, tt_data_parallel_size=4)._is_lane_mode
+
+
+# --------------------------------------------------------------------------
+# Overlap prediction (row stability, answered before the batch is mutated)
+# --------------------------------------------------------------------------
+
+
+def _scheduler_output(scheduled, *, new_reqs=(), resumed=(), finished=()):
+    return SimpleNamespace(
+        num_scheduled_tokens={req_id: 1 for req_id in scheduled},
+        scheduled_new_reqs=list(new_reqs),
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids=set(resumed)),
+        finished_req_ids=set(finished),
+    )
+
+
+def test_unscheduled_lane_row_does_not_count_as_a_layout_change():
+    """A running decode may go unscheduled and keep its stable slot.
+
+    The front-packed batch evicts and condenses in that case, so membership
+    equality is its test; applying that rule here would give up decode overlap
+    on every step that skips a lane.
+    """
+    b = _lane_batch(num_lanes=2, per_lane=2)
+    _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.0)), lane=0)
+    _add_to_lane(b, _make_req("b", [1], [], dict(temperature=0.0)), lane=1)
+
+    assert b.scheduling_preserves_rows(_scheduler_output(("a", "b")))
+    assert b.scheduling_preserves_rows(_scheduler_output(("a",)))
+
+
+def test_lane_row_release_and_placement_are_layout_changes():
+    """The three ``apply_step_plan`` causes must all be predicted."""
+    b = _lane_batch(num_lanes=2, per_lane=2)
+    _add_to_lane(b, _make_req("a", [1], [], dict(temperature=0.0)), lane=0)
+
+    assert not b.scheduling_preserves_rows(
+        _scheduler_output(("a",), finished=("a",)),
+    )
+    assert not b.scheduling_preserves_rows(
+        _scheduler_output(("a", "c"), new_reqs=(SimpleNamespace(req_id="c"),)),
+    )
+    assert not b.scheduling_preserves_rows(
+        _scheduler_output(("a",), resumed=("a",)),
+    )
+    # A request finishing that this batch never held frees no row here.
+    assert b.scheduling_preserves_rows(_scheduler_output(("a",), finished=("gone",)))

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -394,7 +394,6 @@ def test_async_lane_decode_uses_batch_extraction():
     context = SubmittedStepContext(
         req_ids=["req-4"],
         req_id_to_index={"req-4": 0},
-        request_states=(),
         submit_time_ns=123,
     )
     model_input = object()

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -269,7 +269,6 @@ def test_apply_dp_result_suppresses_intermediate_prefill_rows():
         apply_and_build_runner_output=lambda *args, **kwargs: pytest.fail(
             "intermediate rows must not be applied"
         ),
-        _consume_invalidated_req_ids=set,
     )
 
     output = TTModelRunner.apply_dp_execution_result(

--- a/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
+++ b/plugins/vllm-tt-plugin/tests/test_lane_model_runner.py
@@ -269,6 +269,7 @@ def test_apply_dp_result_suppresses_intermediate_prefill_rows():
         apply_and_build_runner_output=lambda *args, **kwargs: pytest.fail(
             "intermediate rows must not be applied"
         ),
+        _consume_invalidated_req_ids=set,
     )
 
     output = TTModelRunner.apply_dp_execution_result(
@@ -347,6 +348,7 @@ def test_submit_prefill_forwards_plan_empty_slots_to_model():
         trace_mode="none",
         request_specific_rope=False,
         model=FakeModel(),
+        async_decode=SimpleNamespace(note_prefill_submitted=lambda: None),
     )
     model_input = SimpleNamespace(
         input_tokens=torch.zeros((1, 1), dtype=torch.int32),

--- a/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
+++ b/plugins/vllm-tt-plugin/tests/test_sample_time_grammar.py
@@ -231,12 +231,12 @@ def test_finish_nondp_sync_applies_grammar_before_sampling():
     def apply_grammar(model_input, grammar_output, *, lane_total):
         order.append("grammar")
         assert lane_total is None
-        return replace(model_input, reset_batch=True)  # mark it was applied
+        return replace(model_input, decode_layout_changed=True)  # mark it was applied
 
     def sample_sync(fwd):
         order.append("sample")
         # Grammar must already be on the input the sampler runs against.
-        assert fwd.model_input.reset_batch is True
+        assert fwd.model_input.decode_layout_changed is True
         return [torch.tensor([[42]], dtype=torch.int32)], []
 
     def build_output(sampled, logprobs, **kwargs):


### PR DESCRIPTION
Makes decode reload policy explicit. vLLM owns the decision of which host inputs
are authoritative on a given decode step and sends it as four commands; a
contract-aware tt-metal generator executes them and adds no reload inference of
its own.

Part of #449. **Merge before** its tt-metal counterpart,
[tenstorrent/tt-metal#52296](https://github.com/tenstorrent/tt-metal/pull/52296),
which implements the adapter side.

## Why

Async device sampling deliberately lets host token state trail the device by one
decode step, so only the runner knows whether `tokens` and `start_pos` are
authoritative. Adapters were guessing, from page-table comparisons, sampling-mode
changes and their own previous-call state. Those guesses are unobservable when
they are wrong: the device silently reuses a stale token or addresses another
request's KV blocks.

## The contract

Four independent boolean commands on every decode, plus `slot_remap` as data:

| Command | Effect |
| --- | --- |
| `reload_inputs` | Restage all forward inputs: token, position, RoPE, page tables. |
| `reload_page_table` | Page-table input only, preserving device-produced token and position. |
| `reload_sampling_params` | Upload temperature/top-k/top-p/penalties, and register per-request seeds. |
| `reset_sampling_state` | Rebuild per-slot penalty history and seeds. |

The first two encode one three-valued decision rather than two switches;
`reset_sampling_state` implies `reload_inputs`. Both are asserted where the plan
is built, because an adapter aligns its RNG counters from the host positions on a
state reset and that is only sound on a step that restages them.

Negotiated by `decode_input_update_contract` on the generator. Absent or `0` keeps
the legacy `reset_batch` call shape and the adapter's existing behaviour, so this
lands before any adapter migrates. Full specification, including what a version-1
adapter owes versus what `supports_async_decode` additionally requires:
[docs/decode-reload-contract.md](plugins/vllm-tt-plugin/docs/decode-reload-contract.md).

## What changes in the plugin

- `TTAsyncDecodeController.plan_decode_reload` is the single place reload policy is
  decided, for every decode, not only overlapped ones.
- Overlap eligibility is predicted from the scheduler output *before* the batch is
  mutated, so a new, finished, resumed or still-prefilling request can no longer be
  noticed after a decode was already allowed to overlap stale host input. Chunked
  prefill is detected from the request's context phase, which is exact where a
  scheduled-token count is not.
- Row stability is answered by the batch, because eviction policy is the batch's:
  front-packed batches evict and condense, lane batches keep a stable slot.
- Requests a later scheduler output finished or resumed travel with the submission
  they invalidate, in the DP gather handle, so a result can only be filtered by ids
  belonging to its own step.
- The state-slot ownership map (from #454) and the decode layout signal advance only
  once a submission is accepted, so a raised `decode_forward` cannot leave either
  describing a step the device never ran.
- Gathered-DP decode overlap requires a version-1 adapter. Version-0 adapters keep
  the finalize-before-submit order rather than reload from host tensors that are
  deliberately one step behind.

## Compatibility

| vLLM | tt-metal adapter | Result |
| --- | --- | --- |
| Old | Legacy / version 0 | Existing behaviour |
| New | Legacy / version 0 | Legacy path, with a warning |
| New | Version 1+ | Explicit commands, eligible resident overlap |
| Old | Strict version 1 | Unsupported: the commands are never sent |

## Validation

- `test_decode_reload_contract.py` (36 tests) and `test_dp_engine.py` (6) are
  host-only: the command plan per transition, the overlap prediction including the
  one-token-remaining chunked continuation and a speculated decode row, the
  invalidation routing in both directions, the deferred ownership settle, the
  contract-version reduction, and the page-table width under a stale token count.
- ruff and `pre-commit run` clean, including `markdownlint` at its manual stage.
- **Device:** Gemma4-12B / 26B-A4B / 31B on `bh_quietbox_2`, paired with
  tt-metal#52296, all green:
  [run 31120816110](https://github.com/tenstorrent/tt-metal/actions/runs/31120816110).
  Gemma4 inherits the contract marker from the shared generator, so this is the v1
  path executing end to end, not the legacy fallback.

### Not yet validated

- The full model/SKU matrix has not been green against these heads.
- Nothing has exercised gathered-DP overlap, which needs an adapter advertising
  `supports_async_decode`. Gemma4 leaves it off, so the green run above covers v1
  command handling and `slot_remap`, not resident decode.
- No CI job collects `plugins/vllm-tt-plugin/tests/`; they run when invoked.
- The device run above predates the rebase onto #454. It needs re-dispatching
  against the current head before merge.

## Filed separately

- [tenstorrent/tt-metal#51981](https://github.com/tenstorrent/tt-metal/issues/51981)
  `tt_transformers` seeded on-device sampling is not reproducible under async
  scheduling. Fixed by #52296 as a side effect.
