### PR TITLE
Add BH-Galaxy to mesh_grid_dict in get_mesh_grid

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -737,6 +737,7 @@ def get_mesh_grid(local_dp_rank=0):
         "P150x8": (1, 8),
         "P300x2": (1, 4),
         "TG": (8, 4),
+        "BH-Galaxy": (8, 4),
     }
     mesh_device_env = os.environ.get("MESH_DEVICE")
     if mesh_device_env is not None:


### PR DESCRIPTION
### Problem

Bringing up Qwen3-32B on BH Galaxy fails at engine start:

```
File ".../vllm-tt-plugin/src/vllm_tt_plugin/worker.py", line 748, in get_mesh_grid
    assert mesh_device_env in mesh_grid_dict, (
AssertionError: Invalid MESH_DEVICE: BH-Galaxy
```

tt-inference-server emits `MESH_DEVICE=BH-Galaxy` for `DeviceTypes.BLACKHOLE_GALAXY`
(`workflows/workflow_types.py:107`, `utils/device_utils.py:21`), but `mesh_grid_dict`
in `get_mesh_grid()` has no entry for it, so the lookup asserts.

### Fix

Add the missing mapping:

```python
"BH-Galaxy": (8, 4),
```

### Why (8, 4)

BH Galaxy is 32x P150 — the same 32-chip 8x4 topology as the Wormhole Galaxy (`TG`),
just Blackhole silicon. Corroborated by tt-inference-server's model spec: the
`BLACKHOLE_GALAXY` block for `qwen3_32b_galaxy` in `workflows/model_specs/dev/llm.yaml`
is a byte-identical copy of the `GALAXY` block, including `max_concurrency: 32  # 8 * 4`
and `data_parallel_size: 4`.

### Follow-up

This file is baked into the image at Docker build time (cloned in
`vllm.tt-metal.src.dev.Dockerfile`), not bind-mounted, so the
`vllm-tt-metal-src-dev` image needs a rebuild and tt-shield's `docker-image`
input needs repointing before CI picks this up.

Failing run: https://github.com/tenstorrent/tt-shield/actions/runs/31178491112/job/92865928576

🤖 Generated with [Claude Code](https://claude.com/claude-code)
