### PR TITLE
Place the streaming reasoning boundary from text, not token ids

### DIFF
--- a/tests/reasoning/test_qwen3_boundary.py
+++ b/tests/reasoning/test_qwen3_boundary.py
@@ -1,0 +1,136 @@
+"""Device-free reproduction of the streaming reasoning->content boundary bug.
+
+Traces taken verbatim from Qwen3-32B on wh-glx6u-08 with --reasoning-parser
+qwen3. The recorded CONTENT deltas were:
+
+    ['r.', '\\n</think', '>{', '"l', 'ocatio', 'n"']
+
+i.e. the tail of the reasoning ('r.') and the marker itself both leaked into
+content, so response_format=json_object content did not parse as JSON.
+
+The cause is that the token id for </think> lands while the text for it -- and
+for the reasoning before it -- is still buffered in the detokenizer. Keying the
+boundary off `end_token_id in previous_token_ids` therefore flips to content
+mode early. These tests encode that lag explicitly: the end token id is placed
+in an EARLIER delta than the text it renders to.
+
+Run: pytest test_qwen3_boundary.py -v
+"""
+
+import pytest
+
+from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+
+END_ID = 2
+TOOL_ID = 3
+PLAIN = 9
+
+
+class _Tok:
+    def __init__(self):
+        self.vocab = {"<think>": 1, "</think>": END_ID,
+                      "<tool_call>": TOOL_ID, "</tool_call>": 4}
+
+    def get_vocab(self):
+        return self.vocab
+
+
+def _drive(deltas_with_ids):
+    """Feed (text, ids) deltas; return accumulated (reasoning, content)."""
+    parser = Qwen3ReasoningParser(_Tok())
+    prev_text, prev_ids = "", []
+    reasoning, content = "", ""
+    for text, ids in deltas_with_ids:
+        msg = parser.extract_reasoning_streaming(
+            previous_text=prev_text,
+            current_text=prev_text + text,
+            delta_text=text,
+            previous_token_ids=list(prev_ids),
+            current_token_ids=list(prev_ids) + list(ids),
+            delta_token_ids=list(ids),
+        )
+        if msg is not None:
+            if getattr(msg, "reasoning", None):
+                reasoning += msg.reasoning
+            if getattr(msg, "content", None):
+                content += msg.content
+        prev_text += text
+        prev_ids += list(ids)
+    return reasoning, content
+
+
+def test_id_lag_does_not_leak_reasoning_or_marker():
+    """The exact hardware trace: id for </think> arrives before its text."""
+    deltas = [
+        ("Let me check the weathe", [PLAIN]),
+        ("r.", [END_ID]),          # <-- id lands here, text still buffered
+        ("\n</think", [PLAIN]),
+        ('>{"location":"Boston"}', [PLAIN]),
+    ]
+    reasoning, content = _drive(deltas)
+
+    assert "</think" not in content, "marker leaked into content: %r" % content
+    assert "r." not in content, "reasoning tail leaked into content: %r" % content
+    assert content == '{"location":"Boston"}', content
+    assert reasoning == "Let me check the weather.\n", repr(reasoning)
+
+
+def test_marker_split_across_deltas():
+    deltas = [
+        ("thinking hard</thi", [END_ID]),
+        ('nk>{"a": 1}', [PLAIN]),
+    ]
+    reasoning, content = _drive(deltas)
+    assert "nk>" not in content, content
+    assert content == '{"a": 1}', content
+    assert reasoning == "thinking hard", repr(reasoning)
+
+
+def test_marker_whole_in_one_delta():
+    deltas = [
+        ("reasoning", [PLAIN]),
+        ('</think>{"a": 1}', [END_ID]),
+    ]
+    reasoning, content = _drive(deltas)
+    assert content == '{"a": 1}', content
+    assert reasoning == "reasoning", repr(reasoning)
+
+
+def test_content_keeps_streaming_after_marker():
+    deltas = [
+        ("r", [PLAIN]),
+        ('</think>{"a"', [END_ID]),
+        (": 1}", [PLAIN]),
+    ]
+    reasoning, content = _drive(deltas)
+    assert content == '{"a": 1}', content
+
+
+def test_tool_call_tag_ends_reasoning_and_stays_in_content():
+    deltas = [
+        ("I should call it", [PLAIN]),
+        ('<tool_call>{"name": "x"}', [TOOL_ID]),
+    ]
+    reasoning, content = _drive(deltas)
+    assert content == '<tool_call>{"name": "x"}', content
+    assert reasoning == "I should call it", repr(reasoning)
+
+
+def test_no_marker_is_all_reasoning():
+    deltas = [("still thinking", [PLAIN]), (" and thinking", [PLAIN])]
+    reasoning, content = _drive(deltas)
+    assert content == "", content
+    assert reasoning == "still thinking and thinking", repr(reasoning)
+
+
+@pytest.mark.parametrize("split_at", list(range(1, 8)))
+def test_every_split_point_of_the_marker(split_at):
+    """</think> chunked at every possible boundary must never leak."""
+    marker = "</think>"
+    deltas = [
+        ("why" + marker[:split_at], [END_ID]),
+        (marker[split_at:] + '{"k": 1}', [PLAIN]),
+    ]
+    reasoning, content = _drive(deltas)
+    assert content == '{"k": 1}', "split_at=%d content=%r" % (split_at, content)
+    assert reasoning == "why", "split_at=%d reasoning=%r" % (split_at, reasoning)

