### PR TITLE
README: mark tenstorrent/vllm deprecated, point users to vllm-tt-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 <!-- markdownlint-disable MD001 MD041 -->
-**⚠️ Running on Tenstorrent hardware**: To use vLLM with Tenstorrent hardware, please follow the instructions in the [TT vLLM plugin README](https://github.com/tenstorrent/vllm/tree/dev/plugins/vllm-tt-plugin) (Note: `dev` is the main development branch).
+
+> [!CAUTION]
+>
+> # This repository is deprecated. Do not use it
+>
+> Tenstorrent support for vLLM now lives in a standalone plugin that runs on
+> **upstream vLLM**, not in this fork:
+>
+> ## ➡️ [github.com/tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin)
+>
+> This fork receives no further fixes, model enablement, or upstream merges,
+> and it will be archived. Start there instead, and migrate any existing setup:
+> install upstream vLLM plus `vllm-tt-plugin` by following that repo's README.
+> Open issues and pull requests against
+> [tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin/issues).
 
 ---
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vllm-project/vllm/main/docs/assets/logos/vllm-logo-text-dark.png">


### PR DESCRIPTION
## What

README-only change on the repo's default branch. Replaces the existing
"Running on Tenstorrent hardware" pointer at the top of `README.md`, which sent
people to the in-tree plugin copy on `dev`, with a GitHub `[!CAUTION]` block
placed above the vLLM logo:

- H1 "This repository is deprecated. Do not use it"
- A heading-sized link to
  [tenstorrent/vllm-tt-plugin](https://github.com/tenstorrent/vllm-tt-plugin)
- Migration instruction (upstream vLLM plus the plugin) and where to file
  issues from now on

## Why here specifically

`main` is the default branch, so this is the first thing anyone landing on the
repo sees. The rest of the deprecation work (in-tree plugin README notice, and
an ASCII banner printed at runtime when the `tt` platform plugin activates)
targets `dev` in #475, since none of that code exists on `main`.

## Testing

`pre-commit run` on the staged file: `typos` and `markdownlint-cli2` pass.
`validate-config` and `attention-backend-docs` fail at import time on my
machine under Python 3.9 (`str | None` inside the hook scripts themselves);
they reproduce on files this PR does not touch, so it is pre-existing
environment breakage, not from this change. A README-only diff cannot affect
either hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)