### PR TITLE
tt: release a preempted request's device state slot

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/model_runner.py
@@ -613,9 +613,7 @@ class TTModelRunner:
         # Remove finished requests from the cached states.
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
-            # Only a FINISHED request releases its slot; an unscheduled one still
-            # owns its state even though the lines below drop it from the batch.
-            self._req_state_slot.pop(req_id, None)
+        self._release_dead_state_slots(scheduler_output)
 
         # Remove the finished requests from the persistent batch.
         # NOTE(woosuk): There could be an edge case where finished_req_ids and
@@ -813,6 +811,30 @@ class TTModelRunner:
         )
 
     # --- Per-request device state slots (see ``self._req_state_slot``) ---
+
+    def _release_dead_state_slots(self, scheduler_output: SchedulerOutput) -> None:
+        """Drop the slot claims of requests whose device state is no longer
+        authoritative.
+
+        The predicate is not "did the step schedule it": a RUNNING request the step
+        left out (what every prefill step does to the whole decode batch) still owns
+        live state and must keep its slot. Only two states release:
+
+        - FINISHED: the request is gone.
+        - PREEMPTED: ``Scheduler._preempt_request`` freed the KV blocks and reset
+          ``num_computed_tokens``, so a resume re-prefills the prompt plus every
+          generated token and writes the slot's final state itself. Nothing reads the
+          old contents, and holding the slot only inflates ``held`` in
+          ``_alloc_prefill_state_slots``, where a shortfall is a hard assert. The
+          per-slot seed RNG does not need the hold either: the device seed is derived
+          from the absolute decode position, not from slot residency.
+
+        ``preempted_req_ids`` is typed optional, hence the ``or ()``.
+        """
+        for req_id in scheduler_output.finished_req_ids:
+            self._req_state_slot.pop(req_id, None)
+        for req_id in scheduler_output.preempted_req_ids or ():
+            self._req_state_slot.pop(req_id, None)
 
     def _alloc_prefill_state_slots(self, row_req_ids: list[str]) -> list[int]:
         """Pick each prefilling request's state slot, skipping slots that live

--- a/plugins/vllm-tt-plugin/tests/test_state_slots.py
+++ b/plugins/vllm-tt-plugin/tests/test_state_slots.py
@@ -8,7 +8,8 @@ at whatever row is free, and ``condense`` moves rows down when a request finishe
 Device state indexed by slot (Qwen3.6 GDN recurrent+conv, the per-slot seed RNG, the
 decode trace's token/position buffers) does not follow, so
 ``_alloc_prefill_state_slots`` and ``_decode_state_slot_remap`` say where each
-request's state is. No device execution: both are pure index bookkeeping, run here
+request's state is, and ``_release_dead_state_slots`` says when a request stops
+owning one. No device execution: all three are pure index bookkeeping, run here
 against a fake runner.
 """
 
@@ -37,6 +38,15 @@ def _prefill(runner, row_req_ids):
 def _decode(runner, row_req_ids):
     remap = TTModelRunner._decode_state_slot_remap(runner, list(row_req_ids))
     return None if remap is None else remap.tolist()
+
+
+def _release(runner, finished=(), preempted=None):
+    """One release pass. ``preempted`` defaults to None, the value a scheduler that
+    preempted nothing reports."""
+    TTModelRunner._release_dead_state_slots(
+        runner,
+        SimpleNamespace(finished_req_ids=set(finished), preempted_req_ids=preempted),
+    )
 
 
 def test_state_follows_the_request_across_row_moves():
@@ -74,6 +84,66 @@ def test_state_follows_the_request_across_row_moves():
     assert _prefill(r, ["B0"]) == [0], (
         "a re-prefilled live request must keep its own slot"
     )