--- a/tests/reasoning/test_qwen3_split_marker.py
+++ b/tests/reasoning/test_qwen3_split_marker.py
@@ -1,0 +1,98 @@
+"""Reproduce the streaming </think> leak with a split delta boundary.
+
+test_streaming_json_object_no_reasoning_leak fails because the literal </think>
+tag reaches `content`, so the accumulated content is not valid JSON. The parser
+is pure Python, so the boundary case can be reproduced with no device and no
+model: feed deltas that split "</think>" across a chunk boundary, exactly as the
+detokenizer's stop-string buffering does.
+
+Run: pytest test_qwen3_split_marker.py -v
+"""
+
+import pytest
+
+from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+
+
+class _Tok:
+    """Minimal tokenizer stub: the parser only needs a vocab lookup."""
+
+    def __init__(self):
+        self.vocab = {"<think>": 1, "</think>": 2, "<tool_call>": 3, "</tool_call>": 4}
+
+    def get_vocab(self):
+        return self.vocab
+
+
+def _parser():
+    p = Qwen3ReasoningParser(_Tok())
+    return p
+
+
+def _drive(parser, deltas, ids_for):
+    """Feed deltas in order, accumulating reasoning/content like the server does."""
+    prev_text = ""
+    prev_ids: list[int] = []
+    reasoning, content = "", ""
+    for d in deltas:
+        ids = ids_for(d)
+        msg = parser.extract_reasoning_streaming(
+            previous_text=prev_text,
+            current_text=prev_text + d,
+            delta_text=d,
+            previous_token_ids=list(prev_ids),
+            current_token_ids=list(prev_ids) + ids,
+            delta_token_ids=ids,
+        )
+        if msg is not None:
+            if getattr(msg, "reasoning", None):
+                reasoning += msg.reasoning
+            if getattr(msg, "content", None):
+                content += msg.content
+        prev_text += d
+        prev_ids += ids
+    return reasoning, content
+
+
+def test_marker_whole_in_one_delta_is_clean():
+    """Baseline: when </think> arrives intact, content is clean JSON."""
+    p = _parser()
+    deltas = ["thinking hard", '</think>{"a": 1}']
+    ids_for = lambda d: [2] if "</think>" in d else [9]  # noqa: E731
+    reasoning, content = _drive(p, deltas, ids_for)
+    assert "</think>" not in content, content
+    assert content == '{"a": 1}', content
+
+
+def test_marker_split_across_deltas_must_not_leak():
+    """The failing case: detokenizer splits "</think>" across two deltas.
+
+    The tag's head arrives in one chunk and its tail in the next, with the end
+    TOKEN ID already consumed. The tail must not be emitted as content.
+    """
+    p = _parser()
+    # "</thi" then "nk>" -- the id lands with the first fragment
+    deltas = ["thinking hard</thi", 'nk>{"a": 1}']
+    ids_for = lambda d: [2] if d.endswith("</thi") else [9]  # noqa: E731
+    reasoning, content = _drive(p, deltas, ids_for)
+    assert "nk>" not in content, "leaked tag tail into content: %r" % content
+    assert "</think>" not in content, content
+    assert content == '{"a": 1}', "content must be clean JSON, got %r" % content
+
+
+def test_marker_split_three_ways_must_not_leak():
+    p = _parser()
+    deltas = ["reasoning", "</", "think>", '{"b": 2}']
+    ids_for = lambda d: [2] if d == "</" else [9]  # noqa: E731
+    reasoning, content = _drive(p, deltas, ids_for)
+    assert "think>" not in content, "leaked into content: %r" % content
+    assert content == '{"b": 2}', content
+
+
+def test_content_after_marker_still_flows():
+    """Regression guard: normal content after the marker keeps streaming."""
+    p = _parser()
+    deltas = ["r", '</think>{"a"', ": 1}"]
+    ids_for = lambda d: [2] if "</think>" in d else [9]  # noqa: E731
+    reasoning, content = _drive(p, deltas, ids_for)
+    assert content == '{"a": 1}', content

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -158,6 +158,53 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         # Everything generated so far is reasoning.
         return model_output, None
 
