### PR TITLE
Accept FABRIC_2D_TORUS_XY and default BH Galaxy to 2D torus

### DIFF
--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -171,7 +171,7 @@ or a mesh shape such as `"(4,8)"`, then pass `--model`:
 For Llama 3.1 8B on N150, set `--max_model_len 32768`; see the tt-metal model
 demo for context-length details.
 
-To run Llama 70B on Galaxy:
+To run Llama 70B on Wormhole Galaxy:
 
 ```bash
 MESH_DEVICE=TG \
@@ -179,18 +179,30 @@ LLAMA_DIR=<path-to-weights> \
 TT_LLAMA_TEXT_VER=llama3_70b_galaxy \
 python plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
   --model "meta-llama/Llama-3.1-70B-Instruct" \
-  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1344544, "trace_region_size": 216580672}}'
 ```
 
-To run GPT-OSS 20B on Galaxy:
+To run GPT-OSS 20B on Wormhole Galaxy:
 
 ```bash
 MESH_DEVICE="(4,8)" \
 python plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
   --model "openai/gpt-oss-20b" \
-  --max_seqs_in_batch 1 \
-  --additional-config '{"tt": {"fabric_config": "FABRIC_1D_RING"}}'
+  --max_seqs_in_batch 1
 ```
+
+To run Qwen3-32B on Blackhole Galaxy:
+
+```bash
+MESH_DEVICE=TG \
+TT_QWEN3_TEXT_VER=qwen3_32b_galaxy \
+python plugins/vllm-tt-plugin/examples/offline_inference_tt.py \
+  --model "Qwen/Qwen3-32B" \
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1345000, "trace_region_size": 184915840}}'
+```
+
+Wormhole Galaxy defaults to `FABRIC_1D_RING` and Blackhole Galaxy defaults to
+`FABRIC_2D_TORUS_XY`, so those recipes do not need an explicit `fabric_config`.
 
 Run Llama 3.2 Vision on N300:
 
@@ -269,7 +281,7 @@ Common options:
 | `trace_region_size` | Trace region size for TT runtime tracing. |
 | `worker_l1_size` | Worker L1 size override. |
 | `l1_small_size` | Small L1 size override. |
-| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, `FABRIC_2D_TORUS_XY`, or `CUSTOM`. Any `ttnn.FabricConfig` name is accepted. |
+| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, `FABRIC_2D_TORUS_XY`, or `CUSTOM`. Any `ttnn.FabricConfig` name is accepted. Defaults: Wormhole Galaxy `FABRIC_1D_RING`, Blackhole Galaxy `FABRIC_2D_TORUS_XY`, other multi-device `FABRIC_1D`. |
 | `fabric_reliability_mode` | Fabric reliability mode, such as `STRICT_INIT` or `RELAXED_INIT`. |
 | `dispatch_core_axis` | Dispatch core axis, `row` or `col`. |
 | `always_compat_sampling` | Use vLLM's LogitProcessor and sampler path even when not required by the batch. Default: `false`. |
@@ -325,7 +337,7 @@ lanes.
 
 Serve them with the familiar `--data_parallel_size N --max_num_seqs M` flags;
 the TT backend transparently maps them to `N` in-process lanes. No config
-changes are needed:
+changes are needed. Wormhole Galaxy example (fabric defaults to `FABRIC_1D_RING`):
 
 ```bash
 MESH_DEVICE=TG \
@@ -336,7 +348,7 @@ python plugins/vllm-tt-plugin/examples/server_example_tt.py \
   --data_parallel_size 4 \
   --max_num_seqs 8 \
   --async-scheduling \
-  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "fabric_config": "FABRIC_1D_RING", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
+  --additional-config '{"tt": {"dispatch_core_axis": "col", "sample_on_device_mode": "all", "worker_l1_size": 1344544, "trace_region_size": 220000000}}'
 ```
 
 `--data_parallel_size 4 --max_num_seqs 8` runs `4` TT lanes of `8` requests

--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -269,7 +269,7 @@ Common options:
 | `trace_region_size` | Trace region size for TT runtime tracing. |
 | `worker_l1_size` | Worker L1 size override. |
 | `l1_small_size` | Small L1 size override. |
-| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, or `CUSTOM`. |
+| `fabric_config` | Fabric config such as `DISABLED`, `FABRIC_1D`, `FABRIC_2D`, `FABRIC_1D_RING`, `FABRIC_2D_TORUS_XY`, or `CUSTOM`. Any `ttnn.FabricConfig` name is accepted. |
 | `fabric_reliability_mode` | Fabric reliability mode, such as `STRICT_INIT` or `RELAXED_INIT`. |
 | `dispatch_core_axis` | Dispatch core axis, `row` or `col`. |
 | `always_compat_sampling` | Use vLLM's LogitProcessor and sampler path even when not required by the batch. Default: `false`. |

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -628,10 +628,6 @@ def get_dispatch_core_config(tt_config):
     return ttnn.DispatchCoreConfig(axis=dispatch_core_axis)
 
 
