### PR TITLE
[fix] Prevent gathered-DP prefill livelock.

### DIFF
--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -365,12 +365,13 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             not request.is_prefill_chunk
             for request in getattr(self.scheduler, "running", [])
         )
-        progress_t = torch.tensor([local_tokens], dtype=torch.int32)
-        dist.all_reduce(progress_t, op=dist.ReduceOp.SUM, group=self.dp_group)
-        decode_t = torch.tensor([int(local_has_decode)], dtype=torch.int32)
-        dist.all_reduce(decode_t, op=dist.ReduceOp.MAX, group=self.dp_group)
+        # Both quantities are non-negative, so a single SUM answers both:
+        # zero total tokens, and zero iff no rank has a running decode.
+        probe_t = torch.tensor([local_tokens, int(local_has_decode)], dtype=torch.int32)
+        dist.all_reduce(probe_t, op=dist.ReduceOp.SUM, group=self.dp_group)
+        global_tokens, ranks_with_decode = (int(v) for v in probe_t.tolist())
 
-        if progress_t.item() != 0 or decode_t.item() == 0:
+        if global_tokens != 0 or ranks_with_decode == 0:
             return scheduler_output
 
         self._dp_gather_forced_mode = TTSchedulingMode.DECODE_ONLY

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -350,6 +350,43 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
         if callable(set_mode):
             set_mode(forced_mode)
 
+    def _dp_schedule_with_zero_prefill_fallback(
+        self,
+        forced_mode: TTSchedulingMode,
+        scheduler_output: SchedulerOutput | None,
+    ) -> SchedulerOutput | None:
+        if forced_mode != TTSchedulingMode.PREFILL_ONLY:
+            return scheduler_output
+
+        local_tokens = (
+            scheduler_output.total_num_scheduled_tokens if scheduler_output else 0
+        )
+        local_has_decode = any(
+            not request.is_prefill_chunk
+            for request in getattr(self.scheduler, "running", [])
+        )
+        progress_t = torch.tensor([local_tokens], dtype=torch.int32)
+        dist.all_reduce(progress_t, op=dist.ReduceOp.SUM, group=self.dp_group)
+        decode_t = torch.tensor([int(local_has_decode)], dtype=torch.int32)
+        dist.all_reduce(decode_t, op=dist.ReduceOp.MAX, group=self.dp_group)
+
+        if progress_t.item() != 0 or decode_t.item() == 0:
+            return scheduler_output
+
+        self._dp_gather_forced_mode = TTSchedulingMode.DECODE_ONLY
+        self._dp_apply_forced_mode(TTSchedulingMode.DECODE_ONLY)
+        decode_output = (
+            self.scheduler.schedule() if self.scheduler.has_requests() else None
+        )
+        if scheduler_output is not None and decode_output is not None:
+            decode_output.finished_req_ids |= scheduler_output.finished_req_ids
+            decode_output.free_encoder_mm_hashes = (
+                scheduler_output.free_encoder_mm_hashes
+                + decode_output.free_encoder_mm_hashes
+            )
+
+        return decode_output
+
     def step(self) -> tuple[dict[int, EngineCoreOutputs], bool]:
         if self._scheduler_paused:
             return {}, False
@@ -358,13 +395,16 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             return {}, False
 
         forced_mode = self._dp_negotiate_forced_mode()
-        if not self.scheduler.has_requests():
+        has_local_requests = self.scheduler.has_requests()
+        self._dp_apply_forced_mode(forced_mode)
+        scheduler_output = self.scheduler.schedule() if has_local_requests else None
+        scheduler_output = self._dp_schedule_with_zero_prefill_fallback(
+            forced_mode, scheduler_output
+        )
+        self._dp_apply_forced_mode(TTSchedulingMode.DEFAULT)
+        if not has_local_requests:
             _ = self._execute_model_dp_gather(None, None)
             return {}, False
-
-        self._dp_apply_forced_mode(forced_mode)
-        scheduler_output = self.scheduler.schedule()
-        self._dp_apply_forced_mode(TTSchedulingMode.DEFAULT)
 
         grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
         model_output = self._execute_model_dp_gather(scheduler_output, grammar_output)
@@ -394,7 +434,12 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
             if self.scheduler.has_requests():
                 self._dp_apply_forced_mode(forced_mode)
                 scheduler_output = self.scheduler.schedule()