+    def _split_reasoning_content(self, text: str) -> tuple[str, str]:
+        """Split accumulated model output into ``(reasoning, content)``.
+
+        Pure function of TEXT. Deliberately ignores token ids: the id stream
+        runs ahead of the detokenizer, so using ids to place the boundary
+        emits still-buffered reasoning as content.
+
+        Reasoning ends at whichever marker comes first:
+          * ``</think>``    -- consumed, never emitted
+          * ``<tool_call>`` -- retained, it belongs to content
+
+        Until a marker is complete, a trailing PREFIX of one is withheld, so a
+        marker split across deltas (``'\\n</think'`` + ``'>'``) is never
+        emitted piecemeal.
+        """
+        # Old template / edge case: the model emits <think> itself.
+        if self.start_token in text:
+            text = text.split(self.start_token, 1)[1]
+
+        markers = [self.end_token]
+        if self._tool_call_token_id is not None:
+            markers.append(self._tool_call_tag)
+
+        end_index = text.find(self.end_token)
+        tool_index = (
+            text.find(self._tool_call_tag)
+            if self._tool_call_token_id is not None
+            else -1
+        )
+
+        if end_index >= 0 and (tool_index < 0 or end_index < tool_index):
+            # </think> is consumed: it is neither reasoning nor content.
+            return text[:end_index], text[end_index + len(self.end_token) :]
+        if tool_index >= 0:
+            # <tool_call> stays in content for the tool parser to pick up.
+            return text[:tool_index], text[tool_index:]
+
+        # No complete marker yet. Withhold any trailing partial marker so it is
+        # not emitted as reasoning and then again as part of the marker.
+        hold = 0
+        for marker in markers:
+            for k in range(min(len(marker) - 1, len(text)), 0, -1):
+                if text.endswith(marker[:k]):
+                    hold = max(hold, k)
+                    break
+        return (text[: len(text) - hold] if hold else text), ""
+
     def extract_reasoning_streaming(
         self,
         previous_text: str,
@@ -179,60 +226,34 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         prompt_is_reasoning_end and routes deltas as content without
         calling this method.
         """
-        # Strip <think> from delta if present (old template / edge case
-        # where the model generates <think> itself).
-        if self.start_token_id in delta_token_ids:
-            start_idx = delta_text.find(self.start_token)
-            if start_idx >= 0:
-                delta_text = delta_text[start_idx + len(self.start_token) :]
-
-        # Cherrypick of https://github.com/vllm-project/vllm/pull/38864
-        # Stop-string buffering can delay the visible text for </think> until a
-        # later chunk, so detect the end marker from text first rather than
-        # relying solely on the token ids from the current delta.
-        end_index = delta_text.find(self.end_token)
-        if end_index >= 0:
-            reasoning = delta_text[:end_index]
-            content = delta_text[end_index + len(self.end_token) :]
-            if not reasoning and not content:
-                return None
-            return DeltaMessage(
-                reasoning=reasoning if reasoning else None,
-                content=content if content else None,
-            )
-
         if self.end_token_id in delta_token_ids and not delta_text:
             # End token in IDs but not in visible text yet. Wait for the
             # detokenizer to flush the buffered text in a later chunk.
             return None
 
-        # Implicit reasoning end via <tool_call>.
-        if (
-            self._tool_call_token_id is not None
-            and self._tool_call_token_id in delta_token_ids
-        ):
-            tool_index = delta_text.find(self._tool_call_tag)
-            if tool_index >= 0:
-                reasoning = delta_text[:tool_index]
-                content = delta_text[tool_index:]
-                return DeltaMessage(
-                    reasoning=reasoning if reasoning else None,
-                    content=content if content else None,
-                )
+        # Place the boundary from TEXT ONLY.
+        #
+        # The previous implementation keyed off
+        #   `self.end_token_id in previous_token_ids`
+        # but the id stream runs AHEAD of the detokenized text, so that flips to
+        # content mode while the reasoning tail and the marker itself are still
+        # buffered -- emitting both as content and breaking
+        # response_format=json_object, whose content must parse as JSON.
+        #
+        # _split_reasoning_content() is a pure function of the accumulated text,
+        # so emitting the difference between the split of previous_text and the
+        # split of previous_text + delta_text is monotonic by construction and
+        # can never emit marker text, however the marker is chunked.
+        prev_reasoning, prev_content = self._split_reasoning_content(previous_text)
+        cur_reasoning, cur_content = self._split_reasoning_content(
+            previous_text + delta_text
+        )
+        reasoning = cur_reasoning[len(prev_reasoning) :]
+        content = cur_content[len(prev_content) :]
 
-        # No end token in this delta.
-        if not delta_text:
-            # Nothing left after stripping start token.
+        if not reasoning and not content:
             return None
-        # Cherrypick of https://github.com/vllm-project/vllm/pull/38864
-        elif self.end_token_id in previous_token_ids or self.end_token in previous_text:
-            # End token already passed: everything is content now.
-            return DeltaMessage(content=delta_text)
-        elif (
-            self._tool_call_token_id is not None
-            and self._tool_call_token_id in previous_token_ids
-        ):
-            return DeltaMessage(content=delta_text)
-        else:
-            # No end token yet: still in reasoning phase.
-            return DeltaMessage(reasoning=delta_text)
+        return DeltaMessage(
+            reasoning=reasoning if reasoning else None,
+            content=content if content else None,
+        )


### PR DESCRIPTION
## Description

Method extract_reasoning_streaming decided its reasoning->content boundary from token ids:

    elif self.end_token_id in previous_token_ids or self.end_token in previous_text:
        return DeltaMessage(content=delta_text)

The issue is that id stream runs ahead of the detokenized text. The id for </think> lands while the text for it, and for the reasoning that precedes it, is still buffered. Once that id is seen, every later delta is forced to content, so still-buffered REASONING is emitted as content.

Observed on Qwen3-32B (TT Galaxy, --reasoning-parser qwen3), content deltas:

    ['r.', '\n</think', '>{', '"l', 'ocatio', 'n"']
      ^^^                ^^^^^^^^
      reasoning tail     the marker itself

Both cases leak, so response_format=json_object content does not parse as JSON. In our case test "test_streaming_json_object_no_reasoning_leak" failed 4/4 with think_leak='</think>'. The same boundary error also dropped tool calls: after a <think> block the <tool_call> tag could be routed to reasoning, where the tool parser never sees it, and the stream ended with finish_reason='stop' and an empty tool_calls array (3/20 runs).

Fix in two steps, both in this commit:

1. Search the ACCUMULATED text for the end marker rather than only the current delta, so a </think> split across deltas ('\n</think' + '>') is detected at all. This removes the tail leak but is NOT sufficient on its own -- it cannot undo a boundary decision the id check already made, so the marker head and the reasoning tail still leaked (4/4 -> still failing, think_leak='</think').

2. Place the boundary from TEXT ONLY. _split_reasoning_content() is a pure function of the accumulated output; emitting the difference between the split of previous_text and the split of previous_text + delta_text is monotonic by construction and can never emit marker text, however the marker is chunked. A trailing PREFIX of a marker is withheld until it resolves. <tool_call> keeps its existing meaning: it ends reasoning and stays in content.

The boundary now requires the marker to appear in the text. The "id present, no text yet" case still returns None and waits for the detokenizer to flush, which is the observed behaviour; a marker whose text were suppressed entirely would leave the output classified as reasoning.

tests/reasoning/test_qwen3_boundary.py encodes the hardware trace directly, including the id lag (the end token id is placed in an EARLIER delta than the text it renders to), every one of the 7 split points of "</think>", the tool_call path, and the no-marker case. test_qwen3_split_marker.py covers the split-delta cases from step 1.

  test_qwen3_boundary.py        before: 9 failed, 4 passed   after: 13 passed
  test_qwen3_split_marker.py                                 after:  4 passed
  test_qwen3_reasoning_parser.py (existing)                        84 passed

Verified end to end on Qwen3-32B / TT Galaxy with the reasoning and tool-call parsers enabled:

  test_streaming_json_object_no_reasoning_leak   PASS  (was 4/4 leaking)
  test_streaming_json_schema_no_reasoning_leak   PASS
  test_streaming_tool_call_with_thinking         PASS 20/20  (was 3/20 dropped)

and across 4 full spec_tests cycles: 25 passed, 0 failed, 0 skipped each.

## Purpose
Fix Qwen3 parser with correct reasoning token split logic.


## Test Plan

## Test Result
CI run: TODO
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