+
+
+def test_release_keeps_a_merely_unscheduled_request():
+    """Every prefill step leaves the whole decode batch unscheduled, and that state is
+    still live. The release predicate must not read "unscheduled" as "dead"."""
+    r = _runner()
+    assert _prefill(r, ["A"]) == [0]
+
+    _release(r)
+    assert r._req_state_slot == {"A": 0}
+    assert _prefill(r, ["B"]) == [1], "a live request's slot must not be reused"
+
+    _release(r, finished={"A"})
+    assert r._req_state_slot == {"B": 1}
+
+
+def test_preemption_frees_the_slot_a_later_prefill_needs():
+    """A preempted request's state is dead: ``_preempt_request`` freed its KV and reset
+    ``num_computed_tokens``, so the resume re-prefills from zero and rewrites the slot.
+    Holding it only shrinks capacity, and the shortfall is a hard assert."""
+    r = _runner()
+    rows = [f"r{i}" for i in range(SLOTS)]
+    assert _prefill(r, rows) == list(range(SLOTS))
+    assert _decode(r, rows) is None
+
+    _release(r, preempted={"r7"})
+    assert "r7" not in r._req_state_slot
+    # The cached request state stays: the resume needs it, and it is what keeps the
+    # stale slot inside ``held``.
+    assert "r7" in r.requests
+
+    # Under ``--scheduling-policy priority`` the preempted request is re-queued by
+    # priority, not to the front, so a higher-priority arrival prefills ahead of it.
+    # Its slot must be free or the prefill has nowhere to go.
+    assert _prefill(r, ["r8"]) == [7]
+
+
+def test_a_resumed_preempted_request_gets_a_slot_and_a_valid_remap():
+    """The resume is an ordinary prefill: it takes whatever slot is free and the next
+    decode step gathers its state to its row."""
+    r = _runner()
+    rows = [f"r{i}" for i in range(SLOTS)]
+    _prefill(r, rows)
+    _decode(r, rows)
+    _release(r, preempted={"r7"})
+    _prefill(r, ["r8"])
+
+    # r7 can resume only once the batch has room: the scheduler caps running at the
+    # slot count and a preempted request does not count against it.
+    _release(r, finished={"r0"})
+    r.requests.pop("r0")
+    assert _prefill(r, ["r7"]) == [0], "the resume takes the slot the finish freed"
+
+    # vLLM re-adds both newcomers at the free rows, so the decode rows no longer match
+    # the slots.
+    decode_rows = [f"r{i}" for i in range(1, 7)] + ["r8", "r7"]
+    remap = _decode(r, decode_rows)
+    assert remap == [1, 2, 3, 4, 5, 6, 7, 0]
+    assert sorted(remap) == list(range(SLOTS)), "must be a permutation"
+    assert _decode(r, decode_rows) is None
 
 
 def test_capacity_and_slot_width_are_enforced():


### PR DESCRIPTION
Port of tenstorrent/vllm-tt-plugin#37, which fixes tenstorrent/vllm-tt-plugin#35. Follow-up to #454, which introduced the slot map. The change here is byte-identical to the plugin PR: the two copies of `model_runner.py` have diverged elsewhere (SPDX header, DP-rank host sampler, chunked-prefill assert), but not in the state-slot region.

Requires fix https://github.com/tenstorrent/tt-metal/pull/52808 (pre-existing bug, made visible by this. Merged).

## The bug

`_update_states` released a request's device state slot only on `finished_req_ids`. A **preempted** request therefore kept its slot while its contents were already dead.

Verified against this tree rather than taken on faith:

- `Scheduler._preempt_request` (`vllm/v1/core/sched/scheduler.py:900`) calls `kv_cache_manager.free(request)` and sets `num_computed_tokens = 0`. The resume is a full re-prefill of the prompt plus every generated token, so it starts GDN conv/recurrent state from zero and writes the slot's final state itself. Nothing ever reads the old contents.
- The per-slot seed RNG does not need the hold either: the device seed is derived from the absolute decode position (`align_seed_counters_to_positions`), and `reset_seed_from_slots_if_needed` reseeds a slot whose value changed.
- Upstream already treats preemption as state death. `vllm/v1/worker/gpu/model_runner.py:426` unions `preempted_req_ids` into `finished_req_ids` before dropping request state, and `vllm/v1/worker/mamba_utils.py:130` pops the mamba state index for `chain(finished, preempted)`. GDN state is the same kind of object.

