### PR TITLE
tt: scope disable_chunked_mm_input to models that actually chunk

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/platform.py
@@ -52,31 +52,38 @@ def _apply_chunked_prefill_policy(vllm_config: "VllmConfig") -> None:
     model_config = vllm_config.model_config
     model_type = getattr(model_config.hf_config, "model_type", None)
 
-    if model_type not in _CHUNKED_PREFILL_MODEL_TYPES:
-        if scheduler_config.enable_chunked_prefill:
-            logger.info(
-                "Chunked prefill is not validated for `model_type=%s`; disabling it.",
-                model_type,
+    if model_type in _CHUNKED_PREFILL_MODEL_TYPES:
+        # A chunk boundary inside a multimodal item would split its embeddings
+        # from their positions. Only meaningful while prefill can be split, and
+        # vLLM rejects the flag outright when one item exceeds the token budget,
+        # so it stays off for every model type below.
+        scheduler_config.disable_chunked_mm_input = True
+        return
+
+    if scheduler_config.enable_chunked_prefill:
+        logger.info(
+            "Chunked prefill is not validated for `model_type=%s`; disabling it.",
+            model_type,
+        )
+        scheduler_config.enable_chunked_prefill = False
+
+        max_num_batched_tokens = scheduler_config.max_num_batched_tokens
+        max_model_len = model_config.max_model_len
+        if max_num_batched_tokens < max_model_len:
+            logger.warning(
+                "`max_num_batched_tokens=%d < max_model_len=%d` with "
+                "chunked prefill "
+                "disabled, bumping `max_num_batched_tokens` to match.",
+                max_num_batched_tokens,
+                max_model_len,
             )
-            scheduler_config.enable_chunked_prefill = False
 
-            max_num_batched_tokens = scheduler_config.max_num_batched_tokens
-            max_model_len = model_config.max_model_len
-            if max_num_batched_tokens < max_model_len:
-                logger.warning(
-                    "`max_num_batched_tokens=%d < max_model_len=%d` with "
-                    "chunked prefill "
-                    "disabled, bumping `max_num_batched_tokens` to match.",
-                    max_num_batched_tokens,
-                    max_model_len,
-                )
+            scheduler_config.max_num_batched_tokens = max_model_len
 
-                scheduler_config.max_num_batched_tokens = max_model_len
-
-        # The scheduler applies this threshold before checking
-        # ``enable_chunked_prefill``. Leaving it nonzero can still split a
-        # prefill despite the disabled flag.
-        scheduler_config.long_prefill_token_threshold = 0
+    # The scheduler applies this threshold before checking
+    # ``enable_chunked_prefill``. Leaving it nonzero can still split a
+    # prefill despite the disabled flag.
+    scheduler_config.long_prefill_token_threshold = 0
 
 
 def _galaxy_generator_version() -> str | None:
@@ -574,8 +581,6 @@ class TTPlatform(Platform):
     def check_and_update_config(cls, vllm_config: "VllmConfig") -> None:
         _install_tt_harmony_truncation_patch()
         _apply_chunked_prefill_policy(vllm_config)
-
-        vllm_config.scheduler_config.disable_chunked_mm_input = True
 
         assert not vllm_config.speculative_config, (
             "Speculative decoding is not yet supported for TT backend"

--- a/plugins/vllm-tt-plugin/tests/test_chunked_prefill_policy.py
+++ b/plugins/vllm-tt-plugin/tests/test_chunked_prefill_policy.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Which model types keep token-chunked prefill, and what is forced off."""
+
+from types import SimpleNamespace
+
+# Importing the platform module reenters vLLM's platform-plugin bootstrap, which
+# resolves against a half-built ``vllm`` and fails unless vLLM has already
+# finished importing itself. This import has to stay first.
+import vllm  # noqa: F401  # isort: skip
+
+from vllm_tt_plugin.platform import _apply_chunked_prefill_policy
+
+
+def _vllm_config(
+    *,
+    model_type: str,
+    enable_chunked_prefill: bool = True,
+    max_num_batched_tokens: int = 2048,
+    max_model_len: int = 16384,
+    long_prefill_token_threshold: int = 512,
+):
+    return SimpleNamespace(
+        scheduler_config=SimpleNamespace(
+            enable_chunked_prefill=enable_chunked_prefill,
+            max_num_batched_tokens=max_num_batched_tokens,
+            long_prefill_token_threshold=long_prefill_token_threshold,
+            disable_chunked_mm_input=False,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type=model_type),
+            max_model_len=max_model_len,
+        ),
+    )
+
+
+def test_gemma4_keeps_chunked_prefill_and_its_token_budget():
+    config = _vllm_config(model_type="gemma4")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+    assert config.scheduler_config.long_prefill_token_threshold == 512
+    assert config.scheduler_config.disable_chunked_mm_input is True
+
+
+def test_unified_gemma4_checkpoint_also_keeps_chunked_prefill():
+    config = _vllm_config(model_type="gemma4_unified")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is True
+
+
+def test_other_model_type_loses_chunked_prefill_and_gets_a_full_prompt_budget():
+    config = _vllm_config(model_type="llama")
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.max_num_batched_tokens == 16384
+
+
+def test_unsplit_prefill_leaves_chunked_mm_input_enabled():
+    # vLLM raises outright when this is set and one mm item is larger than
+    # max_num_batched_tokens, e.g. a VL model pinned to a short max_model_len.
+    # With prefill never split the flag is inert, so it must stay off.
+    config = _vllm_config(
+        model_type="qwen2_5_vl", max_num_batched_tokens=2048, max_model_len=2048
+    )
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.enable_chunked_prefill is False
+    assert config.scheduler_config.disable_chunked_mm_input is False
+
+
+def test_other_model_type_zeroes_the_long_prefill_threshold():
+    # The base scheduler applies this cap before it consults
+    # enable_chunked_prefill, so leaving it set would still split a prefill.
+    config = _vllm_config(model_type="llama", enable_chunked_prefill=False)
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.long_prefill_token_threshold == 0
+    # Chunked prefill was already off, so the token budget is left alone.
+    assert config.scheduler_config.max_num_batched_tokens == 2048
+
+
+def test_token_budget_is_left_alone_when_it_already_covers_the_model_len():
+    config = _vllm_config(model_type="llama", max_num_batched_tokens=32768)
+
+    _apply_chunked_prefill_policy(config)
+
+    assert config.scheduler_config.max_num_batched_tokens == 32768


### PR DESCRIPTION
Port of [vllm-tt-plugin#34](https://github.com/tenstorrent/vllm-tt-plugin/pull/34) (commit `c93b485`) to the in-tree plugin copy. Not yet fixed on `dev`.

## Problem

`TTPlatform.check_and_update_config` set `scheduler_config.disable_chunked_mm_input = True` for every model. vLLM validates that flag unconditionally and raises when a single mm item is larger than `max_num_batched_tokens`:

https://github.com/tenstorrent/vllm/blob/dev/vllm/v1/core/encoder_cache_manager.py#L298-L307

That is exactly a VL model on a short `max_model_len`: Qwen2.5-VL-72B at `max_model_len=2048` has a 16384-token image, so the server refused to start.

## Fix

The flag only does work while a prefill can be split: the scheduler consults it solely to roll back a scheduled range that would land inside an mm item. With chunked prefill off and `long_prefill_token_threshold=0` the whole prompt is scheduled in one piece, so the flag is inert and only its validation can fire. It is now set only for the model types that keep chunked prefill (`gemma4`, `gemma4_unified`); every other model type leaves it at whatever the user passed.

The non-chunking branch is de-indented behind an early return to match the plugin-repo shape, which keeps the two copies easy to diff. No behavior change in that branch.

## Test

New `plugins/vllm-tt-plugin/tests/test_chunked_prefill_policy.py` (ported from the plugin repo, which had no counterpart here) covers the gemma4 and non-chunking cases. Host-only, no device.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/31607905073

🤖 Generated with [Claude Code](https://claude.com/claude-code)