-                self._dp_apply_forced_mode(TTSchedulingMode.DEFAULT)
+            scheduler_output = self._dp_schedule_with_zero_prefill_fallback(
+                forced_mode, scheduler_output
+            )
+            forced_mode = self._dp_gather_forced_mode
+            self._dp_apply_forced_mode(TTSchedulingMode.DEFAULT)
+            if scheduler_output is not None:
                 if not self.is_ec_producer:
                     model_executed = scheduler_output.total_num_scheduled_tokens > 0
                 if not scheduler_output.pending_structured_output_tokens:

--- a/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
+++ b/plugins/vllm-tt-plugin/src/vllm_tt_plugin/engine.py
@@ -375,10 +375,16 @@ class TTDPEngineCoreProc(DPEngineCoreProc):
 
         self._dp_gather_forced_mode = TTSchedulingMode.DECODE_ONLY
         self._dp_apply_forced_mode(TTSchedulingMode.DECODE_ONLY)
+
         decode_output = (
-            self.scheduler.schedule() if self.scheduler.has_requests() else None
+            self.scheduler.schedule()
+            if self.scheduler.has_unfinished_requests()
+            else None
         )
-        if scheduler_output is not None and decode_output is not None:
+        if decode_output is None:
+            return scheduler_output
+
+        if scheduler_output is not None:
             decode_output.finished_req_ids |= scheduler_output.finished_req_ids
             decode_output.free_encoder_mm_hashes = (
                 scheduler_output.free_encoder_mm_hashes

--- a/plugins/vllm-tt-plugin/tests/test_dp_engine.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_engine.py
@@ -49,7 +49,7 @@ def test_dp_zero_prefill_falls_back_collectively(monkeypatch):
     decode_output.total_num_scheduled_tokens = 2
     scheduler = SimpleNamespace(
         running=[SimpleNamespace(is_prefill_chunk=False)],
-        has_requests=lambda: True,
+        has_unfinished_requests=lambda: True,
         schedule=lambda: decode_output,
         set_forced_mode=lambda mode: None,
     )
@@ -67,6 +67,34 @@ def test_dp_zero_prefill_falls_back_collectively(monkeypatch):
     )
 
     assert result is decode_output
+    assert result.finished_req_ids == {"finished-prefill"}
+    assert result.free_encoder_mm_hashes == ["encoder-prefill"]
+    assert core._dp_gather_forced_mode == TTSchedulingMode.DECODE_ONLY
+
+
+def test_dp_zero_prefill_fallback_keeps_output_when_rank_has_drained(monkeypatch):
+    """A rank with nothing left to schedule keeps its output instead of None."""
+    prefill_output = SchedulerOutput.make_empty()
+    prefill_output.finished_req_ids.add("finished-prefill")
+    prefill_output.free_encoder_mm_hashes.append("encoder-prefill")
+    scheduler = SimpleNamespace(
+        running=[],
+        has_unfinished_requests=lambda: False,
+        schedule=lambda: (_ for _ in ()).throw(AssertionError("unexpected reschedule")),
+    )
+    core = _core_with_scheduler(scheduler)
+    reductions = iter(([0], [1]))
+
+    def all_reduce(tensor, *, op, group):
+        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+
+    result = core._dp_schedule_with_zero_prefill_fallback(
+        TTSchedulingMode.PREFILL_ONLY, prefill_output
+    )
+
+    assert result is prefill_output
     assert result.finished_req_ids == {"finished-prefill"}
     assert result.free_encoder_mm_hashes == ["encoder-prefill"]
     assert core._dp_gather_forced_mode == TTSchedulingMode.DECODE_ONLY
