### PR TITLE
CI: baseline pre-existing shellcheck warnings on main

### DIFF
--- a/tools/pre_commit/shellcheck.baseline
+++ b/tools/pre_commit/shellcheck.baseline
@@ -1,0 +1,15 @@
+.buildkite/scripts/run-multi-node-test.sh:SC2086
+.buildkite/scripts/run-multi-node-test.sh:SC2089
+.buildkite/scripts/run-multi-node-test.sh:SC2090
+.buildkite/scripts/tool_call/run-bfcl-eval.sh:SC2317
+.buildkite/scripts/tool_call/run-bfcl-eval.sh:SC2329
+tests/v1/kv_connector/nixl_integration/run_xpu_disagg_accuracy_test.sh:SC2086
+tests/v1/kv_connector/nixl_integration/run_xpu_disagg_accuracy_test.sh:SC2089
+tests/v1/kv_connector/nixl_integration/run_xpu_disagg_accuracy_test.sh:SC2090
+tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh:SC2046
+tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh:SC2048
+tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh:SC2086
+tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh:SC2206
+tools/pre_commit/shellcheck.sh:SC2016
+vllm/utils/numa_wrapper.sh:SC1001
+vllm/utils/numa_wrapper.sh:SC2086

--- a/tools/pre_commit/shellcheck.sh
+++ b/tools/pre_commit/shellcheck.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 scversion="stable"
+baseline="tools/pre_commit/shellcheck.baseline"
 
 if [ -d "shellcheck-${scversion}" ]; then
     export PATH="$PATH:$(pwd)/shellcheck-${scversion}"
@@ -19,6 +20,38 @@ if ! [ -x "$(command -v shellcheck)" ]; then
 fi
 
 # TODO - fix warnings in .buildkite/scripts/hardware_ci/run-amd-test.sh
-find . -path ./.git -prune -o -name "*.sh" \
-  -not -path "./.buildkite/scripts/hardware_ci/run-amd-test.sh" -print0 | \
-  xargs -0 sh -c "for f in \"\$@\"; do git check-ignore -q \"\$f\" || shellcheck -s bash \"\$f\"; done" --
+# collects warnings as "file:SCcode" pairs for baseline comparison.
+collect() {
+  find . -path ./.git -prune -o -name "*.sh" \
+    -not -path "./.buildkite/scripts/hardware_ci/run-amd-test.sh" -print0 | \
+    xargs -0 sh -c 'for f in "$@"; do git check-ignore -q "$f" || shellcheck -s bash -f gcc "$f" || true; done' -- | \
+    sed -nE 's|^\./||; s|^([^:]+):[0-9]+:[0-9]+:.*\[(SC[0-9]+)\]$|\1:\2|p' | \
+    sort -u
+}
+
+if [[ "${1:-}" == "--generate-baseline" ]]; then
+  collect > "$baseline"
+  echo "Wrote baseline to $baseline"
+  exit 0
+fi
+
+if [[ ! -f "$baseline" ]]; then
+  echo "Baseline not found: $baseline (run: $0 --generate-baseline)"
+  exit 1
+fi
+
+current="$(mktemp)"
+trap 'rm -f "$current"' EXIT
+collect > "$current"
+
+# finds new warnings not in baseline
+new_errors="$(comm -23 "$current" <(sort -u "$baseline") || true)"
+if [ -n "$new_errors" ]; then
+  echo "$new_errors" | cut -d: -f1 | sort -u | while IFS= read -r file; do
+    if [[ -f "$file" ]]; then
+      codes=$(echo "$new_errors" | awk -F: -v f="$file" '$1==f {print $2}' | paste -sd ',' -)
+      shellcheck -s bash --include="$codes" "$file" 2>&1 || true
+    fi
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Problem

`pre-commit` fails on every PR against `main` right now, including README-only
ones such as #476. The failure is entirely pre-existing and has nothing to do
with the PRs that trip over it.

Two causes, both in `tools/pre_commit/shellcheck.sh`:

1. **It lints the whole repo, not the changed files.** The hook `find`s every
   `*.sh` in the tree, so any PR inherits the repo's full shellcheck backlog.
2. **The shellcheck version floats.** `scversion="stable"` downloads whatever
   the latest release is at job time, so a new shellcheck release retroactively
   turns previously-green branches red. That is what happened here: `main` last
   ran green on 2026-05-29.

On top of that, the old wrapper's exit status was whatever the last file in the
`xargs` batch returned, so whether the hook passed at all depended on file
ordering. Running it locally on `main` today prints 37 warnings and still exits
0.

The offending warnings are in five upstream files that no TT change touches:

```text
.buildkite/scripts/run-multi-node-test.sh
.buildkite/scripts/tool_call/run-bfcl-eval.sh
tests/v1/kv_connector/nixl_integration/run_xpu_disagg_accuracy_test.sh
tests/v1/kv_connector/nixl_integration/spec_decode_acceptance_test.sh
vllm/utils/numa_wrapper.sh
```

## Fix

Ports the baseline mechanism that `dev` already carries from upstream (vLLM
#32458, "Fix silent failure in shellcheck hook and baseline existing
warnings"), and generates `tools/pre_commit/shellcheck.baseline` against this
branch's tree. The hook now compares the current `file:SCcode` set against the
baseline and fails only on **new** warnings, with a real exit status.

This is a straight port, not a local invention, so `main` and `dev` stay
consistent and the file will merge cleanly with future upstream syncs.

### One deliberate deviation

`run-bfcl-eval.sh` is baselined under **both** `SC2317` and `SC2329`.
shellcheck 0.11.0 (my local version, used to generate the baseline) reports
`SC2329` for that function, while the `stable` build CI currently downloads
still reports `SC2317`. Unmatched baseline entries are ignored by `comm -23`,
so listing both makes the baseline tolerant of that version skew rather than
green on one machine and red on the other.

## Testing

- `bash tools/pre_commit/shellcheck.sh` exits 0 on this branch.
- Negative control: deleting one baseline line (`numa_wrapper.sh:SC1001`) makes
  the hook print that warning and exit 1, confirming regressions are still
  caught rather than silently passing.
- `pre-commit run` on the staged files: `typos`, `Lint shell scripts`, and the
  rest pass. `validate-config` and `attention-backend-docs` fail at import time
  on my machine under Python 3.9 (`str | None` inside the hook scripts); both
  pass in CI on 3.12.

## Merge order

Merge this before #476 and #475, then re-run their checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)