-def _fabric_config_names():
-    return [name for name in dir(ttnn.FabricConfig) if name[0].isupper()]
-
-
 def get_fabric_config(tt_config, num_devices):
     if num_devices == 1:
         # No fabric config for single device
@@ -652,10 +648,10 @@ def get_fabric_config(tt_config, num_devices):
     # work without a plugin allow-list update.
     if tt_config is not None and "fabric_config" in tt_config:
         fabric_config_str = tt_config["fabric_config"]
-        fabric_config = getattr(ttnn.FabricConfig, fabric_config_str, None)
+        fabric_config = ttnn.FabricConfig.__members__.get(fabric_config_str)
         assert fabric_config is not None, (
             f"Invalid fabric_config: {fabric_config_str}. "
-            f"Expected one of {_fabric_config_names()}."
+            f"Expected one of {list(ttnn.FabricConfig.__members__)}."
         )
     return fabric_config
 

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/worker.py
@@ -628,31 +628,34 @@ def get_dispatch_core_config(tt_config):
     return ttnn.DispatchCoreConfig(axis=dispatch_core_axis)
 
 
+def _fabric_config_names():
+    return [name for name in dir(ttnn.FabricConfig) if name[0].isupper()]
+
+
 def get_fabric_config(tt_config, num_devices):
     if num_devices == 1:
         # No fabric config for single device
         fabric_config = None
     else:
-        # Set the most common value as default
-        is_6u = ttnn.cluster.get_cluster_type() == ttnn.cluster.ClusterType.GALAXY
-        fabric_config = (
-            ttnn.FabricConfig.FABRIC_1D_RING if is_6u else ttnn.FabricConfig.FABRIC_1D
-        )
+        # Wormhole Galaxy (6U) uses a 1D ring. Blackhole Galaxy needs a 2D torus:
+        # column-axis collectives have no wraparound path on 1D fabrics.
+        cluster_type = ttnn.cluster.get_cluster_type()
+        if cluster_type == ttnn.cluster.ClusterType.BLACKHOLE_GALAXY:
+            fabric_config = ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+        elif cluster_type == ttnn.cluster.ClusterType.GALAXY:
+            fabric_config = ttnn.FabricConfig.FABRIC_1D_RING
+        else:
+            fabric_config = ttnn.FabricConfig.FABRIC_1D
 
-    # Override fabric_config if specified in TT plugin config.
+    # Override fabric_config if specified in TT plugin config. Resolve the name
+    # from ttnn.FabricConfig so newly added fabrics (e.g. FABRIC_2D_TORUS_XY)
+    # work without a plugin allow-list update.
     if tt_config is not None and "fabric_config" in tt_config:
         fabric_config_str = tt_config["fabric_config"]
-        fabric_config_map = {
-            "DISABLED": ttnn.FabricConfig.DISABLED,
-            "FABRIC_1D": ttnn.FabricConfig.FABRIC_1D,
-            "FABRIC_1D_RING": ttnn.FabricConfig.FABRIC_1D_RING,
-            "FABRIC_2D": ttnn.FabricConfig.FABRIC_2D,
-            "CUSTOM": ttnn.FabricConfig.CUSTOM,
-        }
-        fabric_config = fabric_config_map.get(fabric_config_str)
+        fabric_config = getattr(ttnn.FabricConfig, fabric_config_str, None)
         assert fabric_config is not None, (
             f"Invalid fabric_config: {fabric_config_str}. "
-            f"Expected one of {list(fabric_config_map.keys())}."
+            f"Expected one of {_fabric_config_names()}."
         )
     return fabric_config
 


### PR DESCRIPTION
## Purpose

Add Blackhole Galaxy 2D-torus fabric support to the TT plugin. BH Galaxy column-axis collectives need a 2D torus, but the plugin's hardcoded fabric allow-list rejected it:

```
AssertionError: Invalid fabric_config: FABRIC_2D_TORUS_XY.
```

- Default `BLACKHOLE_GALAXY` to `FABRIC_2D_TORUS_XY` (Wormhole Galaxy stays on `FABRIC_1D_RING`).
- Resolve `fabric_config` names via `ttnn.FabricConfig.__members__` instead of a hardcoded dict, so any fabric enum works without plugin updates.

## Test Plan

- [ ] BH Galaxy: default fabric resolves to `FABRIC_2D_TORUS_XY` (no override needed)
- [ ] Explicit `--additional-config '{"tt": {"fabric_config": "FABRIC_2D_TORUS_XY"}}'` accepted
- [ ] WH Galaxy default remains `FABRIC_1D_RING`

## Test Result

Name resolution verified against `ttnn.FabricConfig` (valid names resolve, invalid names still assert). Same change previously used for BH Galaxy Qwen3-32B vLLM bring-up.