@@ -125,6 +153,7 @@ def test_dp_step_uses_decode_fallback_output(monkeypatch):
     scheduler = SimpleNamespace(
         running=[SimpleNamespace(is_prefill_chunk=False)],
         has_requests=lambda: True,
+        has_unfinished_requests=lambda: True,
         schedule=schedule,
         set_forced_mode=modes.append,
         get_grammar_bitmask=lambda output: None,
@@ -181,6 +210,7 @@ def test_dp_async_step_submits_decode_after_prefill_fallback(monkeypatch):
     scheduler = SimpleNamespace(
         running=[SimpleNamespace(is_prefill_chunk=False)],
         has_requests=lambda: True,
+        has_unfinished_requests=lambda: True,
         schedule=schedule,
         set_forced_mode=modes.append,
         get_grammar_bitmask=lambda output: None,

--- a/plugins/vllm-tt-plugin/tests/test_dp_engine.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_engine.py
@@ -4,9 +4,12 @@
 
 from types import SimpleNamespace
 
+import pytest
 import vllm_tt_plugin.engine as engine_module
 from vllm_tt_plugin.engine import TTDPEngineCoreProc
 from vllm_tt_plugin.scheduler import TTSchedulingMode
+
+from vllm.v1.core.sched.output import SchedulerOutput
 
 
 def _core_with_scheduler(scheduler):
@@ -18,6 +21,7 @@ def _core_with_scheduler(scheduler):
 
 
 def test_dp_negotiation_prefers_running_prefill_continuation(monkeypatch):
+    """Prefill continuations force gathered DP into prefill mode."""
     scheduler = SimpleNamespace(
         waiting=[],
         running=[SimpleNamespace(is_prefill_chunk=True)],
@@ -34,3 +38,188 @@ def test_dp_negotiation_prefers_running_prefill_continuation(monkeypatch):
 
     assert core._dp_negotiate_forced_mode() == TTSchedulingMode.PREFILL_ONLY
     assert core._dp_gather_forced_mode == TTSchedulingMode.PREFILL_ONLY
+
+
+def test_dp_zero_prefill_falls_back_collectively(monkeypatch):
+    """Zero global prefill progress falls back to decode when one exists."""
+    prefill_output = SchedulerOutput.make_empty()
+    prefill_output.finished_req_ids.add("finished-prefill")
+    prefill_output.free_encoder_mm_hashes.append("encoder-prefill")
+    decode_output = SchedulerOutput.make_empty()
+    decode_output.total_num_scheduled_tokens = 2
+    scheduler = SimpleNamespace(
+        running=[SimpleNamespace(is_prefill_chunk=False)],
+        has_requests=lambda: True,
+        schedule=lambda: decode_output,
+        set_forced_mode=lambda mode: None,
+    )
+    core = _core_with_scheduler(scheduler)
+    reductions = iter(([0], [1]))
+
+    def all_reduce(tensor, *, op, group):
+        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        assert group is core.dp_group
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+
+    result = core._dp_schedule_with_zero_prefill_fallback(
+        TTSchedulingMode.PREFILL_ONLY, prefill_output
+    )
+
+    assert result is decode_output
+    assert result.finished_req_ids == {"finished-prefill"}
+    assert result.free_encoder_mm_hashes == ["encoder-prefill"]
+    assert core._dp_gather_forced_mode == TTSchedulingMode.DECODE_ONLY
+
+
+@pytest.mark.parametrize(
+    ("running", "reductions"),
+    [
+        pytest.param(
+            [SimpleNamespace(is_prefill_chunk=False)],
+            ([1], [1]),
+            id="prefill-progress-on-any-rank",
+        ),
+        pytest.param([], ([0], [0]), id="no-running-decode"),
+    ],
+)
+def test_dp_zero_prefill_no_fallback(monkeypatch, running, reductions):
+    """Prefill remains selected when fallback conditions are incomplete."""
+    prefill_output = SchedulerOutput.make_empty()
+    scheduler = SimpleNamespace(
+        running=running,
+        has_requests=lambda: True,
+        schedule=lambda: (_ for _ in ()).throw(AssertionError("unexpected reschedule")),
+    )
+    core = _core_with_scheduler(scheduler)
+    core._dp_gather_forced_mode = TTSchedulingMode.PREFILL_ONLY
+    reductions = iter(reductions)
+
+    def all_reduce(tensor, *, op, group):
+        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+
+    result = core._dp_schedule_with_zero_prefill_fallback(
+        TTSchedulingMode.PREFILL_ONLY, prefill_output
+    )
+
+    assert result is prefill_output
+    assert core._dp_gather_forced_mode == TTSchedulingMode.PREFILL_ONLY
+
+
+def test_dp_step_uses_decode_fallback_output(monkeypatch):
+    """Synchronous DP steps execute the decode fallback output."""
+    prefill_output = SchedulerOutput.make_empty()
+    decode_output = SchedulerOutput.make_empty()
+    decode_output.total_num_scheduled_tokens = 1
+    modes = []
+
+    def schedule():
+        return (
+            decode_output
+            if modes[-1] == TTSchedulingMode.DECODE_ONLY
+            else prefill_output
+        )
+
+    scheduler = SimpleNamespace(
+        running=[SimpleNamespace(is_prefill_chunk=False)],
+        has_requests=lambda: True,
+        schedule=schedule,
+        set_forced_mode=modes.append,
+        get_grammar_bitmask=lambda output: None,
+        update_from_output=lambda output, model_output: {"updated": output},
+    )
+    core = _core_with_scheduler(scheduler)
+    core._scheduler_paused = False
+    reductions = iter(([0], [1]))
+    executed = []
+
+    def all_reduce(tensor, *, op, group):
+        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+    monkeypatch.setattr(core, "_dp_any_rank_has_scheduler_requests", lambda: True)
+    monkeypatch.setattr(
+        core,
+        "_dp_negotiate_forced_mode",
+        lambda: TTSchedulingMode.PREFILL_ONLY,
+    )
+    monkeypatch.setattr(
+        core,
+        "_execute_model_dp_gather",
+        lambda output, grammar: executed.append(output) or None,
+    )
+    monkeypatch.setattr(core, "_process_aborts_queue", lambda: None)
+
+    outputs, model_executed = core.step()
+
+    assert outputs["updated"] is decode_output
+    assert model_executed is True
+    assert executed == [decode_output]
+    assert modes[:2] == [
+        TTSchedulingMode.PREFILL_ONLY,
+        TTSchedulingMode.DECODE_ONLY,
+    ]
+    assert modes[-1] == TTSchedulingMode.DEFAULT
+
+
+def test_dp_async_step_submits_decode_after_prefill_fallback(monkeypatch):
+    """Async DP steps submit the decode fallback with decode mode active."""
+    prefill_output = SchedulerOutput.make_empty()
+    decode_output = SchedulerOutput.make_empty()
+    decode_output.total_num_scheduled_tokens = 1
+    modes = []
+
+    def schedule():
+        return (
+            decode_output
+            if modes[-1] == TTSchedulingMode.DECODE_ONLY
+            else prefill_output
+        )
+
+    scheduler = SimpleNamespace(
+        running=[SimpleNamespace(is_prefill_chunk=False)],
+        has_requests=lambda: True,
+        schedule=schedule,
+        set_forced_mode=modes.append,
+        get_grammar_bitmask=lambda output: None,
+    )
+    core = _core_with_scheduler(scheduler)
+    core.batch_queue = object()
+    core._dp_in_flight = None
+    core.is_ec_producer = False
+    reductions = iter(([0], [1]))
+    submitted = []
+
+    def all_reduce(tensor, *, op, group):
+        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+
+    def submit(output, grammar, *, overlap_ok):
+        submitted.append((output, core._dp_gather_forced_mode, overlap_ok))
+        return object()
+
+    monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
+    monkeypatch.setattr(core, "_dp_any_rank_has_scheduler_requests", lambda: True)
+    monkeypatch.setattr(
+        core,
+        "_dp_negotiate_forced_mode",
+        lambda: TTSchedulingMode.PREFILL_ONLY,
+    )
+    monkeypatch.setattr(
+        core,
+        "_dp_can_attempt_steady_decode_from_scheduler",
+        lambda output, grammar: True,
+    )
+    monkeypatch.setattr(core, "dp_gather_submit", submit)
+
+    outputs, model_executed = core.step_dp_with_batch_queue()
+
+    assert outputs == {}
+    assert model_executed is True
+    assert submitted == [(decode_output, TTSchedulingMode.DECODE_ONLY, True)]
+    assert modes[:2] == [
+        TTSchedulingMode.PREFILL_ONLY,
+        TTSchedulingMode.DECODE_ONLY,
+    ]
+    assert modes[-1] == TTSchedulingMode.DEFAULT

--- a/plugins/vllm-tt-plugin/tests/test_dp_engine.py
+++ b/plugins/vllm-tt-plugin/tests/test_dp_engine.py
@@ -54,10 +54,11 @@ def test_dp_zero_prefill_falls_back_collectively(monkeypatch):
         set_forced_mode=lambda mode: None,
     )
     core = _core_with_scheduler(scheduler)
-    reductions = iter(([0], [1]))
+    all_reduce_calls = []
 
     def all_reduce(tensor, *, op, group):
-        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        all_reduce_calls.append(op)
+        tensor.copy_(engine_module.torch.tensor([0, 1]))
         assert group is core.dp_group
 
     monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
@@ -70,6 +71,7 @@ def test_dp_zero_prefill_falls_back_collectively(monkeypatch):
     assert result.finished_req_ids == {"finished-prefill"}
     assert result.free_encoder_mm_hashes == ["encoder-prefill"]
     assert core._dp_gather_forced_mode == TTSchedulingMode.DECODE_ONLY
+    assert all_reduce_calls == [engine_module.dist.ReduceOp.SUM]
 
 
 def test_dp_zero_prefill_fallback_keeps_output_when_rank_has_drained(monkeypatch):
@@ -83,10 +85,9 @@ def test_dp_zero_prefill_fallback_keeps_output_when_rank_has_drained(monkeypatch
         schedule=lambda: (_ for _ in ()).throw(AssertionError("unexpected reschedule")),
     )
     core = _core_with_scheduler(scheduler)
-    reductions = iter(([0], [1]))
 
     def all_reduce(tensor, *, op, group):
-        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        tensor.copy_(engine_module.torch.tensor([0, 1]))
 
     monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
 
@@ -101,17 +102,17 @@ def test_dp_zero_prefill_fallback_keeps_output_when_rank_has_drained(monkeypatch
 
 
 @pytest.mark.parametrize(
-    ("running", "reductions"),
+    ("running", "probe"),
     [
         pytest.param(
             [SimpleNamespace(is_prefill_chunk=False)],
-            ([1], [1]),
+            [1, 1],
             id="prefill-progress-on-any-rank",
         ),
-        pytest.param([], ([0], [0]), id="no-running-decode"),
+        pytest.param([], [0, 0], id="no-running-decode"),
     ],
 )
-def test_dp_zero_prefill_no_fallback(monkeypatch, running, reductions):
+def test_dp_zero_prefill_no_fallback(monkeypatch, running, probe):
     """Prefill remains selected when fallback conditions are incomplete."""
     prefill_output = SchedulerOutput.make_empty()
     scheduler = SimpleNamespace(
@@ -121,10 +122,9 @@ def test_dp_zero_prefill_no_fallback(monkeypatch, running, reductions):
     )
     core = _core_with_scheduler(scheduler)
     core._dp_gather_forced_mode = TTSchedulingMode.PREFILL_ONLY
-    reductions = iter(reductions)
 
     def all_reduce(tensor, *, op, group):
-        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        tensor.copy_(engine_module.torch.tensor(probe))
 
     monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
 
@@ -161,11 +161,10 @@ def test_dp_step_uses_decode_fallback_output(monkeypatch):
     )
     core = _core_with_scheduler(scheduler)
     core._scheduler_paused = False
-    reductions = iter(([0], [1]))
     executed = []
 
     def all_reduce(tensor, *, op, group):
-        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        tensor.copy_(engine_module.torch.tensor([0, 1]))
 
     monkeypatch.setattr(engine_module.dist, "all_reduce", all_reduce)
     monkeypatch.setattr(core, "_dp_any_rank_has_scheduler_requests", lambda: True)
@@ -219,11 +218,10 @@ def test_dp_async_step_submits_decode_after_prefill_fallback(monkeypatch):
     core.batch_queue = object()
     core._dp_in_flight = None
     core.is_ec_producer = False
-    reductions = iter(([0], [1]))
     submitted = []
 
     def all_reduce(tensor, *, op, group):
-        tensor.copy_(engine_module.torch.tensor(next(reductions)))
+        tensor.copy_(engine_module.torch.tensor([0, 1]))
 
     def submit(output, grammar, *, overlap_ok):
         submitted.append((output, core._dp_gather_forced_mode, overlap_ok))


### PR DESCRIPTION
## Purpose

Resolves #450 

Fallback to a coordinated decode step when forced prefill schedules zero tokens globally and a running decode can make progress. Preserve discarded prefill bookkeeping and cover sync and async gathered-DP paths.

## Test Plan

- [x] Add corresponding tests to `test_dp_modes.py`.
- [x] Run smoke tests.

## Test Result

- [x] All tests from `test_dp_modes.py` pass.
- [x] [Passing](https://github.com/tenstorrent/tt-metal/actions/runs/32233632415)

