### PR TITLE
Mark tenstorrent/vllm deprecated, point users to vllm-tt-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,22 @@
 <!-- markdownlint-disable MD001 MD041 -->
+
+> [!CAUTION]
+>
+> # This repository is deprecated. Do not use it
+>
+> Tenstorrent support for vLLM now lives in a standalone plugin that runs on
+> **upstream vLLM**, not in this fork:
+>
+> ## ➡️ [github.com/tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin)
+>
+> This fork receives no further fixes, model enablement, or upstream merges,
+> and it will be archived. Start there instead, and migrate any existing setup:
+> install upstream vLLM plus `vllm-tt-plugin` by following that repo's README.
+> Open issues and pull requests against
+> [tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin/issues).
+
+---
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">

--- a/plugins/vllm-tt-plugin/README.md
+++ b/plugins/vllm-tt-plugin/README.md
@@ -1,5 +1,15 @@
 # vLLM TT Plugin
 
+> [!CAUTION]
+>
+> ## This in-tree copy of the plugin is deprecated
+>
+> The plugin is developed and released from its own repository, against
+> **upstream vLLM**:
+> [github.com/tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin).
+> The copy here is frozen and will be archived with the rest of this fork. Use
+> the standalone repository for installation, issues and pull requests.
+
 Tenstorrent backend plugin for vLLM.
 
 `vllm-tt-plugin` integrates Tenstorrent hardware into vLLM using the standard

--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import logging
+import sys
 import traceback
 from itertools import chain
 from typing import TYPE_CHECKING
@@ -183,6 +184,46 @@ builtin_platform_plugins = {
 }
 
 
+TT_PLATFORM_PLUGIN_NAME = "tt"
+
+_TT_DEPRECATION_BANNER = r"""
+################################################################################
+#                                                                              #
+#        **************************************************************        #
+#                                                                              #
+#                             D E P R E C A T E D                              #
+#                                                                              #
+#        **************************************************************        #
+#                                                                              #
+#          This vLLM fork (tenstorrent/vllm) is no longer maintained.          #
+#         Tenstorrent support now ships as a plugin for UPSTREAM vLLM:         #
+#                                                                              #
+#          >>>   https://github.com/tenstorrent/vllm-tt-plugin   <<<           #
+#                                                                              #
+#      No further fixes, model enablement, or upstream merges land here,       #
+#     and this repository will be archived. Migrate now: install upstream      #
+#        vLLM plus vllm-tt-plugin, following that repository's README.         #
+#                File issues and pull requests there, not here.                #
+#                                                                              #
+################################################################################
+"""
+
+_tt_deprecation_warned = False
+
+
+def _warn_tt_fork_deprecated() -> None:
+    """Shout the fork deprecation once per process when TT is the platform.
+
+    Written straight to stderr rather than through logging: it has to survive
+    VLLM_CONFIGURE_LOGGING=0 and any log level the caller picked.
+    """
+    global _tt_deprecation_warned
+    if _tt_deprecation_warned:
+        return
+    _tt_deprecation_warned = True
+    print(_TT_DEPRECATION_BANNER, file=sys.stderr, flush=True)
+
+
 def resolve_current_platform_cls_qualname() -> str:
     platform_plugins = load_plugins_by_group(PLATFORM_PLUGINS_GROUP)
 
@@ -210,6 +251,8 @@ def resolve_current_platform_cls_qualname() -> str:
     elif len(activated_oot_plugins) == 1:
         platform_cls_qualname = platform_plugins[activated_oot_plugins[0]]()
         logger.info("Platform plugin %s is activated", activated_oot_plugins[0])
+        if activated_oot_plugins[0] == TT_PLATFORM_PLUGIN_NAME:
+            _warn_tt_fork_deprecated()
     elif len(activated_builtin_plugins) >= 2:
         raise RuntimeError(
             "Only one platform plugin can be activated, but got: "


### PR DESCRIPTION
## What

Marks this fork deprecated and drives users to
[tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin),
which runs on upstream vLLM.

Three touchpoints:

1. **`README.md`** — a GitHub `[!CAUTION]` block as the very first content,
   above the vLLM logo: "This repository is deprecated. Do not use it.", a
   heading-sized link to the plugin repo, and where to file issues from now on.
2. **`plugins/vllm-tt-plugin/README.md`** — notice that this in-tree copy is
   frozen and development happens in the standalone repo.
3. **`vllm/platforms/__init__.py`** — an 80-column ASCII banner printed when
   the `tt` platform plugin activates:

```text
################################################################################
#        **************************************************************        #
#                             D E P R E C A T E D                              #
#        **************************************************************        #
#          This vLLM fork (tenstorrent/vllm) is no longer maintained.          #
#         Tenstorrent support now ships as a plugin for UPSTREAM vLLM:         #
#          >>>   https://github.com/tenstorrent/vllm-tt-plugin   <<<           #
#      No further fixes, model enablement, or upstream merges land here,       #
#     and this repository will be archived. Migrate now: install upstream      #
#        vLLM plus vllm-tt-plugin, following that repository's README.         #
#                File issues and pull requests there, not here.                #
################################################################################
```

## Why the banner lives in platform resolution

It sits in `resolve_current_platform_cls_qualname`, not in the plugin's
`entrypoints.py`, so it fires both for the in-tree plugin copy and for a
standalone `vllm-tt-plugin` installed against a build of this fork.

It is written straight to stderr rather than through `logger`, so
`VLLM_CONFIGURE_LOGGING=0` or a raised log level cannot suppress it, and it is
guarded to print once per process (each spawned worker / DP process prints its
own copy).

## Testing

`pre-commit run` on the staged files: `ruff check`, `ruff format`, `typos` and
the SPDX check pass. Four local hooks (`mypy-local`, `check-root-lazy-imports`,
`validate-config`, `attention-backend-docs`) fail at import time on my machine
under Python 3.9 (`str | None` inside the hook scripts themselves); the same
failure reproduces on files this PR does not touch, so it is pre-existing
environment breakage, not from this change.

## Not included

Archiving the repo itself, closing open issues and PRs with a redirect, and any
`.github` issue-template redirect are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)