So between preemption and resume the stale entry has exactly one effect: it inflates `held` in `_alloc_prefill_state_slots`, which ends in a bare `assert free`. That raises out of `_prepare_model_inputs` and kills the engine core instead of degrading one response.

## Reachability

Under the default FCFS policy it is not reachable: `_preempt_request` calls `waiting.prepend_request`, and `FCFSRequestQueue.prepend_request` is `deque.appendleft`, so the preempted request is the first prefill candidate of the next step and is therefore in `prefilling`, which excludes its own slot from `held`.

Under `--scheduling-policy priority` it is: `PriorityRequestQueue.prepend_request` just delegates to `add_request` (a `heappush`), so the preempted request is re-inserted by priority and a higher-priority arrival prefills ahead of it. With `max_num_seqs=8`:

1. 8 running requests hold slots 0..7.
2. KV pressure preempts `r7`. `self.requests["r7"]` and `_req_state_slot["r7"] == 7` both survive (the runner deliberately keeps cached state for an unscheduled request).
3. A higher-priority `r8` is admitted ahead of `r7`.
4. `prefilling == {"r8"}`, so `held` is slots 0..6 plus the dead slot 7 = all 8.
5. `AssertionError: no free device state slot for 1 prefill(s): held=[0, 1, 2, 3, 4, 5, 6, 7], capacity=8`.

That is the literal assert the new test produces when the fix is reverted.

## The change

The predicate becomes "is this request's device state still authoritative" rather than "did this step schedule it", in a named helper so the distinction is stated once:

- **FINISHED** -> release.
- **PREEMPTED** -> release. KV freed, `num_computed_tokens == 0`, state dead.
- **RUNNING but unscheduled** (what every TT prefill step produces for the whole decode batch) -> keep. This is what #454 fixes and the change must not regress it.

`SchedulerOutput.preempted_req_ids` is populated unconditionally by `Scheduler.schedule` (`scheduler.py:870`) and `TTScheduler.schedule` reaches `super().schedule()` on every branch, so it always arrives. Lane DP is covered too: `merge_lane_scheduler_outputs` already unions each lane's `preempted_req_ids` into the merged output (`lane_scheduler.py:194`). The field is typed `set[str] | None`, hence the `or ()`.

## Tests

`plugins/vllm-tt-plugin/tests/test_state_slots.py`, three cases, host-only index bookkeeping like the existing ones:

- `test_release_keeps_a_merely_unscheduled_request` - guards against over-releasing and regressing #454.
- `test_preemption_frees_the_slot_a_later_prefill_needs` - the sequence above.
- `test_a_resumed_preempted_request_gets_a_slot_and_a_valid_remap` - the resume takes a free slot and the next decode step gathers a valid permutation.

Revert the one-loop fix and the last two fail with the engine-killing assert; the first still passes. Verified by running the file against the real methods extracted from this tree's `model_runner.py` 

CI: https://github.com/tenstorrent/tt-metal/actions/runs/31502942949 (with the needed `tt-metal` change)

## Out of scope, filed on the plugin repo

1. tenstorrent/vllm-tt-plugin#39 - `assert free` is a harsh failure for a bookkeeping shortfall even with the right predicate. Releasing the least-recently-scheduled holder's slot would degrade one stale response instead of crashing the engine core.
2. tenstorrent/vllm-tt-plugin#38 - `TTLaneScheduler._build_step_plan` has the same class of bug in the lane-DP row allocator, but the fix is not a one-liner: the lane input batch keeps an unscheduled request at its row, so freeing the row in the scheduler without also removing the request from the batch lets `add_request_to_row` place a newcomer on top of it. Both copies of the file are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
